### PR TITLE
test+docs: prove ESLint rule covers cn/clsx/cva/twMerge patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,18 @@ export default [
 
 This rule targets arbitrary spacing utilities such as `p-[13px]`, `gap-[18px]`, `translate-x-[10px]`, and autofixes to the nearest configured scale value.
 
+#### Supported patterns
+
+The rule checks every string literal in your code, so it works automatically with common utility functions:
+
+- `cn("p-[13px]")` / `cn("p-[13px]", condition && "m-[7px]")`
+- `clsx("p-[13px]", "gap-[18px]")`
+- `twMerge("p-[13px]", otherClasses)`
+- `cva("base", { variants: { size: { sm: "p-[5px]" } } })`
+- `<div className={cn("p-[13px]")} />`
+
+No extra config needed — if the string contains an arbitrary spacing value, it gets caught and autofixed.
+
 ### Recommended stack for full Tailwind enforcement
 
 Use both layers:

--- a/test/eslint-utility-functions.test.js
+++ b/test/eslint-utility-functions.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const test = require('node:test');
+const { RuleTester } = require('eslint');
+const rule = require('../src/eslint/rules/tailwind-class-use-scale');
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+});
+
+test('eslint rule detects arbitrary spacing in cn() calls', () => {
+  tester.run('tailwind-class-use-scale', rule, {
+    valid: [],
+    invalid: [
+      {
+        code: 'const cls = cn("p-[13px] flex");',
+        output: 'const cls = cn("p-[12px] flex");',
+        errors: [{ message: /Unexpected Tailwind arbitrary spacing/ }],
+      },
+    ],
+  });
+});
+
+test('eslint rule detects arbitrary spacing in clsx() calls', () => {
+  tester.run('tailwind-class-use-scale', rule, {
+    valid: [],
+    invalid: [
+      {
+        code: 'const cls = clsx("p-[13px]", "m-[7px]");',
+        output: 'const cls = clsx("p-[12px]", "m-[8px]");',
+        errors: [
+          { message: /Unexpected Tailwind arbitrary spacing/ },
+          { message: /Unexpected Tailwind arbitrary spacing/ },
+        ],
+      },
+    ],
+  });
+});
+
+test('eslint rule detects arbitrary spacing in twMerge() calls', () => {
+  tester.run('tailwind-class-use-scale', rule, {
+    valid: [],
+    invalid: [
+      {
+        code: 'const cls = twMerge("p-[13px]", active && "m-[7px]");',
+        output: 'const cls = twMerge("p-[12px]", active && "m-[8px]");',
+        errors: [
+          { message: /Unexpected Tailwind arbitrary spacing/ },
+          { message: /Unexpected Tailwind arbitrary spacing/ },
+        ],
+      },
+    ],
+  });
+});
+
+test('eslint rule detects arbitrary spacing in cva() variant objects', () => {
+  tester.run('tailwind-class-use-scale', rule, {
+    valid: [],
+    invalid: [
+      {
+        code: 'const button = cva("base", { variants: { size: { sm: "p-[5px]" } } });',
+        output: 'const button = cva("base", { variants: { size: { sm: "p-[4px]" } } });',
+        errors: [{ message: /Unexpected Tailwind arbitrary spacing/ }],
+      },
+    ],
+  });
+});
+
+test('eslint rule detects arbitrary spacing in JSX className with cn()', () => {
+  tester.run('tailwind-class-use-scale', rule, {
+    valid: [],
+    invalid: [
+      {
+        code: '<div className={cn("p-[13px]")} />',
+        output: '<div className={cn("p-[12px]")} />',
+        errors: [{ message: /Unexpected Tailwind arbitrary spacing/ }],
+      },
+    ],
+  });
+});


### PR DESCRIPTION
## Summary

- Added `test/eslint-utility-functions.test.js` with 5 tests proving the `tailwind-class-use-scale` ESLint rule already catches arbitrary spacing values inside `cn()`, `clsx()`, `cva()`, and `twMerge()` calls (including JSX className expressions).
- Updated README.md with a new "Supported patterns" subsection under the ESLint companion layer docs, listing all covered utility function patterns.

## Test plan

- [x] `node --test test/eslint-utility-functions.test.js` -- all 5 tests pass
- [x] `node --test test/*.test.js` -- full suite (63 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for the `rhythmguard-tailwind/tailwind-class-use-scale` ESLint rule, documenting support for `cn()`, `clsx()`, `twMerge()`, `cva()`, and JSX className usage with automatic detection and fixing of arbitrary spacing values.

* **Tests**
  * Added test suite validating the rule's detection and auto-fix functionality across all supported patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->