### PR TITLE
feat: react-tailwind config and framework integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,14 +155,27 @@ npm install --save-dev stylelint-plugin-rhythmguard
 
 `migration` keeps on-scale numeric values temporarily while auto-building token mappings from CSS custom properties and optional Tailwind spacing config.
 
+### React / Next.js + Tailwind config
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/react-tailwind"]
+}
+```
+
+`react-tailwind` extends the tailwind config with CSS Modules overrides (spacing + radius enforcement) and ignores Next.js build directories.
+
 Stable shared config entry points:
 
 - `stylelint-plugin-rhythmguard/configs/recommended`
 - `stylelint-plugin-rhythmguard/configs/strict`
 - `stylelint-plugin-rhythmguard/configs/tailwind`
+- `stylelint-plugin-rhythmguard/configs/react-tailwind`
 - `stylelint-plugin-rhythmguard/configs/expanded`
 - `stylelint-plugin-rhythmguard/configs/logical`
 - `stylelint-plugin-rhythmguard/configs/migration`
+
+Framework-specific setup for Vue, Lit, Astro, and SvelteKit: [`docs/FRAMEWORKS.md`](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/FRAMEWORKS.md)
 
 ## Comparison and Migration Recipes
 

--- a/docs/FRAMEWORKS.md
+++ b/docs/FRAMEWORKS.md
@@ -1,0 +1,150 @@
+# Framework Integration Guide
+
+Rhythmguard configs for common frontend frameworks. Use the shipped config for React/Next.js, or copy a snippet for Vue, Lit, or Astro.
+
+## React / Next.js + Tailwind (shipped config)
+
+```bash
+npm install --save-dev stylelint stylelint-plugin-rhythmguard
+```
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/react-tailwind"]
+}
+```
+
+This gives you:
+
+- Tailwind-aware Stylelint configuration
+- Spacing scale and token enforcement on all CSS files
+- Expanded enforcement (spacing + radius) on CSS Modules (`*.module.css`)
+- `.next/` and `out/` build directories ignored
+
+Pair with the ESLint companion for Tailwind class-string governance in JSX/TSX:
+
+```js
+// eslint.config.js
+import rhythmguard from 'stylelint-plugin-rhythmguard/eslint';
+
+export default [
+  {
+    plugins: { 'rhythmguard-tailwind': rhythmguard },
+    rules: {
+      'rhythmguard-tailwind/tailwind-class-use-scale': [
+        'error',
+        { scale: [0, 4, 8, 12, 16, 24, 32] },
+      ],
+    },
+  },
+];
+```
+
+## Vue (config snippet)
+
+Vue Single File Components need `postcss-html` to parse `<style>` blocks.
+
+```bash
+npm install --save-dev stylelint stylelint-plugin-rhythmguard postcss-html
+```
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/strict"],
+  "overrides": [
+    {
+      "files": ["**/*.vue"],
+      "customSyntax": "postcss-html"
+    }
+  ]
+}
+```
+
+Lint command:
+
+```bash
+npx stylelint "src/**/*.{css,vue}"
+```
+
+## Lit (config snippet)
+
+Lit templates use tagged template literals for CSS. Use `postcss-lit` to parse them.
+
+```bash
+npm install --save-dev stylelint stylelint-plugin-rhythmguard postcss-lit
+```
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/strict"],
+  "overrides": [
+    {
+      "files": ["**/*.ts", "**/*.js"],
+      "customSyntax": "postcss-lit"
+    }
+  ]
+}
+```
+
+Lint command:
+
+```bash
+npx stylelint "src/**/*.{css,ts,js}"
+```
+
+## Astro (config snippet)
+
+Astro components embed `<style>` blocks similar to Vue. Use `postcss-html`.
+
+```bash
+npm install --save-dev stylelint stylelint-plugin-rhythmguard postcss-html
+```
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/strict"],
+  "overrides": [
+    {
+      "files": ["**/*.astro"],
+      "customSyntax": "postcss-html"
+    }
+  ]
+}
+```
+
+Lint command:
+
+```bash
+npx stylelint "src/**/*.{css,astro}"
+```
+
+## SvelteKit (config snippet)
+
+Svelte components embed `<style>` blocks. Use `postcss-html`.
+
+```bash
+npm install --save-dev stylelint stylelint-plugin-rhythmguard postcss-html
+```
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/strict"],
+  "overrides": [
+    {
+      "files": ["**/*.svelte"],
+      "customSyntax": "postcss-html"
+    }
+  ],
+  "ignoreFiles": [".svelte-kit/**"]
+}
+```
+
+Lint command:
+
+```bash
+npx stylelint "src/**/*.{css,svelte}"
+```
+
+## Why only React/Next.js gets a shipped config
+
+Vue, Lit, Astro, and Svelte require `customSyntax` packages (`postcss-html`, `postcss-lit`) that most React projects don't need. Shipping them as dependencies would add unnecessary weight for the majority of users. The snippets above are copy-paste ready and stay current as those packages evolve.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
       "require": "./src/configs/migration.js",
       "import": "./src/configs/migration.mjs"
     },
+    "./configs/react-tailwind": {
+      "require": "./src/configs/react-tailwind.js",
+      "import": "./src/configs/react-tailwind.mjs"
+    },
     "./presets": {
       "require": "./src/presets/index.js",
       "import": "./src/presets/index.mjs"

--- a/src/configs/react-tailwind.js
+++ b/src/configs/react-tailwind.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+  extends: [
+    'stylelint-plugin-rhythmguard/configs/tailwind',
+  ],
+  ignoreFiles: [
+    '.next/**',
+    'out/**',
+    'node_modules/**',
+  ],
+  overrides: [
+    {
+      files: ['**/*.module.css'],
+      rules: {
+        'rhythmguard/use-scale': [
+          true,
+          {
+            propertyGroups: ['spacing', 'radius'],
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/src/configs/react-tailwind.mjs
+++ b/src/configs/react-tailwind.mjs
@@ -1,0 +1,4 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const config = require('./react-tailwind.js');
+export default config;


### PR DESCRIPTION
## Summary

- New react-tailwind config: extends tailwind + CSS Modules overrides + Next.js ignores
- New docs/FRAMEWORKS.md: config snippets for Vue, Lit, Astro, SvelteKit
- README updated with new config and link to frameworks guide

## Test plan

- [x] 58/58 tests passing
- [x] Lint clean
- [x] Config loads correctly