### PR TITLE
Lean npm artifact and publish adoption/distribution playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-02-21
+
+### Changed
+
+- npm package artifact is now leaner by excluding non-runtime media assets from published files.
+- README media links now use absolute GitHub URLs so npm README rendering remains intact without bundling local media files.
+- Added a dedicated "Drop-In for Existing Projects" path with a single install command and a single config block.
+- Added comparison and migration guidance:
+  - `docs/COMPARISON.md` (`defensive-css` vs `logical-css` vs Rhythmguard + migration recipes)
+  - `docs/ADOPTION_DIFFS.md` (real before/after excerpts from public codebases)
+- Added Dev.to publishing assets:
+  - `docs/DEVTO_ORIGINAL_UPDATE_NOTE_2026-02-21.md`
+  - `docs/DEVTO_CONTINUATION_2026-02-21.md`
+
 ## [1.4.1] - 2026-02-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./assets/rhythmguard-banner.svg" width="100%" alt="Rhythmguard banner in Geist Pixel" />
+  <img src="https://raw.githubusercontent.com/petrilahdelma/stylelint-plugin-rhythmguard/main/assets/rhythmguard-banner.svg" width="100%" alt="Rhythmguard banner in Geist Pixel" />
 </p>
 
 # stylelint-plugin-rhythmguard
@@ -17,8 +17,8 @@ High-precision spacing governance for CSS and design systems.
 ## Demo
 
 <p align="center">
-  <a href="./assets/rhythmguard-campaign-60s.webm">
-    <img src="./assets/rhythmguard-campaign-60s.gif" width="100%" alt="Rhythmguard 60-second demo" />
+  <a href="https://github.com/petrilahdelma/stylelint-plugin-rhythmguard/blob/main/assets/rhythmguard-campaign-60s.webm">
+    <img src="https://raw.githubusercontent.com/petrilahdelma/stylelint-plugin-rhythmguard/main/assets/rhythmguard-campaign-60s.gif" width="100%" alt="Rhythmguard 60-second demo" />
   </a>
 </p>
 
@@ -35,7 +35,7 @@ It is built for teams that want:
 ## Rule Matrix
 
 <p align="center">
-  <img src="./assets/rhythmguard-rules.svg" width="100%" alt="Rhythmguard rule matrix visual" />
+  <img src="https://raw.githubusercontent.com/petrilahdelma/stylelint-plugin-rhythmguard/main/assets/rhythmguard-rules.svg" width="100%" alt="Rhythmguard rule matrix visual" />
 </p>
 
 | Rule | What it does | Autofix |
@@ -48,6 +48,20 @@ It is built for teams that want:
 
 ```bash
 npm install --save-dev stylelint stylelint-plugin-rhythmguard
+```
+
+## Drop-In for Existing Projects (Recommended)
+
+If your project already uses Stylelint, you only need one command and one config block:
+
+```bash
+npm install --save-dev stylelint-plugin-rhythmguard
+```
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/recommended"]
+}
 ```
 
 ## Quick Start
@@ -116,6 +130,12 @@ Stable shared config entry points:
 - `stylelint-plugin-rhythmguard/configs/expanded`
 - `stylelint-plugin-rhythmguard/configs/logical`
 - `stylelint-plugin-rhythmguard/configs/migration`
+
+## Comparison and Migration Recipes
+
+- Side-by-side tool fit guide with migration snippets: [`docs/COMPARISON.md`](https://github.com/petrilahdelma/stylelint-plugin-rhythmguard/blob/main/docs/COMPARISON.md)
+- Real-world before/after excerpts from public repos: [`docs/ADOPTION_DIFFS.md`](https://github.com/petrilahdelma/stylelint-plugin-rhythmguard/blob/main/docs/ADOPTION_DIFFS.md)
+- Distribution submissions to Stylelint discovery surfaces: [`docs/DISTRIBUTION.md`](https://github.com/petrilahdelma/stylelint-plugin-rhythmguard/blob/main/docs/DISTRIBUTION.md)
 
 ### Full custom setup
 
@@ -545,6 +565,21 @@ Detailed methodology and custom args are documented in [`docs/BENCHMARKING.md`](
 ## Article
 
 - Dev.to: [Enforcing your spacing standards with Rhythmguard](https://dev.to/petrilahdelma/enforcing-your-spacing-standards-with-rhythmguard-a-custom-stylelint-plugin-1ojj)
+- Original article update note (Feb 21, 2026): [`docs/DEVTO_ORIGINAL_UPDATE_NOTE_2026-02-21.md`](https://github.com/petrilahdelma/stylelint-plugin-rhythmguard/blob/main/docs/DEVTO_ORIGINAL_UPDATE_NOTE_2026-02-21.md)
+- Continuation draft (ready to publish): [`docs/DEVTO_CONTINUATION_2026-02-21.md`](https://github.com/petrilahdelma/stylelint-plugin-rhythmguard/blob/main/docs/DEVTO_CONTINUATION_2026-02-21.md)
+
+## Used by and Community Examples
+
+Public codebases currently used for production migration examples:
+
+- [PetriLahdelma/digitaltableteur-nextjs](https://github.com/PetriLahdelma/digitaltableteur-nextjs)
+- [PetriLahdelma/digitaltableteur](https://github.com/PetriLahdelma/digitaltableteur)
+
+Want your team listed here?
+
+1. Open an issue with `used-by` in the title.
+2. Include one before/after diff and your Rhythmguard config.
+3. Add migration notes (false positives, rules enabled, rollout phase).
 
 ## Release Workflow
 

--- a/docs/ADOPTION_DIFFS.md
+++ b/docs/ADOPTION_DIFFS.md
@@ -1,0 +1,98 @@
+# Real Before/After Diffs (Public Codebases)
+
+These examples are extracted from public repositories and run through Rhythmguard with autofix enabled.
+
+## Source repositories
+
+- [PetriLahdelma/digitaltableteur-nextjs](https://github.com/PetriLahdelma/digitaltableteur-nextjs)
+- [PetriLahdelma/digitaltableteur](https://github.com/PetriLahdelma/digitaltableteur)
+
+## Example 1: Header spacing normalization
+
+Source: [`digitaltableteur-nextjs/app/components/Header/Header.module.css`](https://github.com/PetriLahdelma/digitaltableteur-nextjs/blob/main/app/components/Header/Header.module.css#L28)
+
+```diff
+ .headerInner {
+-  padding: 14px 0;
++  padding: 12px 0;
+ }
+```
+
+## Example 2: Mobile header spacing
+
+Source: [`digitaltableteur-nextjs/app/components/Header/Header.module.css`](https://github.com/PetriLahdelma/digitaltableteur-nextjs/blob/main/app/components/Header/Header.module.css#L150)
+
+```diff
+ @media (width <= 900px) {
+   .headerInner {
+-    padding: 10px 16px;
++    padding: 8px 16px;
+   }
+ }
+```
+
+## Example 3: Gallery gap consistency
+
+Source: [`digitaltableteur/nextjs-app/shared/components/Gallery/Gallery.module.css`](https://github.com/PetriLahdelma/digitaltableteur/blob/main/nextjs-app/shared/components/Gallery/Gallery.module.css#L77)
+
+```diff
+ @media (width <= 900px) {
+   .gallery {
+-    gap: 20px;
++    gap: 16px;
+   }
+
+   .column {
+-    gap: 20px;
++    gap: 16px;
+   }
+ }
+```
+
+## Example 4: Motion offset scale alignment
+
+Source: [`digitaltableteur/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.module.css`](https://github.com/PetriLahdelma/digitaltableteur/blob/main/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.module.css#L99)
+
+```diff
+ @keyframes fade-in-up {
+   from {
+-    transform: translateY(10px);
++    transform: translateY(8px);
+     opacity: 0;
+   }
+ }
+```
+
+## Lint output before fix
+
+Command:
+
+```bash
+npx stylelint /tmp/rhythmguard-real-examples.before.css --config /tmp/rhythmguard-real-examples.stylelintrc.json --formatter string
+```
+
+Output:
+
+```text
+../../../../tmp/rhythmguard-real-examples.before.css
+   3:12  ✖  Unexpected off-scale value "14px". Use scale values (nearest: 12px or 16px).             rhythmguard/use-scale
+   8:14  ✖  Unexpected off-scale value "10px". Use scale values (nearest: 8px or 12px).              rhythmguard/use-scale
+  15:10  ✖  Unexpected off-scale value "20px". Use scale values (nearest: 16px or 24px).             rhythmguard/use-scale
+  19:10  ✖  Unexpected off-scale value "20px". Use scale values (nearest: 16px or 24px).             rhythmguard/use-scale
+  26:27  ✖  Unexpected off-scale value "10px". Use scale values (nearest: 8px or 12px).              rhythmguard/use-scale
+  26:27  ✖  Unexpected transform translation value "10px". Use scale values (nearest: 8px or 12px).  rhythmguard/no-offscale-transform
+
+✖ 6 problems (6 errors, 0 warnings)
+  6 errors potentially fixable with the "--fix" option.
+```
+
+## Lint output after fix
+
+Command:
+
+```bash
+npx stylelint /tmp/rhythmguard-real-examples.css --config /tmp/rhythmguard-real-examples.stylelintrc.json --formatter string
+```
+
+Output: no violations.
+

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -1,0 +1,137 @@
+# Defensive CSS vs Logical CSS vs Rhythmguard
+
+This guide helps teams choose the right Stylelint plugin for each problem, then roll them out in a practical order.
+
+## Quick decision matrix
+
+| Tool | Primary problem solved | Best fit |
+| --- | --- | --- |
+| `stylelint-plugin-defensive-css` | Resilience and accessibility guardrails | UI hardening, interaction safety, reduced-motion, focus behavior |
+| `stylelint-plugin-logical-css` | Direction-agnostic and writing-mode-safe CSS | Internationalization, RTL/LTR parity, logical properties and keywords |
+| `stylelint-plugin-rhythmguard` | Design-token + spacing-scale governance | Consistent spacing/radius/size/typography and deterministic scale autofix |
+| `stylelint-scales` | Property-specific numeric scale enforcement | Teams that want granular scale rules per property category |
+
+## When to use each
+
+### Use `stylelint-plugin-defensive-css` when:
+
+- You want to prevent fragile UX patterns (`:hover` misuse, unsafe `will-change`, missing reduced-motion handling).
+- Accessibility and robust interaction behavior are immediate priorities.
+
+### Use `stylelint-plugin-logical-css` when:
+
+- You are migrating to logical properties (`margin-inline`, `padding-block`, etc.).
+- You support multiple writing directions and want CSS that adapts without rewrites.
+
+### Use `stylelint-plugin-rhythmguard` when:
+
+- Your spacing scale is being bypassed by arbitrary values.
+- You need token migration support and deterministic autofix to nearest scale values.
+- You want one plugin that can cover spacing, transform translation offsets, and optional radius/typography/size groups.
+
+### Use `stylelint-scales` when:
+
+- You want a broad rule-pack where each property family has its own numeric rule.
+- Your team prefers direct per-rule tuning by property type over a single governance model.
+
+## Recommended rollout order in real teams
+
+1. `defensive-css` for safety and accessibility baseline.
+2. `logical-css` for directional correctness.
+3. `rhythmguard` for scale and token consistency.
+
+## Migration recipes (copy/paste)
+
+## 1) Baseline defensive hardening
+
+```json
+{
+  "extends": ["stylelint-plugin-defensive-css/configs/recommended"]
+}
+```
+
+## 2) Add logical CSS enforcement
+
+```json
+{
+  "extends": [
+    "stylelint-plugin-defensive-css/configs/recommended",
+    "stylelint-plugin-logical-css/configs/recommended"
+  ]
+}
+```
+
+## 3) Add Rhythmguard scale governance
+
+```json
+{
+  "extends": [
+    "stylelint-plugin-defensive-css/configs/recommended",
+    "stylelint-plugin-logical-css/configs/recommended",
+    "stylelint-plugin-rhythmguard/configs/recommended"
+  ]
+}
+```
+
+## 4) Token migration phase (temporary)
+
+```json
+{
+  "extends": [
+    "stylelint-plugin-defensive-css/configs/recommended",
+    "stylelint-plugin-logical-css/configs/recommended",
+    "stylelint-plugin-rhythmguard/configs/migration"
+  ]
+}
+```
+
+## 5) Tight production profile (after migration)
+
+```json
+{
+  "extends": [
+    "stylelint-plugin-defensive-css/configs/recommended",
+    "stylelint-plugin-logical-css/configs/recommended",
+    "stylelint-plugin-rhythmguard/configs/strict"
+  ]
+}
+```
+
+## Rhythmguard-specific migration rule block
+
+Use this during transition from literals to tokens:
+
+```json
+{
+  "rules": {
+    "rhythmguard/prefer-token": [
+      true,
+      {
+        "allowNumericScale": true,
+        "tokenMapFromCssCustomProperties": true,
+        "tokenMapFromTailwindSpacing": true,
+        "tailwindConfigPath": "./tailwind.config.mjs"
+      }
+    ]
+  }
+}
+```
+
+## Tailwind class-string companion (ESLint)
+
+```js
+// eslint.config.js
+import rhythmguard from 'stylelint-plugin-rhythmguard/eslint';
+
+export default [
+  {
+    plugins: {
+      'rhythmguard-tailwind': rhythmguard,
+    },
+    rules: {
+      'rhythmguard-tailwind/tailwind-class-use-scale': ['error', { scale: [0, 4, 8, 12, 16, 24, 32] }],
+    },
+  },
+];
+```
+

--- a/docs/DEVTO_CONTINUATION_2026-02-21.md
+++ b/docs/DEVTO_CONTINUATION_2026-02-21.md
@@ -1,0 +1,187 @@
+---
+title: From Spacing Rules to Production Guardrails: Rhythmguard 1.4.1 in Real Teams
+published: false
+tags: css, stylelint, designsystems, frontend
+---
+
+If you already read the first Rhythmguard post, this is the practical continuation: how teams are actually adopting it in production codebases without a big-bang rewrite.
+
+Top note for the original article:
+
+> Updated Feb 21, 2026: v1.4.1 hotfixes (regex matcher determinism + generic scale messaging).
+
+## What changed since the first post
+
+- Safer matching behavior for property-scale regex handling (deterministic matching).
+- Cleaner user-facing messaging for scale violations.
+- More practical rollout patterns for existing projects and Tailwind-heavy stacks.
+
+## The adoption pattern that works
+
+Most teams fail adoption by enabling everything at once. The better path is phased:
+
+1. Drop in recommended config immediately.
+2. Run migration mode to stabilize literals and token mapping.
+3. Move to strict governance once tokenization is reliable.
+4. Add Tailwind class-string enforcement in ESLint for template coverage.
+
+## Phase 1: Drop-in for existing projects
+
+Install:
+
+```bash
+npm install --save-dev stylelint-plugin-rhythmguard
+```
+
+Use:
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/recommended"]
+}
+```
+
+This gives immediate spacing-scale guardrails with deterministic autofix.
+
+## Phase 2: Migration mode (literal-to-token transition)
+
+When teams still have lots of raw numeric values, switch to migration config temporarily:
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/migration"]
+}
+```
+
+Then use token-map helpers:
+
+```json
+{
+  "rules": {
+    "rhythmguard/prefer-token": [
+      true,
+      {
+        "allowNumericScale": true,
+        "tokenMapFromCssCustomProperties": true,
+        "tokenMapFromTailwindSpacing": true,
+        "tailwindConfigPath": "./tailwind.config.mjs"
+      }
+    ]
+  }
+}
+```
+
+## Phase 3: Production guardrails
+
+Once violations are stable and token migration is mostly complete:
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/strict"]
+}
+```
+
+If you also enforce logical and defensive CSS:
+
+```json
+{
+  "extends": [
+    "stylelint-plugin-defensive-css/configs/recommended",
+    "stylelint-plugin-logical-css/configs/recommended",
+    "stylelint-plugin-rhythmguard/configs/strict"
+  ]
+}
+```
+
+## Tailwind + ESLint companion setup
+
+Stylelint covers CSS declarations. Tailwind arbitrary values inside class strings need ESLint coverage.
+
+```js
+// eslint.config.js
+import rhythmguard from 'stylelint-plugin-rhythmguard/eslint';
+
+export default [
+  {
+    plugins: {
+      'rhythmguard-tailwind': rhythmguard,
+    },
+    rules: {
+      'rhythmguard-tailwind/tailwind-class-use-scale': ['error', { scale: [0, 4, 8, 12, 16, 24, 32] }],
+    },
+  },
+];
+```
+
+Use Stylelint Tailwind config on the CSS side:
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/tailwind"]
+}
+```
+
+## CI snippet (copy/paste)
+
+```yaml
+name: lint-css-governance
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx stylelint "**/*.{css,scss}" --max-warnings=0
+      - run: npx eslint . --max-warnings=0
+```
+
+## Real before/after lint output
+
+Examples were extracted from public repos:
+
+- `digitaltableteur-nextjs/app/components/Header/Header.module.css`
+- `digitaltableteur/nextjs-app/shared/components/Gallery/Gallery.module.css`
+- `digitaltableteur/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.module.css`
+
+Before:
+
+```text
+../../../../tmp/rhythmguard-real-examples.before.css
+   3:12  ✖  Unexpected off-scale value "14px". Use scale values (nearest: 12px or 16px).             rhythmguard/use-scale
+   8:14  ✖  Unexpected off-scale value "10px". Use scale values (nearest: 8px or 12px).              rhythmguard/use-scale
+  15:10  ✖  Unexpected off-scale value "20px". Use scale values (nearest: 16px or 24px).             rhythmguard/use-scale
+  19:10  ✖  Unexpected off-scale value "20px". Use scale values (nearest: 16px or 24px).             rhythmguard/use-scale
+  26:27  ✖  Unexpected off-scale value "10px". Use scale values (nearest: 8px or 12px).              rhythmguard/use-scale
+  26:27  ✖  Unexpected transform translation value "10px". Use scale values (nearest: 8px or 12px).  rhythmguard/no-offscale-transform
+
+✖ 6 problems (6 errors, 0 warnings)
+  6 errors potentially fixable with the "--fix" option.
+```
+
+After `--fix`:
+
+```text
+No violations.
+```
+
+## Rollout checklist for teams
+
+1. Start with `recommended` in warning mode if your codebase is noisy.
+2. Enable `migration` while token maps are being built.
+3. Track lint deltas per PR.
+4. Move to `strict` and fail CI on regressions.
+5. Pair with ESLint Tailwind companion rules to cover class strings.
+
+## Final note
+
+The biggest win is not “fewer lint errors.” It is predictable, reviewable spacing decisions across teams and repositories.
+

--- a/docs/DEVTO_ORIGINAL_UPDATE_NOTE_2026-02-21.md
+++ b/docs/DEVTO_ORIGINAL_UPDATE_NOTE_2026-02-21.md
@@ -1,0 +1,6 @@
+Use this as the top note in the original Dev.to post.
+
+```md
+> Updated Feb 21, 2026: v1.4.1 hotfixes (regex matcher determinism + generic scale messaging).
+```
+

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -3,9 +3,9 @@
 Submitted PRs to improve discovery where Stylelint users already browse tools:
 
 1. Awesome Stylelint plugin list:
-   - https://github.com/stylelint/awesome-stylelint/pull/110
+   - Primary (open): https://github.com/stylelint/awesome-stylelint/pull/109
+   - Duplicate (closed): https://github.com/stylelint/awesome-stylelint/pull/110
 2. Related plugins cross-link (`stylelint-plugin-defensive-css`):
    - https://github.com/yuschick/stylelint-plugin-defensive-css/pull/152
 3. Related plugins cross-link (`stylelint-plugin-logical-css`):
    - https://github.com/yuschick/stylelint-plugin-logical-css/pull/123
-

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,0 +1,11 @@
+# Distribution Submissions (Feb 21, 2026)
+
+Submitted PRs to improve discovery where Stylelint users already browse tools:
+
+1. Awesome Stylelint plugin list:
+   - https://github.com/stylelint/awesome-stylelint/pull/110
+2. Related plugins cross-link (`stylelint-plugin-defensive-css`):
+   - https://github.com/yuschick/stylelint-plugin-defensive-css/pull/152
+3. Related plugins cross-link (`stylelint-plugin-logical-css`):
+   - https://github.com/yuschick/stylelint-plugin-logical-css/pull/123
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stylelint-plugin-rhythmguard",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint-plugin-rhythmguard",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "known-css-properties": "^0.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-rhythmguard",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Stylelint plugin for spacing scale, token enforcement, and Tailwind class-string governance",
   "keywords": [
     "stylelint",
@@ -68,7 +68,6 @@
     }
   },
   "files": [
-    "assets",
     "scales",
     "schemas",
     "src",


### PR DESCRIPTION
## Summary
- remove non-runtime media assets from published npm files and keep README media working via absolute GitHub URLs
- add a one-command + one-config drop-in path for existing projects
- add comparison and migration recipes (defensive-css vs logical-css vs Rhythmguard)
- add real before/after migration diffs from public codebases
- add Dev.to publication assets (original top-note + full continuation draft)
- document distribution submissions to Stylelint discovery surfaces

## Validation
- npm pack --dry-run (package size reduced from ~2.2 MB to ~27.7 kB)
- npm run lint
- npm test
- npm run test:pack-smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comparison and migration guides, real-world before/after examples, and publication/update notes to help adoption and rollout.

* **New Features**
  * Introduced a simplified "Drop-In" installation path with a single install command and config block.

* **Improvements**
  * Updated media links for reliable rendering and reduced npm package size by excluding non-runtime media.
  * Bumped release to v1.4.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->