### PR TITLE
feat: W3C DTCG and nested token file format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ Options:
 | `mathFunctionArguments` | `Record<mathFn, number[]>` | `{}` | Restricts linting to specific 1-based argument indexes per math function |
 | `ignoreMathFunctionArguments` | `Record<mathFn, number[]>` | `{}` | Excludes specific 1-based argument indexes per math function |
 | `tokenMap` | `Record<string,string>` | `{}` | Enables autofix from raw value to token |
-| `tokenMapFile` | `string` | `null` | JSON file path to merge additional token mappings |
+| `tokenMapFile` | `string` | `null` | JSON file path to merge additional token mappings (supports flat, Style Dictionary, and W3C DTCG formats) |
 | `tokenMapFromCssCustomProperties` | `boolean` | `false` | Auto-builds mappings from matching custom property declarations in the same stylesheet |
 | `tokenMapFromTailwindSpacing` | `boolean` | `false` | Auto-builds mappings from `theme.spacing` and `theme.extend.spacing` in Tailwind config |
 | `tailwindConfigPath` | `string` | `null` | Path to Tailwind config used by `tokenMapFromTailwindSpacing` (`.js`, `.cjs`, `.mjs`) |
@@ -553,6 +553,35 @@ console.log(rhythmguard.presets.getCommunityScaleMetadata('product-decimal-10'))
 console.log(rhythmguard.presets.scales['rhythmic-4']);
 console.log(Object.keys(rhythmguard.eslint.rules));
 ```
+
+## Token File Formats
+
+The `tokenMapFile` option supports multiple JSON formats:
+
+**Flat token-to-value:**
+
+```json
+{ "--spacing-4": "16px", "--spacing-3": "12px" }
+```
+
+**Style Dictionary:**
+
+```json
+{ "--spacing-4": { "value": "16px" } }
+```
+
+**W3C DTCG (Design Token Community Group):**
+
+```json
+{
+  "spacing": {
+    "4": { "$value": "16px", "$type": "dimension" },
+    "2": { "$value": "8px", "$type": "dimension" }
+  }
+}
+```
+
+Nested DTCG groups are walked recursively. The key path becomes the CSS variable name: `spacing.4` → `var(--spacing-4)`. Non-length values (colors, fonts) are ignored automatically.
 
 ## Autofix Philosophy
 

--- a/src/utils/token-map.js
+++ b/src/utils/token-map.js
@@ -79,6 +79,31 @@ function mergeExplicitTokenMap(target, source) {
   return target;
 }
 
+function walkTokenGroup(map, group, prefix, baseFontSize) {
+  for (const [key, value] of Object.entries(group)) {
+    const tokenName = `${prefix}-${key}`;
+
+    if (!isPlainObject(value)) {
+      continue;
+    }
+
+    // Leaf node with $value (DTCG)
+    if (typeof value.$value === 'string') {
+      addLengthValueMapping(map, value.$value, tokenName, baseFontSize);
+      continue;
+    }
+
+    // Leaf node with value (Style Dictionary)
+    if (typeof value.value === 'string') {
+      addLengthValueMapping(map, value.value, tokenName, baseFontSize);
+      continue;
+    }
+
+    // Nested group — recurse deeper
+    walkTokenGroup(map, value, tokenName, baseFontSize);
+  }
+}
+
 function mergeTokenMapFromFile({
   baseFontSize,
   currentMap,
@@ -130,8 +155,21 @@ function mergeTokenMapFromFile({
       continue;
     }
 
-    if (isPlainObject(entryValue) && typeof entryValue.value === 'string') {
-      addLengthValueMapping(nextMap, entryValue.value, entryKey, baseFontSize);
+    if (isPlainObject(entryValue)) {
+      // Style Dictionary format: { value: "16px" }
+      if (typeof entryValue.value === 'string') {
+        addLengthValueMapping(nextMap, entryValue.value, entryKey, baseFontSize);
+        continue;
+      }
+
+      // W3C DTCG format: { $value: "16px", $type: "dimension" }
+      if (typeof entryValue.$value === 'string') {
+        addLengthValueMapping(nextMap, entryValue.$value, entryKey, baseFontSize);
+        continue;
+      }
+
+      // Nested group — recurse (e.g. { spacing: { 4: { $value: "16px" } } })
+      walkTokenGroup(nextMap, entryValue, entryKey, baseFontSize);
     }
   }
 

--- a/test/prefer-token-token-sources.test.js
+++ b/test/prefer-token-token-sources.test.js
@@ -96,3 +96,97 @@ test('prefer-token can load spacing values from ESM Tailwind config', async () =
 
   assert.equal(result.code, '.stack { gap: theme(spacing.5); }');
 });
+
+test('prefer-token loads DTCG flat format with $value', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-dtcg-flat-'));
+  const tokenMapPath = path.join(tempDir, 'tokens.json');
+  fs.writeFileSync(tokenMapPath, JSON.stringify({
+    '--spacing-4': { $value: '16px', $type: 'dimension' },
+    '--spacing-3': { $value: '12px', $type: 'dimension' },
+  }));
+
+  const result = await lintCss({
+    code: '.stack { padding: 16px; gap: 12px; }',
+    fix: true,
+    rules: {
+      'rhythmguard/prefer-token': [
+        true,
+        { tokenMapFile: tokenMapPath },
+      ],
+    },
+  });
+
+  assert.equal(result.code, '.stack { padding: var(--spacing-4); gap: var(--spacing-3); }');
+});
+
+test('prefer-token loads DTCG nested format with $value', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-dtcg-nested-'));
+  const tokenMapPath = path.join(tempDir, 'tokens.json');
+  fs.writeFileSync(tokenMapPath, JSON.stringify({
+    spacing: {
+      '4': { $value: '16px', $type: 'dimension' },
+      '2': { $value: '8px', $type: 'dimension' },
+    },
+  }));
+
+  const result = await lintCss({
+    code: '.stack { padding: 16px; margin: 8px; }',
+    fix: true,
+    rules: {
+      'rhythmguard/prefer-token': [
+        true,
+        { tokenMapFile: tokenMapPath },
+      ],
+    },
+  });
+
+  assert.equal(result.code, '.stack { padding: var(--spacing-4); margin: var(--spacing-2); }');
+});
+
+test('prefer-token loads deeply nested DTCG format', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-dtcg-deep-'));
+  const tokenMapPath = path.join(tempDir, 'tokens.json');
+  fs.writeFileSync(tokenMapPath, JSON.stringify({
+    primitives: {
+      spacing: {
+        sm: { $value: '8px', $type: 'dimension' },
+        md: { $value: '16px', $type: 'dimension' },
+      },
+    },
+  }));
+
+  const result = await lintCss({
+    code: '.stack { padding: 16px; gap: 8px; }',
+    fix: true,
+    rules: {
+      'rhythmguard/prefer-token': [
+        true,
+        { tokenMapFile: tokenMapPath },
+      ],
+    },
+  });
+
+  assert.equal(result.code, '.stack { padding: var(--primitives-spacing-md); gap: var(--primitives-spacing-sm); }');
+});
+
+test('prefer-token ignores non-dimension DTCG tokens', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-dtcg-filter-'));
+  const tokenMapPath = path.join(tempDir, 'tokens.json');
+  fs.writeFileSync(tokenMapPath, JSON.stringify({
+    '--spacing-4': { $value: '16px', $type: 'dimension' },
+    '--color-primary': { $value: '#3b82f6', $type: 'color' },
+  }));
+
+  const result = await lintCss({
+    code: '.stack { padding: 16px; }',
+    fix: true,
+    rules: {
+      'rhythmguard/prefer-token': [
+        true,
+        { tokenMapFile: tokenMapPath },
+      ],
+    },
+  });
+
+  assert.equal(result.code, '.stack { padding: var(--spacing-4); }');
+});


### PR DESCRIPTION
## Summary

- Support `$value` property (W3C DTCG standard) in token map JSON files
- Recurse into nested token groups — key path becomes CSS variable name (`spacing.4` → `var(--spacing-4)`)
- Style Dictionary `.value` format already worked — no changes needed
- Document all three supported formats in README

## Test plan

- [x] 62/62 tests passing
- [x] Lint clean
- [x] DTCG flat format: `{"--spacing-4": {"$value": "16px"}}` → autofix works
- [x] DTCG nested: `{"spacing": {"4": {"$value": "16px"}}}` → autofix works  
- [x] Deep nesting: `{"primitives": {"spacing": {"md": {"$value": "16px"}}}}` → autofix works
- [x] Non-dimension tokens (colors) correctly ignored
- [x] Existing flat and Style Dictionary formats still work (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multiple token file formats (Flat, Style Dictionary, W3C DTCG) for token mapping, including nested group traversal and token-path-derived CSS variable names.

* **Documentation**
  * Clarified tokenMapFile docs with supported JSON shapes, recursive traversal rules, variable-naming from key paths, and that non-length tokens are ignored.

* **Tests**
  * Added tests covering flat, nested, and deeply nested token maps and filtering of non-dimension tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->