### PR TITLE
feat: expand rhythmguard enforcement, configs, and integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ## [Unreleased]
 
+### Added
+
+- New shared configs:
+  - `stylelint-plugin-rhythmguard/configs/expanded`
+  - `stylelint-plugin-rhythmguard/configs/logical`
+  - `stylelint-plugin-rhythmguard/configs/migration`
+- New ESLint companion export: `stylelint-plugin-rhythmguard/eslint` with rule:
+  - `rhythmguard-tailwind/tailwind-class-use-scale`
+- Token migration source automation for `rhythmguard/prefer-token`:
+  - `tokenMapFromCssCustomProperties`
+  - `tokenMapFile`
+  - `tokenMapFromTailwindSpacing` + `tailwindConfigPath`
+- ESM wrapper entry points for package root, configs, presets, rules, and ESLint companion.
+
+### Changed
+
+- Broadened scale enforcement model with built-in property groups:
+  - `spacing`, `radius`, `typography`, `size`
+- New per-property override options:
+  - `propertyGroups`
+  - `propertyScales`
+- New math-function targeting options:
+  - `mathFunctionArguments`
+  - `ignoreMathFunctionArguments`
+- New `unitStrategy` option (`convert` or `exact`) for non-convertible unit workflows.
+- Compatibility updated to support Stylelint `^16 || ^17`.
+- Tailwind token-map extraction now supports `.js`, `.cjs`, and `.mjs` config files and merges `theme.spacing` with `theme.extend.spacing`.
+
 ## [1.3.0] - 2026-02-17
 
 ### Added

--- a/docs/TAILWIND.md
+++ b/docs/TAILWIND.md
@@ -4,8 +4,8 @@ This guide describes the production setup for Rhythmguard in Tailwind-based code
 
 ## Scope Model
 
-- Rhythmguard enforces CSS declaration values that Stylelint can parse.
-- Tailwind class strings in markup (`class="p-4"` / `className="p-[13px]"`) are out of scope for Stylelint rules.
+- Rhythmguard Stylelint rules enforce CSS declaration values that Stylelint can parse.
+- Rhythmguard ESLint companion rules enforce Tailwind class-string arbitrary values in templates.
 
 ## Recommended Layered Setup
 
@@ -24,9 +24,26 @@ This gives:
 
 ### 2) Template class-string layer
 
-Use an ESLint plugin for Tailwind utility class strings:
+Use the built-in Rhythmguard ESLint companion for arbitrary spacing classes:
 
-- `eslint-plugin-tailwindcss` for class-string governance and arbitrary-value controls.
+```js
+import rhythmguard from 'stylelint-plugin-rhythmguard/eslint';
+
+export default [
+  {
+    plugins: {
+      'rhythmguard-tailwind': rhythmguard,
+    },
+    rules: {
+      'rhythmguard-tailwind/tailwind-class-use-scale': ['error', { scale: [0, 4, 8, 12, 16, 24, 32] }],
+    },
+  },
+];
+```
+
+Then layer on:
+
+- `eslint-plugin-tailwindcss` for broader class-string governance and conventions.
 
 Use Prettier for deterministic ordering:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "known-css-properties": "^0.37.0",
-        "stylelint-config-tailwindcss": "^1.0.1"
+        "stylelint-config-tailwindcss": "^1.0.1",
+        "stylelint-plugin-logical-css": "^2.0.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -19,13 +20,14 @@
         "geist": "^1.7.0",
         "postcss-value-parser": "^4.2.0",
         "stylelint": "^16.15.0",
+        "stylelint-plugin-logical-css": "^2.0.2",
         "stylelint-scales": "^5.0.0"
       },
       "engines": {
         "node": ">=18.18.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.0.0"
+        "stylelint": "^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3482,6 +3484,16 @@
       "peerDependencies": {
         "stylelint": ">=13.13.1",
         "tailwindcss": ">=2.2.16"
+      }
+    },
+    "node_modules/stylelint-plugin-logical-css": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stylelint-plugin-logical-css/-/stylelint-plugin-logical-css-2.0.2.tgz",
+      "integrity": "sha512-k3AgoE0EA7RPDg+PNf3obo3HAAi4ViqEpFYWwbEsSiI1+ScNogVtBNnZ068gfXv63wybTR0XfAQE72fdHSX7Mw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "stylelint": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/stylelint-scales": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stylelint-plugin-rhythmguard",
   "version": "1.3.0",
-  "description": "Stylelint plugin for spacing scale and token enforcement",
+  "description": "Stylelint plugin for spacing scale, token enforcement, and Tailwind class-string governance",
   "keywords": [
     "stylelint",
     "stylelint-plugin",
@@ -10,19 +10,62 @@
     "design-tokens",
     "spacing-scale",
     "spacing",
-    "linting"
+    "linting",
+    "tailwindcss",
+    "eslint-plugin",
+    "logical-css"
   ],
   "type": "commonjs",
   "main": "src/index.js",
   "exports": {
-    ".": "./src/index.js",
-    "./configs/recommended": "./src/configs/recommended.js",
-    "./configs/strict": "./src/configs/strict.js",
-    "./configs/tailwind": "./src/configs/tailwind.js",
-    "./presets": "./src/presets/index.js",
-    "./rules/use-scale": "./src/rules/use-scale/index.js",
-    "./rules/prefer-token": "./src/rules/prefer-token/index.js",
-    "./rules/no-offscale-transform": "./src/rules/no-offscale-transform/index.js"
+    ".": {
+      "require": "./src/index.js",
+      "import": "./src/index.mjs"
+    },
+    "./configs/recommended": {
+      "require": "./src/configs/recommended.js",
+      "import": "./src/configs/recommended.mjs"
+    },
+    "./configs/strict": {
+      "require": "./src/configs/strict.js",
+      "import": "./src/configs/strict.mjs"
+    },
+    "./configs/tailwind": {
+      "require": "./src/configs/tailwind.js",
+      "import": "./src/configs/tailwind.mjs"
+    },
+    "./configs/expanded": {
+      "require": "./src/configs/expanded.js",
+      "import": "./src/configs/expanded.mjs"
+    },
+    "./configs/logical": {
+      "require": "./src/configs/logical.js",
+      "import": "./src/configs/logical.mjs"
+    },
+    "./configs/migration": {
+      "require": "./src/configs/migration.js",
+      "import": "./src/configs/migration.mjs"
+    },
+    "./presets": {
+      "require": "./src/presets/index.js",
+      "import": "./src/presets/index.mjs"
+    },
+    "./rules/use-scale": {
+      "require": "./src/rules/use-scale/index.js",
+      "import": "./src/rules/use-scale/index.mjs"
+    },
+    "./rules/prefer-token": {
+      "require": "./src/rules/prefer-token/index.js",
+      "import": "./src/rules/prefer-token/index.mjs"
+    },
+    "./rules/no-offscale-transform": {
+      "require": "./src/rules/no-offscale-transform/index.js",
+      "import": "./src/rules/no-offscale-transform/index.mjs"
+    },
+    "./eslint": {
+      "require": "./src/eslint/index.js",
+      "import": "./src/eslint/index.mjs"
+    }
   },
   "files": [
     "assets",
@@ -58,11 +101,12 @@
     "email": "hello@petrilahdelma.com"
   },
   "peerDependencies": {
-    "stylelint": "^16.0.0"
+    "stylelint": "^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "known-css-properties": "^0.37.0",
-    "stylelint-config-tailwindcss": "^1.0.1"
+    "stylelint-config-tailwindcss": "^1.0.1",
+    "stylelint-plugin-logical-css": "^2.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
@@ -71,7 +115,8 @@
     "geist": "^1.7.0",
     "postcss-value-parser": "^4.2.0",
     "stylelint": "^16.15.0",
-    "stylelint-scales": "^5.0.0"
+    "stylelint-scales": "^5.0.0",
+    "stylelint-plugin-logical-css": "^2.0.2"
   },
   "engines": {
     "node": ">=18.18.0"

--- a/src/configs/expanded.js
+++ b/src/configs/expanded.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  plugins: ['stylelint-plugin-rhythmguard'],
+  rules: {
+    'rhythmguard/use-scale': [
+      true,
+      {
+        propertyGroups: ['spacing', 'radius', 'typography', 'size'],
+        scale: [0, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64],
+      },
+    ],
+    'rhythmguard/no-offscale-transform': [
+      true,
+      {
+        scale: [0, 4, 8, 12, 16, 24, 32],
+      },
+    ],
+    'rhythmguard/prefer-token': [
+      true,
+      {
+        propertyGroups: ['spacing', 'radius'],
+        tokenPattern: '^--space-|^--radius-',
+      },
+    ],
+  },
+};

--- a/src/configs/expanded.mjs
+++ b/src/configs/expanded.mjs
@@ -1,0 +1,4 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const config = require('./expanded.js');
+export default config;

--- a/src/configs/logical.js
+++ b/src/configs/logical.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  extends: [
+    'stylelint-plugin-logical-css/configs/recommended',
+    'stylelint-plugin-rhythmguard/configs/strict',
+  ],
+  rules: {
+    'rhythmguard/use-scale': [
+      true,
+      {
+        propertyGroups: ['spacing', 'size'],
+      },
+    ],
+  },
+};

--- a/src/configs/logical.mjs
+++ b/src/configs/logical.mjs
@@ -1,0 +1,4 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const config = require('./logical.js');
+export default config;

--- a/src/configs/migration.js
+++ b/src/configs/migration.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = {
+  plugins: ['stylelint-plugin-rhythmguard'],
+  rules: {
+    'rhythmguard/use-scale': [
+      true,
+      {
+        propertyGroups: ['spacing', 'radius'],
+        scale: [0, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64],
+      },
+    ],
+    'rhythmguard/prefer-token': [
+      true,
+      {
+        allowNumericScale: true,
+        propertyGroups: ['spacing', 'radius'],
+        tokenMapFromCssCustomProperties: true,
+        tokenMapFromTailwindSpacing: true,
+        tailwindConfigPath: './tailwind.config.js',
+        tokenPattern: '^--space-|^--radius-',
+      },
+    ],
+    'rhythmguard/no-offscale-transform': [
+      true,
+      {
+        scale: [0, 4, 8, 12, 16, 24, 32],
+      },
+    ],
+  },
+};

--- a/src/configs/migration.mjs
+++ b/src/configs/migration.mjs
@@ -1,0 +1,4 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const config = require('./migration.js');
+export default config;

--- a/src/configs/recommended.mjs
+++ b/src/configs/recommended.mjs
@@ -1,0 +1,4 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const config = require('./recommended.js');
+export default config;

--- a/src/configs/strict.mjs
+++ b/src/configs/strict.mjs
@@ -1,0 +1,4 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const config = require('./strict.js');
+export default config;

--- a/src/configs/tailwind.mjs
+++ b/src/configs/tailwind.mjs
@@ -1,0 +1,4 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const config = require('./tailwind.js');
+export default config;

--- a/src/eslint/index.js
+++ b/src/eslint/index.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const tailwindClassUseScale = require('./rules/tailwind-class-use-scale');
+
+module.exports = {
+  rules: {
+    'tailwind-class-use-scale': tailwindClassUseScale,
+  },
+  configs: {
+    recommended: {
+      rules: {
+        'rhythmguard-tailwind/tailwind-class-use-scale': 'warn',
+      },
+    },
+  },
+};

--- a/src/eslint/index.mjs
+++ b/src/eslint/index.mjs
@@ -1,0 +1,8 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const plugin = require('./index.js');
+
+export default plugin;
+export const rules = plugin.rules;
+export const configs = plugin.configs;

--- a/src/eslint/rules/tailwind-class-use-scale.js
+++ b/src/eslint/rules/tailwind-class-use-scale.js
@@ -1,0 +1,206 @@
+'use strict';
+
+const {
+  formatLength,
+  nearestScaleValues,
+  normalizeScale,
+  numbersEqual,
+  parseLengthToken,
+  toPx,
+} = require('../../utils/length');
+
+const RULE_NAME = 'tailwind-class-use-scale';
+
+const ARBITRARY_SPACING_CLASS = /^(?<utility>-?(?:m(?:[trblxy])?|p(?:[trblxy])?|gap(?:-[xy])?|space-[xy]|inset(?:-[xy])?|top|right|bottom|left|translate-[xy]|scroll-(?:m|p)(?:[trblxy])?))-\[(?<rawValue>[^\]]+)\]$/;
+
+function getOptions(context) {
+  const option = context.options && context.options[0] ? context.options[0] : {};
+
+  return {
+    allowNegative: option.allowNegative !== false,
+    baseFontSize:
+      typeof option.baseFontSize === 'number' &&
+      Number.isFinite(option.baseFontSize) &&
+      option.baseFontSize > 0
+        ? option.baseFontSize
+        : 16,
+    scale: Array.isArray(option.scale)
+      ? option.scale
+      : [0, 4, 8, 12, 16, 24, 32],
+    units: Array.isArray(option.units)
+      ? option.units.map((unit) => String(unit).toLowerCase())
+      : ['px', 'rem', 'em'],
+  };
+}
+
+function findClassSegments(value) {
+  const segments = [];
+  const tokenRegex = /\S+/g;
+  let match;
+
+  while ((match = tokenRegex.exec(value)) !== null) {
+    segments.push({
+      start: match.index,
+      token: match[0],
+    });
+  }
+
+  return segments;
+}
+
+function analyzeToken(token, options, scalePx) {
+  const match = token.match(ARBITRARY_SPACING_CLASS);
+  if (!match || !match.groups) {
+    return null;
+  }
+
+  const parsedLength = parseLengthToken(match.groups.rawValue);
+  if (!parsedLength || parsedLength.number === 0 || parsedLength.unit === '') {
+    return null;
+  }
+
+  if (!options.allowNegative && parsedLength.number < 0) {
+    return {
+      nearest: null,
+      parsedLength,
+      reason: 'negative',
+    };
+  }
+
+  if (!options.units.includes(parsedLength.unit)) {
+    return null;
+  }
+
+  const pxValue = toPx(Math.abs(parsedLength.number), parsedLength.unit, options.baseFontSize);
+  if (pxValue === null) {
+    return null;
+  }
+
+  const isOnScale = scalePx.some((entry) => numbersEqual(entry, pxValue));
+  if (isOnScale) {
+    return null;
+  }
+
+  const nearest = nearestScaleValues(pxValue, scalePx);
+  if (!nearest) {
+    return null;
+  }
+
+  const signedNearest = parsedLength.number < 0
+    ? -Math.abs(nearest.nearest)
+    : nearest.nearest;
+
+  const replacementValuePx = signedNearest;
+  const replacementNumber = parsedLength.unit === 'px'
+    ? replacementValuePx
+    : replacementValuePx / options.baseFontSize;
+
+  const replacementValue = formatLength(replacementNumber, parsedLength.unit);
+  const fixedToken = token.replace(match.groups.rawValue, replacementValue);
+
+  return {
+    fixedToken,
+    nearest,
+    parsedLength,
+    reason: 'off-scale',
+  };
+}
+
+function maybeCheckNodeText(node, sourceCode, context, options, scalePx, allowFix) {
+  const rawText = sourceCode.getText(node);
+  let value = null;
+  let quote = null;
+
+  if (node.type === 'Literal' && typeof node.value === 'string') {
+    value = node.value;
+    quote = rawText[0] === '"' || rawText[0] === "'" ? rawText[0] : '"';
+  }
+
+  if (node.type === 'TemplateElement') {
+    value = node.value.raw;
+  }
+
+  if (!value || typeof value !== 'string') {
+    return;
+  }
+
+  const segments = findClassSegments(value);
+  if (segments.length === 0) {
+    return;
+  }
+  for (const segment of segments) {
+    const analysis = analyzeToken(segment.token, options, scalePx);
+    if (!analysis) {
+      continue;
+    }
+
+    const lower = analysis.nearest
+      ? formatLength(analysis.nearest.lower, 'px')
+      : 'n/a';
+    const upper = analysis.nearest
+      ? formatLength(analysis.nearest.upper, 'px')
+      : 'n/a';
+    context.report({
+      message:
+        analysis.reason === 'negative'
+          ? `Unexpected Tailwind arbitrary spacing value "${segment.token}". Negative values are disabled for this rule.`
+          : `Unexpected Tailwind arbitrary spacing value "${segment.token}". Use scale values (nearest: ${lower} or ${upper}).`,
+      node,
+      fix:
+        allowFix && analysis.reason !== 'negative' && node.type === 'Literal'
+          ? (fixer) => {
+            const nextValue = `${value.slice(0, segment.start)}${analysis.fixedToken}${value.slice(segment.start + segment.token.length)}`;
+            const escaped = nextValue.replace(new RegExp(quote, 'g'), `\\${quote}`);
+            return fixer.replaceText(node, `${quote}${escaped}${quote}`);
+          }
+          : null,
+    });
+  }
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Enforce spacing scale for Tailwind arbitrary spacing utilities in class strings',
+    },
+    fixable: 'code',
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          allowNegative: { type: 'boolean' },
+          baseFontSize: { type: 'number' },
+          scale: {
+            items: {
+              anyOf: [
+                { type: 'number' },
+                { type: 'string' },
+              ],
+            },
+            type: 'array',
+          },
+          units: {
+            items: { type: 'string' },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
+  },
+  create(context) {
+    const options = getOptions(context);
+    const scalePx = normalizeScale(options.scale, options.baseFontSize);
+    const sourceCode = context.sourceCode || context.getSourceCode();
+
+    return {
+      Literal(node) {
+        maybeCheckNodeText(node, sourceCode, context, options, scalePx, true);
+      },
+      TemplateElement(node) {
+        maybeCheckNodeText(node, sourceCode, context, options, scalePx, false);
+      },
+    };
+  },
+  ruleName: RULE_NAME,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -16,5 +16,9 @@ module.exports.configs = {
   recommended: require('./configs/recommended'),
   strict: require('./configs/strict'),
   tailwind: require('./configs/tailwind'),
+  expanded: require('./configs/expanded'),
+  logical: require('./configs/logical'),
+  migration: require('./configs/migration'),
 };
+module.exports.eslint = require('./eslint');
 module.exports.presets = require('./presets');

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,0 +1,10 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const plugin = require('./index.js');
+
+export default plugin;
+export const rules = plugin.rules;
+export const configs = plugin.configs;
+export const presets = plugin.presets;
+export const eslint = plugin.eslint;

--- a/src/presets/index.mjs
+++ b/src/presets/index.mjs
@@ -1,0 +1,12 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const presets = require('./index.js');
+
+export default presets;
+export const scales = presets.scales;
+export const communityScaleMetadata = presets.communityScaleMetadata;
+export const listScalePresetNames = presets.listScalePresetNames;
+export const listCommunityScalePresetNames = presets.listCommunityScalePresetNames;
+export const getScalePreset = presets.getScalePreset;
+export const getCommunityScaleMetadata = presets.getCommunityScaleMetadata;

--- a/src/rules/no-offscale-transform/index.js
+++ b/src/rules/no-offscale-transform/index.js
@@ -7,17 +7,20 @@ const {
   fromPx,
   nearestScaleValues,
   normalizeScale,
+  normalizeScaleByUnit,
   numbersEqual,
   parseLengthToken,
   toPx,
 } = require('../../utils/length');
 const {
   buildScaleOptions,
+  resolvePropertyScale,
   validateNoOffscaleTransformSecondaryOptions,
 } = require('../../utils/options');
 const {
   declarationValueIndex,
   isMathFunction,
+  shouldLintMathArgument,
   walkRootValueNodes,
   walkTransformTranslateNodes,
 } = require('../../utils/value-utils');
@@ -37,6 +40,11 @@ function getFixedNodeValue(parsedLength, nearestPx, options) {
   }
 
   const signedNearest = parsedLength.number < 0 ? -Math.abs(nearestPx) : nearestPx;
+
+  if (options.unitStrategy === 'exact') {
+    return formatLength(signedNearest, parsedLength.unit || 'px');
+  }
+
   const converted = fromPx(signedNearest, unit, options.baseFontSize);
 
   if (converted === null) {
@@ -76,7 +84,22 @@ const ruleFunction = (primary, secondaryOptions) => {
       });
     }
 
-    const scalePx = normalizeScale(options.scale, options.baseFontSize);
+    const scaleCache = new Map();
+    const getScaleStateForProperty = (prop) => {
+      const cached = scaleCache.get(prop);
+      if (cached) {
+        return cached;
+      }
+
+      const selectedScale = resolvePropertyScale(prop, options);
+      const next = {
+        scaleByUnit: normalizeScaleByUnit(selectedScale),
+        scalePx: normalizeScale(selectedScale, options.baseFontSize),
+      };
+
+      scaleCache.set(prop, next);
+      return next;
+    };
 
     root.walkDecls((decl) => {
       const prop = decl.prop.toLowerCase();
@@ -85,9 +108,10 @@ const ruleFunction = (primary, secondaryOptions) => {
       }
 
       const parsed = valueParser(decl.value);
+      const { scaleByUnit, scalePx } = getScaleStateForProperty(prop);
       let changed = false;
 
-      const report = (node, nearest, fixedValue = null) => {
+      const report = (node, nearest, nearestUnit, fixedValue = null) => {
         const index = declarationValueIndex(decl) + node.sourceIndex;
         const endIndex = index + node.value.length;
 
@@ -96,8 +120,8 @@ const ruleFunction = (primary, secondaryOptions) => {
           index,
           message: messages.rejected(
             node.value,
-            formatLength(nearest.lower, 'px'),
-            formatLength(nearest.upper, 'px'),
+            formatLength(nearest.lower, nearestUnit),
+            formatLength(nearest.upper, nearestUnit),
           ),
           node: decl,
           result,
@@ -132,6 +156,41 @@ const ruleFunction = (primary, secondaryOptions) => {
           return;
         }
 
+        if (
+          parsedLength.unit &&
+          parsedLength.unit !== '%' &&
+          !options.units.includes(parsedLength.unit)
+        ) {
+          return;
+        }
+
+        if (options.unitStrategy === 'exact') {
+          const unit = parsedLength.unit || 'px';
+          const unitScale = scaleByUnit.get(unit);
+          if (!unitScale || unitScale.length === 0) {
+            return;
+          }
+
+          const absoluteValue = Math.abs(parsedLength.number);
+          const isOnScale = unitScale.some((entry) => numbersEqual(entry, absoluteValue));
+          if (isOnScale) {
+            return;
+          }
+
+          const nearest = nearestScaleValues(absoluteValue, unitScale);
+          if (!nearest) {
+            return;
+          }
+
+          const fixedValue = options.fixToScale
+            ? getFixedNodeValue(parsedLength, nearest.nearest, options)
+            : null;
+
+          report(node, nearest, unit, fixedValue);
+          changed = true;
+          return;
+        }
+
         const pxValue = toPx(Math.abs(parsedLength.number), parsedLength.unit, options.baseFontSize);
         if (pxValue === null) {
           return;
@@ -151,12 +210,12 @@ const ruleFunction = (primary, secondaryOptions) => {
           ? getFixedNodeValue(parsedLength, nearest.nearest, options)
           : null;
 
-        report(node, nearest, fixedValue);
+        report(node, nearest, 'px', fixedValue);
         changed = true;
       };
 
       if (prop === 'transform') {
-        walkTransformTranslateNodes(parsed, (node, parentFunctionName) => {
+        walkTransformTranslateNodes(parsed, (node, context) => {
           if (node.type === 'function') {
             if (isMathFunction(node.value) && !options.enforceInsideMathFunctions) {
               return true;
@@ -169,11 +228,7 @@ const ruleFunction = (primary, secondaryOptions) => {
             return false;
           }
 
-          if (
-            parentFunctionName &&
-            isMathFunction(parentFunctionName) &&
-            !options.enforceInsideMathFunctions
-          ) {
+          if (!shouldLintMathArgument(context, options)) {
             return false;
           }
 
@@ -181,7 +236,7 @@ const ruleFunction = (primary, secondaryOptions) => {
           return false;
         });
       } else {
-        walkRootValueNodes(parsed, (node, parentFunctionName) => {
+        walkRootValueNodes(parsed, (node, context) => {
           if (node.type === 'function') {
             if (isMathFunction(node.value) && !options.enforceInsideMathFunctions) {
               return true;
@@ -194,11 +249,7 @@ const ruleFunction = (primary, secondaryOptions) => {
             return false;
           }
 
-          if (
-            parentFunctionName &&
-            isMathFunction(parentFunctionName) &&
-            !options.enforceInsideMathFunctions
-          ) {
+          if (!shouldLintMathArgument(context, options)) {
             return false;
           }
 

--- a/src/rules/no-offscale-transform/index.mjs
+++ b/src/rules/no-offscale-transform/index.mjs
@@ -1,0 +1,7 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const rule = require('./index.js');
+export default rule;
+export const ruleName = rule.ruleName;
+export const messages = rule.messages;
+export const meta = rule.meta;

--- a/src/rules/prefer-token/index.mjs
+++ b/src/rules/prefer-token/index.mjs
@@ -1,0 +1,7 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const rule = require('./index.js');
+export default rule;
+export const ruleName = rule.ruleName;
+export const messages = rule.messages;
+export const meta = rule.meta;

--- a/src/rules/use-scale/index.mjs
+++ b/src/rules/use-scale/index.mjs
@@ -1,0 +1,7 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const rule = require('./index.js');
+export default rule;
+export const ruleName = rule.ruleName;
+export const messages = rule.messages;
+export const meta = rule.meta;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,18 +1,46 @@
 'use strict';
 
-const SPACING_PROPERTY_PATTERNS = [
-  /^margin(?:-.+)?$/,
-  /^padding(?:-.+)?$/,
-  /^gap$/,
-  /^row-gap$/,
-  /^column-gap$/,
-  /^inset(?:-.+)?$/,
-  /^scroll-margin(?:-.+)?$/,
-  /^scroll-padding(?:-.+)?$/,
-  /^translate$/,
-  /^translate-[xyz]$/,
-  /^transform$/,
-];
+const PROPERTY_GROUP_PATTERNS = Object.freeze({
+  spacing: Object.freeze([
+    /^margin(?:-.+)?$/,
+    /^padding(?:-.+)?$/,
+    /^gap$/,
+    /^row-gap$/,
+    /^column-gap$/,
+    /^inset(?:-.+)?$/,
+    /^scroll-margin(?:-.+)?$/,
+    /^scroll-padding(?:-.+)?$/,
+    /^translate$/,
+    /^translate-[xyz]$/,
+    /^transform$/,
+  ]),
+  radius: Object.freeze([
+    /^border-radius$/,
+    /^border-(?:top|right|bottom|left)-(?:left|right)-radius$/,
+    /^border-(?:start|end)-(?:start|end)-radius$/,
+    /^outline-offset$/,
+  ]),
+  size: Object.freeze([
+    /^inline-size$/,
+    /^block-size$/,
+    /^min-inline-size$/,
+    /^min-block-size$/,
+    /^max-inline-size$/,
+    /^max-block-size$/,
+    /^(?:min-|max-)?(?:width|height)$/,
+  ]),
+  typography: Object.freeze([
+    /^font-size$/,
+    /^line-height$/,
+    /^letter-spacing$/,
+    /^word-spacing$/,
+  ]),
+});
+
+const DEFAULT_PROPERTY_GROUPS = Object.freeze(['spacing']);
+const PROPERTY_GROUP_NAMES = Object.freeze(Object.keys(PROPERTY_GROUP_PATTERNS));
+
+const SPACING_PROPERTY_PATTERNS = PROPERTY_GROUP_PATTERNS.spacing;
 
 const DEFAULT_IGNORE_KEYWORDS = [
   'auto',
@@ -33,9 +61,49 @@ const TRANSLATE_FUNCTIONS = new Set([
 
 const MATH_FUNCTIONS = new Set(['calc', 'clamp', 'min', 'max']);
 
+const SUPPORTED_SCALE_UNITS = new Set([
+  'px',
+  'rem',
+  'em',
+  '%',
+  'vh',
+  'vw',
+  'vi',
+  'vb',
+  'vmin',
+  'vmax',
+  'svh',
+  'svw',
+  'svi',
+  'svb',
+  'lvh',
+  'lvw',
+  'lvi',
+  'lvb',
+  'dvh',
+  'dvw',
+  'dvi',
+  'dvb',
+  'cqh',
+  'cqw',
+  'cqi',
+  'cqb',
+  'cqmin',
+  'cqmax',
+  'ch',
+  'ex',
+]);
+
+const DEFAULT_MATH_FUNCTION_ARGUMENT_FILTER = Object.freeze({});
+
 module.exports = {
   DEFAULT_IGNORE_KEYWORDS,
+  DEFAULT_MATH_FUNCTION_ARGUMENT_FILTER,
+  DEFAULT_PROPERTY_GROUPS,
   MATH_FUNCTIONS,
+  PROPERTY_GROUP_NAMES,
+  PROPERTY_GROUP_PATTERNS,
   SPACING_PROPERTY_PATTERNS,
+  SUPPORTED_SCALE_UNITS,
   TRANSLATE_FUNCTIONS,
 };

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -4,7 +4,12 @@ const stylelint = require('stylelint');
 const { all: knownCssProperties = [] } = require('known-css-properties');
 const {
   DEFAULT_IGNORE_KEYWORDS,
+  DEFAULT_PROPERTY_GROUPS,
+  MATH_FUNCTIONS,
+  PROPERTY_GROUP_NAMES,
+  PROPERTY_GROUP_PATTERNS,
   SPACING_PROPERTY_PATTERNS,
+  SUPPORTED_SCALE_UNITS,
 } = require('./constants');
 const { parseLengthToken } = require('./length');
 const {
@@ -14,17 +19,19 @@ const {
 } = require('../presets/scales');
 
 const DEFAULT_SCALE = getScalePreset('rhythmic-4') || [0, 4, 8, 12, 16, 24, 32];
-const VALID_UNITS = new Set(['px', 'rem', 'em']);
 const VALIDATE_ALWAYS = () => true;
+const SUPPORTED_MATH_FUNCTIONS = new Set(Array.from(MATH_FUNCTIONS));
 
-const supportedSpacingProperties = new Set(
+const allPropertyPatterns = Object.values(PROPERTY_GROUP_PATTERNS).flat();
+
+const supportedScaleProperties = new Set(
   knownCssProperties.filter((property) =>
-    SPACING_PROPERTY_PATTERNS.some((pattern) => pattern.test(property)),
+    allPropertyPatterns.some((pattern) => pattern.test(property)),
   ),
 );
-supportedSpacingProperties.add('translate-x');
-supportedSpacingProperties.add('translate-y');
-supportedSpacingProperties.add('translate-z');
+supportedScaleProperties.add('translate-x');
+supportedScaleProperties.add('translate-y');
+supportedScaleProperties.add('translate-z');
 
 function isPlainObject(value) {
   return (
@@ -51,7 +58,11 @@ function isSupportedUnit(value) {
     return false;
   }
 
-  return VALID_UNITS.has(value.trim().toLowerCase());
+  return SUPPORTED_SCALE_UNITS.has(value.trim().toLowerCase());
+}
+
+function isUnitStrategy(value) {
+  return value === 'convert' || value === 'exact';
 }
 
 function isScaleEntry(value) {
@@ -68,7 +79,27 @@ function isScaleEntry(value) {
     return false;
   }
 
-  return parsed.unit === '' || VALID_UNITS.has(parsed.unit);
+  return parsed.unit === '' || SUPPORTED_SCALE_UNITS.has(parsed.unit);
+}
+
+function parseRegexLikeString(value) {
+  if (!isNonEmptyString(value)) {
+    return null;
+  }
+
+  if (value[0] !== '/' || value.lastIndexOf('/') <= 0) {
+    return null;
+  }
+
+  const lastSlash = value.lastIndexOf('/');
+  const pattern = value.slice(1, lastSlash);
+  const flags = value.slice(lastSlash + 1);
+
+  try {
+    return new RegExp(pattern, flags);
+  } catch {
+    return null;
+  }
 }
 
 function isPropertyPatternEntry(value) {
@@ -80,8 +111,13 @@ function isPropertyPatternEntry(value) {
     return false;
   }
 
+  const regex = parseRegexLikeString(value.trim());
+  if (regex) {
+    return true;
+  }
+
   const normalized = value.trim().toLowerCase();
-  return supportedSpacingProperties.has(normalized);
+  return supportedScaleProperties.has(normalized);
 }
 
 function isTokenMap(value) {
@@ -90,6 +126,85 @@ function isTokenMap(value) {
   }
 
   return Object.values(value).every((tokenValue) => isNonEmptyString(tokenValue));
+}
+
+function isPropertyGroupName(value) {
+  if (!isNonEmptyString(value)) {
+    return false;
+  }
+
+  return PROPERTY_GROUP_NAMES.includes(value.trim().toLowerCase());
+}
+
+function isMathFunctionArgumentList(value) {
+  return Array.isArray(value) && value.every((item) => Number.isInteger(item) && item > 0);
+}
+
+function isMathFunctionArgumentMap(value) {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  return Object.entries(value).every(([fn, args]) => {
+    if (!isNonEmptyString(fn)) {
+      return false;
+    }
+
+    if (!SUPPORTED_MATH_FUNCTIONS.has(fn.trim().toLowerCase())) {
+      return false;
+    }
+
+    return isMathFunctionArgumentList(args);
+  });
+}
+
+function isScaleOverrideEntry(value) {
+  if (Array.isArray(value)) {
+    return value.every((entry) => isScaleEntry(entry));
+  }
+
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  const hasPreset = value.preset !== undefined;
+  const hasScale = value.scale !== undefined;
+  const hasCustomScale = value.customScale !== undefined;
+
+  if (!hasPreset && !hasScale && !hasCustomScale) {
+    return false;
+  }
+
+  if (hasPreset && !isNonEmptyString(value.preset)) {
+    return false;
+  }
+
+  if (hasScale && (!Array.isArray(value.scale) || !value.scale.every((entry) => isScaleEntry(entry)))) {
+    return false;
+  }
+
+  if (
+    hasCustomScale &&
+    (!Array.isArray(value.customScale) || !value.customScale.every((entry) => isScaleEntry(entry)))
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function isPropertyScaleMap(value) {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  return Object.entries(value).every(([property, scaleOverride]) => {
+    if (!isPropertyPatternEntry(property)) {
+      return false;
+    }
+
+    return isScaleOverrideEntry(scaleOverride);
+  });
 }
 
 function validateSecondaryOptionShapes(result, ruleName, secondaryOptions, schema) {
@@ -171,6 +286,116 @@ function validateSecondaryOptions({
   return validOptions && validShapes;
 }
 
+function normalizePropertyGroups(rawGroups) {
+  const source = Array.isArray(rawGroups) && rawGroups.length > 0
+    ? rawGroups
+    : DEFAULT_PROPERTY_GROUPS;
+
+  const normalized = source
+    .map((group) => String(group).trim().toLowerCase())
+    .filter((group) => PROPERTY_GROUP_NAMES.includes(group));
+
+  return normalized.length > 0 ? [...new Set(normalized)] : [...DEFAULT_PROPERTY_GROUPS];
+}
+
+function resolvePropertyPatterns(options) {
+  if (Array.isArray(options.properties)) {
+    return options.properties;
+  }
+
+  const groups = normalizePropertyGroups(options.propertyGroups);
+  const patterns = [];
+
+  for (const group of groups) {
+    patterns.push(...PROPERTY_GROUP_PATTERNS[group]);
+  }
+
+  return patterns.length > 0 ? patterns : SPACING_PROPERTY_PATTERNS;
+}
+
+function compilePropertyMatcher(entry) {
+  if (entry instanceof RegExp) {
+    return entry;
+  }
+
+  if (!isNonEmptyString(entry)) {
+    return null;
+  }
+
+  const trimmed = entry.trim();
+  const parsedRegex = parseRegexLikeString(trimmed);
+  if (parsedRegex) {
+    return parsedRegex;
+  }
+
+  return trimmed.toLowerCase();
+}
+
+function resolveScaleOverride(override) {
+  if (Array.isArray(override)) {
+    return override;
+  }
+
+  if (!isPlainObject(override)) {
+    return null;
+  }
+
+  return resolveScaleSelection(override, DEFAULT_SCALE).scale;
+}
+
+function buildPropertyScaleOverrides(propertyScales) {
+  if (!isPlainObject(propertyScales)) {
+    return [];
+  }
+
+  const overrides = [];
+
+  for (const [entry, scaleOverride] of Object.entries(propertyScales)) {
+    const matcher = compilePropertyMatcher(entry);
+    const scale = resolveScaleOverride(scaleOverride);
+    if (!matcher || !Array.isArray(scale)) {
+      continue;
+    }
+
+    overrides.push({
+      matcher,
+      scale,
+    });
+  }
+
+  return overrides;
+}
+
+function normalizeMathFunctionArgumentMap(value) {
+  if (!isPlainObject(value)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([fn, args]) => {
+      const normalizedFn = String(fn).trim().toLowerCase();
+      if (!SUPPORTED_MATH_FUNCTIONS.has(normalizedFn) || !isMathFunctionArgumentList(args)) {
+        return [];
+      }
+
+      return [
+        [
+          normalizedFn,
+          [...new Set(args)].sort((a, b) => a - b),
+        ],
+      ];
+    }),
+  );
+}
+
+function resolveUnits(options) {
+  if (Array.isArray(options.units)) {
+    return options.units.map((unit) => String(unit).toLowerCase());
+  }
+
+  return ['px', 'rem', 'em'];
+}
+
 const SCALE_VALIDATION_SCHEMA = Object.freeze({
   allowNegative: Object.freeze({
     entryValidator: isBoolean,
@@ -191,12 +416,23 @@ const SCALE_VALIDATION_SCHEMA = Object.freeze({
   fixToScale: Object.freeze({
     entryValidator: isBoolean,
   }),
+  ignoreMathFunctionArguments: Object.freeze({
+    entryValidator: isMathFunctionArgumentMap,
+    expectsObject: true,
+  }),
+  mathFunctionArguments: Object.freeze({
+    entryValidator: isMathFunctionArgumentMap,
+    expectsObject: true,
+  }),
   preset: Object.freeze({
     entryValidator: isNonEmptyString,
   }),
   scale: Object.freeze({
     entryValidator: isScaleEntry,
     expectsArray: true,
+  }),
+  unitStrategy: Object.freeze({
+    entryValidator: isUnitStrategy,
   }),
   units: Object.freeze({
     entryValidator: isSupportedUnit,
@@ -213,6 +449,14 @@ const USE_SCALE_VALIDATION_SCHEMA = Object.freeze({
   properties: Object.freeze({
     entryValidator: isPropertyPatternEntry,
     expectsArray: true,
+  }),
+  propertyGroups: Object.freeze({
+    entryValidator: isPropertyGroupName,
+    expectsArray: true,
+  }),
+  propertyScales: Object.freeze({
+    entryValidator: isPropertyScaleMap,
+    expectsObject: true,
   }),
   tokenFunctions: Object.freeze({
     entryValidator: isNonEmptyString,
@@ -241,9 +485,17 @@ const PREFER_TOKEN_VALIDATION_SCHEMA = Object.freeze({
   enforceInsideMathFunctions: Object.freeze({
     entryValidator: isBoolean,
   }),
+  ignoreMathFunctionArguments: Object.freeze({
+    entryValidator: isMathFunctionArgumentMap,
+    expectsObject: true,
+  }),
   ignoreValues: Object.freeze({
     entryValidator: isNonEmptyString,
     expectsArray: true,
+  }),
+  mathFunctionArguments: Object.freeze({
+    entryValidator: isMathFunctionArgumentMap,
+    expectsObject: true,
   }),
   preset: Object.freeze({
     entryValidator: isNonEmptyString,
@@ -252,9 +504,20 @@ const PREFER_TOKEN_VALIDATION_SCHEMA = Object.freeze({
     entryValidator: isPropertyPatternEntry,
     expectsArray: true,
   }),
+  propertyGroups: Object.freeze({
+    entryValidator: isPropertyGroupName,
+    expectsArray: true,
+  }),
+  propertyScales: Object.freeze({
+    entryValidator: isPropertyScaleMap,
+    expectsObject: true,
+  }),
   scale: Object.freeze({
     entryValidator: isScaleEntry,
     expectsArray: true,
+  }),
+  tailwindConfigPath: Object.freeze({
+    entryValidator: isNonEmptyString,
   }),
   tokenFunctions: Object.freeze({
     entryValidator: isNonEmptyString,
@@ -264,8 +527,24 @@ const PREFER_TOKEN_VALIDATION_SCHEMA = Object.freeze({
     entryValidator: isTokenMap,
     expectsObject: true,
   }),
+  tokenMapFile: Object.freeze({
+    entryValidator: isNonEmptyString,
+  }),
+  tokenMapFromCssCustomProperties: Object.freeze({
+    entryValidator: isBoolean,
+  }),
+  tokenMapFromTailwindSpacing: Object.freeze({
+    entryValidator: isBoolean,
+  }),
   tokenPattern: Object.freeze({
     entryValidator: isNonEmptyString,
+  }),
+  unitStrategy: Object.freeze({
+    entryValidator: isUnitStrategy,
+  }),
+  units: Object.freeze({
+    entryValidator: isSupportedUnit,
+    expectsArray: true,
   }),
 });
 
@@ -294,15 +573,17 @@ function buildScaleOptions(rawOptions) {
         : 16,
     enforceInsideMathFunctions: options.enforceInsideMathFunctions === true,
     fixToScale: options.fixToScale !== false,
+    ignoreMathFunctionArguments: normalizeMathFunctionArgumentMap(options.ignoreMathFunctionArguments),
     ignoreValues: Array.isArray(options.ignoreValues)
       ? options.ignoreValues.map((value) => String(value).toLowerCase())
       : DEFAULT_IGNORE_KEYWORDS,
     invalidPreset: scaleSelection.invalidPreset,
+    mathFunctionArguments: normalizeMathFunctionArgumentMap(options.mathFunctionArguments),
     preset: scaleSelection.selectedPreset,
     presetNames: listScalePresetNames(),
-    properties: Array.isArray(options.properties)
-      ? options.properties
-      : SPACING_PROPERTY_PATTERNS,
+    properties: resolvePropertyPatterns(options),
+    propertyGroups: normalizePropertyGroups(options.propertyGroups),
+    propertyScaleOverrides: buildPropertyScaleOverrides(options.propertyScales),
     scale: scaleSelection.scale,
     tokenFunctions: Array.isArray(options.tokenFunctions)
       ? options.tokenFunctions.map((value) => String(value).toLowerCase())
@@ -311,9 +592,8 @@ function buildScaleOptions(rawOptions) {
       typeof options.tokenPattern === 'string' && options.tokenPattern.length > 0
         ? options.tokenPattern
         : '^--space-',
-    units: Array.isArray(options.units)
-      ? options.units.map((unit) => String(unit).toLowerCase())
-      : ['px', 'rem', 'em'],
+    unitStrategy: options.unitStrategy === 'exact' ? 'exact' : 'convert',
+    units: resolveUnits(options),
   };
 }
 
@@ -330,16 +610,22 @@ function buildTokenOptions(rawOptions) {
         ? options.baseFontSize
         : 16,
     enforceInsideMathFunctions: options.enforceInsideMathFunctions === true,
+    ignoreMathFunctionArguments: normalizeMathFunctionArgumentMap(options.ignoreMathFunctionArguments),
     ignoreValues: Array.isArray(options.ignoreValues)
       ? options.ignoreValues.map((value) => String(value).toLowerCase())
       : DEFAULT_IGNORE_KEYWORDS,
     invalidPreset: scaleSelection.invalidPreset,
+    mathFunctionArguments: normalizeMathFunctionArgumentMap(options.mathFunctionArguments),
     preset: scaleSelection.selectedPreset,
     presetNames: listScalePresetNames(),
-    properties: Array.isArray(options.properties)
-      ? options.properties
-      : SPACING_PROPERTY_PATTERNS,
+    properties: resolvePropertyPatterns(options),
+    propertyGroups: normalizePropertyGroups(options.propertyGroups),
+    propertyScaleOverrides: buildPropertyScaleOverrides(options.propertyScales),
     scale: scaleSelection.scale,
+    tailwindConfigPath:
+      typeof options.tailwindConfigPath === 'string' && options.tailwindConfigPath.length > 0
+        ? options.tailwindConfigPath
+        : null,
     tokenFunctions: Array.isArray(options.tokenFunctions)
       ? options.tokenFunctions.map((value) => String(value).toLowerCase())
       : ['var', 'theme', 'token'],
@@ -347,11 +633,41 @@ function buildTokenOptions(rawOptions) {
       options.tokenMap && typeof options.tokenMap === 'object'
         ? options.tokenMap
         : {},
+    tokenMapFile:
+      typeof options.tokenMapFile === 'string' && options.tokenMapFile.length > 0
+        ? options.tokenMapFile
+        : null,
+    tokenMapFromCssCustomProperties: options.tokenMapFromCssCustomProperties === true,
+    tokenMapFromTailwindSpacing: options.tokenMapFromTailwindSpacing === true,
     tokenPattern:
       typeof options.tokenPattern === 'string' && options.tokenPattern.length > 0
         ? options.tokenPattern
         : '^--space-',
+    unitStrategy: options.unitStrategy === 'exact' ? 'exact' : 'convert',
+    units: resolveUnits(options),
   };
+}
+
+function resolvePropertyScale(prop, options) {
+  if (!Array.isArray(options.propertyScaleOverrides)) {
+    return options.scale;
+  }
+
+  for (const override of options.propertyScaleOverrides) {
+    if (override.matcher instanceof RegExp) {
+      if (override.matcher.test(prop)) {
+        return override.scale;
+      }
+
+      continue;
+    }
+
+    if (String(override.matcher).toLowerCase() === prop.toLowerCase()) {
+      return override.scale;
+    }
+  }
+
+  return options.scale;
 }
 
 function validateUseScaleSecondaryOptions(result, ruleName, secondaryOptions) {
@@ -387,6 +703,7 @@ function validatePreferTokenSecondaryOptions(result, ruleName, secondaryOptions)
 module.exports = {
   buildScaleOptions,
   buildTokenOptions,
+  resolvePropertyScale,
   validateNoOffscaleTransformSecondaryOptions,
   validatePreferTokenSecondaryOptions,
   validateUseScaleSecondaryOptions,

--- a/src/utils/token-map.js
+++ b/src/utils/token-map.js
@@ -1,0 +1,358 @@
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  formatLength,
+  parseLengthToken,
+  toPx,
+} = require('./length');
+
+function isPlainObject(value) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value)
+  );
+}
+
+function normalizeTokenReference(tokenReference) {
+  if (typeof tokenReference !== 'string') {
+    return null;
+  }
+
+  const trimmed = tokenReference.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (/^(var\(|theme\(|token\(|\$|@)/.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (trimmed.startsWith('--')) {
+    return `var(${trimmed})`;
+  }
+
+  return `var(--${trimmed})`;
+}
+
+function addLengthValueMapping(map, rawLength, tokenReference, baseFontSize) {
+  if (typeof rawLength !== 'string') {
+    return;
+  }
+
+  const parsed = parseLengthToken(rawLength);
+  if (!parsed) {
+    return;
+  }
+
+  const token = normalizeTokenReference(tokenReference);
+  if (!token) {
+    return;
+  }
+
+  const absolute = Math.abs(parsed.number);
+  const normalizedRaw = formatLength(absolute, parsed.unit || 'px');
+  map[normalizedRaw] = token;
+
+  const px = toPx(absolute, parsed.unit, baseFontSize);
+  if (px !== null) {
+    map[`${px}px`] = token;
+  }
+}
+
+function mergeExplicitTokenMap(target, source) {
+  if (!isPlainObject(source)) {
+    return target;
+  }
+
+  for (const [raw, tokenReference] of Object.entries(source)) {
+    if (typeof tokenReference !== 'string') {
+      continue;
+    }
+
+    target[raw] = tokenReference;
+  }
+
+  return target;
+}
+
+function mergeTokenMapFromFile({
+  baseFontSize,
+  currentMap,
+  tokenMapFile,
+}) {
+  if (!tokenMapFile) {
+    return currentMap;
+  }
+
+  const resolvedPath = path.resolve(process.cwd(), tokenMapFile);
+  if (!fs.existsSync(resolvedPath)) {
+    return currentMap;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(resolvedPath, 'utf8'));
+  } catch {
+    return currentMap;
+  }
+
+  if (!isPlainObject(parsed)) {
+    return currentMap;
+  }
+
+  const nextMap = {
+    ...currentMap,
+  };
+
+  for (const [entryKey, entryValue] of Object.entries(parsed)) {
+    if (typeof entryValue === 'string') {
+      const keyAsLength = parseLengthToken(entryKey);
+      const valueAsLength = parseLengthToken(entryValue);
+
+      if (keyAsLength) {
+        nextMap[entryKey] = entryValue;
+        continue;
+      }
+
+      if (valueAsLength) {
+        addLengthValueMapping(nextMap, entryValue, entryKey, baseFontSize);
+      }
+
+      continue;
+    }
+
+    if (typeof entryValue === 'number') {
+      addLengthValueMapping(nextMap, `${entryValue}px`, entryKey, baseFontSize);
+      continue;
+    }
+
+    if (isPlainObject(entryValue) && typeof entryValue.value === 'string') {
+      addLengthValueMapping(nextMap, entryValue.value, entryKey, baseFontSize);
+    }
+  }
+
+  return nextMap;
+}
+
+function mergeTokenMapFromCssCustomProperties({
+  baseFontSize,
+  currentMap,
+  root,
+  tokenRegex,
+}) {
+  const nextMap = {
+    ...currentMap,
+  };
+
+  root.walkDecls((decl) => {
+    const prop = decl.prop.toLowerCase();
+    if (!prop.startsWith('--')) {
+      return;
+    }
+
+    if (!tokenRegex.test(prop)) {
+      return;
+    }
+
+    const parsed = parseLengthToken(decl.value);
+    if (!parsed || parsed.number === 0) {
+      return;
+    }
+
+    addLengthValueMapping(nextMap, decl.value, `var(${decl.prop})`, baseFontSize);
+  });
+
+  return nextMap;
+}
+
+const tailwindSpacingCache = new Map();
+
+function extractTailwindSpacing(config) {
+  if (!isPlainObject(config)) {
+    return null;
+  }
+
+  const theme = isPlainObject(config.theme)
+    ? config.theme
+    : null;
+  if (!theme) {
+    return null;
+  }
+
+  const spacing = isPlainObject(theme.spacing)
+    ? theme.spacing
+    : {};
+  const extendSpacing =
+    isPlainObject(theme.extend) && isPlainObject(theme.extend.spacing)
+      ? theme.extend.spacing
+      : {};
+
+  return {
+    ...spacing,
+    ...extendSpacing,
+  };
+}
+
+function loadTailwindSpacingFromRequire(resolvedPath) {
+  try {
+    const loaded = require(resolvedPath);
+    const config = loaded && typeof loaded.default === 'object'
+      ? loaded.default
+      : loaded;
+
+    return extractTailwindSpacing(config);
+  } catch {
+    return null;
+  }
+}
+
+function loadTailwindSpacingFromDynamicImport(resolvedPath) {
+  const script = [
+    'const { pathToFileURL } = require("node:url");',
+    '(async () => {',
+    '  try {',
+    '    const configPath = process.argv[1];',
+    '    const loaded = await import(pathToFileURL(configPath).href);',
+    '    const config = loaded && typeof loaded.default === "object" ? loaded.default : loaded;',
+    '    if (!config || typeof config !== "object" || Array.isArray(config)) {',
+    '      process.stdout.write("{}");',
+    '      return;',
+    '    }',
+    '    const theme = config.theme && typeof config.theme === "object" && !Array.isArray(config.theme)',
+    '      ? config.theme',
+    '      : null;',
+    '    if (!theme) {',
+    '      process.stdout.write("{}");',
+    '      return;',
+    '    }',
+    '    const spacing = theme.spacing && typeof theme.spacing === "object" && !Array.isArray(theme.spacing)',
+    '      ? theme.spacing',
+    '      : {};',
+    '    const extendSpacing = theme.extend && typeof theme.extend === "object" && !Array.isArray(theme.extend) &&',
+    '      theme.extend.spacing && typeof theme.extend.spacing === "object" && !Array.isArray(theme.extend.spacing)',
+    '      ? theme.extend.spacing',
+    '      : {};',
+    '    process.stdout.write(JSON.stringify({ ...spacing, ...extendSpacing }));',
+    '  } catch {',
+    '    process.exit(1);',
+    '  }',
+    '})();',
+  ].join('\n');
+
+  const child = spawnSync(process.execPath, ['-e', script, resolvedPath], {
+    encoding: 'utf8',
+    timeout: 5000,
+  });
+
+  if (child.error || child.status !== 0) {
+    return null;
+  }
+
+  if (typeof child.stdout !== 'string' || child.stdout.trim() === '') {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(child.stdout);
+    return isPlainObject(parsed)
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function loadTailwindSpacing(resolvedPath) {
+  if (tailwindSpacingCache.has(resolvedPath)) {
+    return tailwindSpacingCache.get(resolvedPath);
+  }
+
+  const spacing =
+    loadTailwindSpacingFromRequire(resolvedPath) ||
+    loadTailwindSpacingFromDynamicImport(resolvedPath);
+
+  tailwindSpacingCache.set(resolvedPath, spacing);
+  return spacing;
+}
+
+function mergeTokenMapFromTailwindSpacing({
+  currentMap,
+  tailwindConfigPath,
+}) {
+  if (!tailwindConfigPath) {
+    return currentMap;
+  }
+
+  const resolvedPath = path.resolve(process.cwd(), tailwindConfigPath);
+  if (!fs.existsSync(resolvedPath)) {
+    return currentMap;
+  }
+
+  const spacing = loadTailwindSpacing(resolvedPath);
+  if (!isPlainObject(spacing) || Object.keys(spacing).length === 0) {
+    return currentMap;
+  }
+
+  const nextMap = {
+    ...currentMap,
+  };
+
+  for (const [key, value] of Object.entries(spacing)) {
+    if (typeof value !== 'string') {
+      continue;
+    }
+
+    const parsed = parseLengthToken(value);
+    if (!parsed || parsed.number === 0) {
+      continue;
+    }
+
+    const absolute = Math.abs(parsed.number);
+    const normalizedRaw = formatLength(absolute, parsed.unit || 'px');
+    nextMap[normalizedRaw] = `theme(spacing.${key})`;
+  }
+
+  return nextMap;
+}
+
+function buildEffectiveTokenMap({
+  options,
+  root,
+  tokenRegex,
+}) {
+  let tokenMap = mergeExplicitTokenMap({}, options.tokenMap);
+
+  if (options.tokenMapFile) {
+    tokenMap = mergeTokenMapFromFile({
+      baseFontSize: options.baseFontSize,
+      currentMap: tokenMap,
+      tokenMapFile: options.tokenMapFile,
+    });
+  }
+
+  if (options.tokenMapFromCssCustomProperties) {
+    tokenMap = mergeTokenMapFromCssCustomProperties({
+      baseFontSize: options.baseFontSize,
+      currentMap: tokenMap,
+      root,
+      tokenRegex,
+    });
+  }
+
+  if (options.tokenMapFromTailwindSpacing && options.tailwindConfigPath) {
+    tokenMap = mergeTokenMapFromTailwindSpacing({
+      currentMap: tokenMap,
+      tailwindConfigPath: options.tailwindConfigPath,
+    });
+  }
+
+  return tokenMap;
+}
+
+module.exports = {
+  buildEffectiveTokenMap,
+};

--- a/test/advanced-options.test.js
+++ b/test/advanced-options.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { lintCss } = require('./helpers/lint');
+
+test('use-scale supports property groups beyond spacing', async () => {
+  const result = await lintCss({
+    code: '.card { border-radius: 10px; }',
+    rules: {
+      'rhythmguard/use-scale': [
+        true,
+        {
+          propertyGroups: ['radius'],
+          scale: [0, 4, 8, 12, 16],
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.warnings.length, 1);
+  assert.equal(result.warnings[0].rule, 'rhythmguard/use-scale');
+});
+
+test('use-scale supports per-property scale overrides', async () => {
+  const result = await lintCss({
+    code: '.card { margin: 6px; padding: 6px; }',
+    fix: true,
+    rules: {
+      'rhythmguard/use-scale': [
+        true,
+        {
+          properties: ['margin', 'padding'],
+          propertyScales: {
+            margin: [0, 2, 4, 6, 8],
+          },
+          scale: [0, 4, 8, 12],
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.code, '.card { margin: 6px; padding: 4px; }');
+});
+
+test('use-scale supports exact unit strategy for non-convertible units', async () => {
+  const result = await lintCss({
+    code: '.card { margin: 3vw; }',
+    fix: true,
+    rules: {
+      'rhythmguard/use-scale': [
+        true,
+        {
+          scale: ['0vw', '2vw', '4vw'],
+          unitStrategy: 'exact',
+          units: ['vw'],
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.code, '.card { margin: 2vw; }');
+});
+
+test('use-scale supports math argument targeting', async () => {
+  const result = await lintCss({
+    code: '.card { margin: clamp(9px, 5vw, 13px); }',
+    rules: {
+      'rhythmguard/use-scale': [
+        true,
+        {
+          enforceInsideMathFunctions: true,
+          mathFunctionArguments: {
+            clamp: [1, 3],
+          },
+          scale: [0, 4, 8, 12, 16],
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.warnings.length, 2);
+  assert.ok(result.warnings.every((warning) => warning.rule === 'rhythmguard/use-scale'));
+});

--- a/test/eslint-tailwind.test.js
+++ b/test/eslint-tailwind.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { Linter } = require('eslint');
+
+const eslintPlugin = require('../src/eslint');
+
+test('eslint tailwind class rule reports off-scale arbitrary values', () => {
+  const linter = new Linter({ configType: 'eslintrc' });
+  linter.defineRule(
+    'rhythmguard-tailwind/tailwind-class-use-scale',
+    eslintPlugin.rules['tailwind-class-use-scale'],
+  );
+
+  const messages = linter.verify(
+    "const classes = 'p-[13px] gap-[8px]';",
+    {
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+      rules: {
+        'rhythmguard-tailwind/tailwind-class-use-scale': ['error', {
+          scale: [0, 4, 8, 12, 16, 24, 32],
+        }],
+      },
+    },
+  );
+
+  assert.equal(messages.length, 1);
+  assert.match(messages[0].message, /p-\[13px\]/);
+});
+
+test('eslint tailwind class rule autofixes nearest value', () => {
+  const linter = new Linter({ configType: 'eslintrc' });
+  linter.defineRule(
+    'rhythmguard-tailwind/tailwind-class-use-scale',
+    eslintPlugin.rules['tailwind-class-use-scale'],
+  );
+
+  const fixResult = linter.verifyAndFix(
+    "const classes = 'p-[13px]';",
+    {
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+      rules: {
+        'rhythmguard-tailwind/tailwind-class-use-scale': ['error', {
+          scale: [0, 4, 8, 12, 16, 24, 32],
+        }],
+      },
+    },
+  );
+
+  assert.equal(fixResult.fixed, true);
+  assert.equal(fixResult.output, "const classes = 'p-[12px]';");
+});

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -1,29 +1,40 @@
 'use strict';
 
+const path = require('node:path');
 const assert = require('node:assert/strict');
 const test = require('node:test');
+const { pathToFileURL } = require('node:url');
 
 const plugin = require('../src/index');
 
-test('plugin exports rules and shared configs', () => {
+test('plugin exports rules, shared configs, presets, and eslint companion', () => {
   assert.ok(Array.isArray(plugin));
   assert.ok(plugin.rules);
   assert.ok(plugin.rules['rhythmguard/use-scale']);
   assert.ok(plugin.rules['rhythmguard/prefer-token']);
   assert.ok(plugin.rules['rhythmguard/no-offscale-transform']);
+
   assert.ok(plugin.configs.recommended);
   assert.ok(plugin.configs.strict);
   assert.ok(plugin.configs.tailwind);
+  assert.ok(plugin.configs.expanded);
+  assert.ok(plugin.configs.logical);
+  assert.ok(plugin.configs.migration);
+
   assert.deepEqual(plugin.configs.tailwind.extends, [
     'stylelint-config-tailwindcss',
     'stylelint-plugin-rhythmguard/configs/strict',
   ]);
+
   assert.ok(plugin.presets);
   assert.ok(plugin.presets.scales['rhythmic-4']);
   assert.ok(plugin.presets.scales['product-decimal-10']);
   assert.ok(Array.isArray(plugin.presets.listScalePresetNames()));
   assert.ok(Array.isArray(plugin.presets.listCommunityScalePresetNames()));
   assert.ok(plugin.presets.getCommunityScaleMetadata('product-decimal-10'));
+
+  assert.ok(plugin.eslint);
+  assert.ok(plugin.eslint.rules['tailwind-class-use-scale']);
 });
 
 test('strict config avoids transform overlap in use-scale', () => {
@@ -42,4 +53,14 @@ test('strict config avoids transform overlap in use-scale', () => {
     properties.some((pattern) => String(pattern) === '/^transform$/'),
     false,
   );
+});
+
+test('esm entrypoint exposes default plugin object', async () => {
+  const entryPath = path.join(__dirname, '..', 'src', 'index.mjs');
+  const esm = await import(pathToFileURL(entryPath).href);
+
+  assert.ok(esm.default);
+  assert.ok(esm.default.rules['rhythmguard/use-scale']);
+  assert.ok(esm.configs.logical);
+  assert.ok(esm.eslint.rules['tailwind-class-use-scale']);
 });

--- a/test/prefer-token-token-sources.test.js
+++ b/test/prefer-token-token-sources.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { lintCss } = require('./helpers/lint');
+
+test('prefer-token can build token map from CSS custom properties', async () => {
+  const result = await lintCss({
+    code: ':root { --space-3: 12px; } .stack { gap: 12px; }',
+    fix: true,
+    rules: {
+      'rhythmguard/prefer-token': [
+        true,
+        {
+          tokenMapFromCssCustomProperties: true,
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.code, ':root { --space-3: 12px; } .stack { gap: var(--space-3); }');
+});
+
+test('prefer-token can load token mappings from JSON file', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-token-map-'));
+  const tokenMapPath = path.join(tempDir, 'tokens.json');
+  fs.writeFileSync(tokenMapPath, JSON.stringify({
+    '--space-4': '16px',
+  }));
+
+  const result = await lintCss({
+    code: '.stack { gap: 16px; }',
+    fix: true,
+    rules: {
+      'rhythmguard/prefer-token': [
+        true,
+        {
+          tokenMapFile: tokenMapPath,
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.code, '.stack { gap: var(--space-4); }');
+});
+
+test('prefer-token can load spacing values from Tailwind config', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-tailwind-map-'));
+  const tailwindConfigPath = path.join(tempDir, 'tailwind.config.cjs');
+  fs.writeFileSync(
+    tailwindConfigPath,
+    'module.exports = { theme: { spacing: { "3": "0.75rem", "4": "1rem" } } };',
+  );
+
+  const result = await lintCss({
+    code: '.stack { gap: 0.75rem; }',
+    fix: true,
+    rules: {
+      'rhythmguard/prefer-token': [
+        true,
+        {
+          tokenMapFromTailwindSpacing: true,
+          tailwindConfigPath,
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.code, '.stack { gap: theme(spacing.3); }');
+});
+
+test('prefer-token can load spacing values from ESM Tailwind config', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-tailwind-map-esm-'));
+  const tailwindConfigPath = path.join(tempDir, 'tailwind.config.mjs');
+  fs.writeFileSync(
+    tailwindConfigPath,
+    'export default { theme: { spacing: { "3": "0.75rem" }, extend: { spacing: { "5": "1.25rem" } } } };',
+  );
+
+  const result = await lintCss({
+    code: '.stack { gap: 1.25rem; }',
+    fix: true,
+    rules: {
+      'rhythmguard/prefer-token': [
+        true,
+        {
+          tokenMapFromTailwindSpacing: true,
+          tailwindConfigPath,
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.code, '.stack { gap: theme(spacing.5); }');
+});


### PR DESCRIPTION
- add broader property-group enforcement and per-property scale overrides

- add token-map source automation and ESM/CJS export support

- add Tailwind class-string ESLint companion and new shared configs

- update docs/tests and Tailwind config source compatibility

## Summary

- what changed:
- why it changed:

## Checklist

- [ ] `npm run lint`
- [ ] `npm test`
- [ ] `npm run scales:validate` (if community scales changed)
- [ ] README/docs updated where needed
- [ ] CHANGELOG updated for user-facing behavior changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added property groups (spacing, radius, typography, size) with per-property scale overrides
  * ESLint companion plugin for enforcing Tailwind arbitrary class values against scales
  * Token mapping from CSS custom properties, JSON files, and Tailwind configs
  * New configuration presets: expanded, logical, migration

* **Chores**
  * Extended Stylelint compatibility to ^16 || ^17
  * Added dual CommonJS/ESM entry points

<!-- end of auto-generated comment: release notes by coderabbit.ai -->