### PR TITLE
feat: Tailwind v4 @theme token extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,12 @@ Rhythmguard works well in Tailwind projects, but it enforces what Stylelint can 
 - CSS Modules (for example `*.module.css`)
 - declarations inside `@layer` blocks
 
+### Tailwind v4 @theme tokens
+
+The `tailwind` config preset automatically extracts spacing tokens from Tailwind v4 `@theme` blocks and uses them for `prefer-token` enforcement. Raw values like `padding: 16px` are autofixed to `padding: var(--spacing-4)`.
+
+See [`docs/TAILWIND.md`](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/TAILWIND.md) for full setup.
+
 ### What Rhythmguard does not cover
 
 - Tailwind class strings in templates/JSX/TSX, for example:

--- a/docs/TAILWIND.md
+++ b/docs/TAILWIND.md
@@ -7,6 +7,33 @@ This guide describes the production setup for Rhythmguard in Tailwind-based code
 - Rhythmguard Stylelint rules enforce CSS declaration values that Stylelint can parse.
 - Rhythmguard ESLint companion rules enforce Tailwind class-string arbitrary values in templates.
 
+## Tailwind v4 (@theme support)
+
+Tailwind v4 defines spacing tokens as CSS custom properties inside `@theme` blocks:
+
+```css
+@theme {
+  --spacing-1: 4px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+}
+```
+
+The `tailwind` config preset automatically extracts these as token mappings. No extra config needed:
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/tailwind"]
+}
+```
+
+With this config, `padding: 16px` will be flagged and autofixed to `padding: var(--spacing-4)`.
+
+### Tailwind v3 compatibility
+
+Tailwind v3 projects using `tailwind.config.js` can continue using `tokenMapFromTailwindSpacing` with `tailwindConfigPath`. Both sources can coexist — explicit `tokenMap` and file-based maps always take precedence.
+
 ## Recommended Layered Setup
 
 ### 1) Stylelint layer (CSS declarations)

--- a/src/configs/tailwind.js
+++ b/src/configs/tailwind.js
@@ -5,4 +5,13 @@ module.exports = {
     'stylelint-config-tailwindcss',
     'stylelint-plugin-rhythmguard/configs/strict',
   ],
+  rules: {
+    'rhythmguard/prefer-token': [
+      true,
+      {
+        tokenPattern: '^--spacing-',
+        tokenMapFromCssCustomProperties: true,
+      },
+    ],
+  },
 };

--- a/src/utils/token-map.js
+++ b/src/utils/token-map.js
@@ -324,7 +324,7 @@ function buildEffectiveTokenMap({
   root,
   tokenRegex,
 }) {
-  let tokenMap = mergeExplicitTokenMap({}, options.tokenMap);
+  let tokenMap = {};
 
   if (options.tokenMapFile) {
     tokenMap = mergeTokenMapFromFile({
@@ -349,6 +349,9 @@ function buildEffectiveTokenMap({
       tailwindConfigPath: options.tailwindConfigPath,
     });
   }
+
+  // Explicit tokenMap applied last so it takes precedence over auto-derived tokens
+  tokenMap = mergeExplicitTokenMap(tokenMap, options.tokenMap);
 
   return tokenMap;
 }

--- a/test/prefer-token-token-sources.test.js
+++ b/test/prefer-token-token-sources.test.js
@@ -96,3 +96,90 @@ test('prefer-token can load spacing values from ESM Tailwind config', async () =
 
   assert.equal(result.code, '.stack { gap: theme(spacing.5); }');
 });
+
+test('prefer-token builds token map from @theme block declarations', async () => {
+  const result = await lintCss({
+    code: '@theme { --spacing-4: 16px; --spacing-3: 12px; } .stack { padding: 16px; gap: 12px; }',
+    fix: true,
+    rules: {
+      'rhythmguard/prefer-token': [
+        true,
+        {
+          tokenMapFromCssCustomProperties: true,
+          tokenPattern: '^--spacing-',
+        },
+      ],
+    },
+  });
+
+  assert.equal(
+    result.code,
+    '@theme { --spacing-4: 16px; --spacing-3: 12px; } .stack { padding: var(--spacing-4); gap: var(--spacing-3); }',
+  );
+});
+
+test('prefer-token builds token map from mixed @theme and :root declarations', async () => {
+  const result = await lintCss({
+    code: '@theme { --spacing-4: 16px; } :root { --spacing-2: 8px; } .stack { padding: 16px; margin: 8px; }',
+    fix: true,
+    rules: {
+      'rhythmguard/prefer-token': [
+        true,
+        {
+          tokenMapFromCssCustomProperties: true,
+          tokenPattern: '^--spacing-',
+        },
+      ],
+    },
+  });
+
+  assert.equal(
+    result.code,
+    '@theme { --spacing-4: 16px; } :root { --spacing-2: 8px; } .stack { padding: var(--spacing-4); margin: var(--spacing-2); }',
+  );
+});
+
+test('prefer-token ignores non-spacing @theme variables based on tokenPattern', async () => {
+  const result = await lintCss({
+    code: '@theme { --spacing-4: 16px; --color-primary: #3b82f6; } .stack { padding: 16px; }',
+    fix: true,
+    rules: {
+      'rhythmguard/prefer-token': [
+        true,
+        {
+          tokenMapFromCssCustomProperties: true,
+          tokenPattern: '^--spacing-',
+        },
+      ],
+    },
+  });
+
+  assert.equal(
+    result.code,
+    '@theme { --spacing-4: 16px; --color-primary: #3b82f6; } .stack { padding: var(--spacing-4); }',
+  );
+});
+
+test('explicit tokenMap takes precedence over @theme-derived tokens', async () => {
+  const result = await lintCss({
+    code: '@theme { --spacing-4: 16px; } .stack { padding: 16px; }',
+    fix: true,
+    rules: {
+      'rhythmguard/prefer-token': [
+        true,
+        {
+          tokenMapFromCssCustomProperties: true,
+          tokenPattern: '^--spacing-',
+          tokenMap: {
+            '16px': 'var(--custom-space-4)',
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(
+    result.code,
+    '@theme { --spacing-4: 16px; } .stack { padding: var(--custom-space-4); }',
+  );
+});


### PR DESCRIPTION
## Summary

- `tokenMapFromCssCustomProperties` already walks `@theme` at-rule children via PostCSS `walkDecls` — no core changes needed
- **Tailwind config preset** now enables `tokenMapFromCssCustomProperties` with `tokenPattern: "^--spacing-"` by default
- **Precedence fix**: explicit `tokenMap` now correctly takes priority over auto-derived tokens
- **4 new tests** covering `@theme` extraction, mixed sources, filtering, and precedence

A Tailwind v4 project using `extends: ["stylelint-plugin-rhythmguard/configs/tailwind"]` gets zero-config token governance. `padding: 16px` autofixes to `padding: var(--spacing-4)`.

## Test plan

- [x] 62/62 tests passing
- [x] Lint clean
- [x] @theme block extraction works with autofix
- [x] Mixed @theme + :root sources work
- [x] tokenPattern correctly filters non-spacing variables
- [x] Explicit tokenMap takes precedence over @theme tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tailwind v4 @theme spacing token support with automatic extraction
  * Auto-fixes raw spacing values (e.g., `padding: 16px`) to tokenized equivalents

* **Documentation**
  * Added comprehensive Tailwind v4 @theme integration guide
  * Added Tailwind v3 compatibility documentation for existing configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->