### PR TITLE
feat(cli): audit, init, and doctor commands

### DIFF
--- a/docs/superpowers/specs/2026-04-13-phase3-cli-tools-design.md
+++ b/docs/superpowers/specs/2026-04-13-phase3-cli-tools-design.md
@@ -1,0 +1,170 @@
+# Design Spec: Phase 3 CLI Tools — audit, init, doctor
+
+Date: 2026-04-13
+Phase: 3 — Adoption UX
+Status: Approved
+
+## Goal
+
+Add three CLI commands that reduce setup friction and make Rhythmguard easier to adopt and recommend: audit (report scale drift), init (scaffold config), doctor (validate setup).
+
+## Shared Architecture
+
+All three commands live in `src/cli/`. A thin router at `src/cli/index.js` dispatches based on `process.argv[2]`. No external CLI framework — just `process.argv` parsing and `node:readline` for prompts.
+
+Package.json gets a `"bin"` field pointing to the router. All commands are `#!/usr/bin/env node`.
+
+### Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/cli/index.js` | Create | CLI entry point / router |
+| `src/cli/audit.js` | Create | audit command |
+| `src/cli/init.js` | Create | init command |
+| `src/cli/doctor.js` | Create | doctor command |
+| `package.json` | Modify | Add `bin` field, add `src/cli` to `files` |
+| `README.md` | Modify | Document CLI commands |
+
+## 3.1: `npx rhythmguard audit <dir>`
+
+### What it does
+
+Scans a directory, runs Stylelint with Rhythmguard rules in read-only mode, and outputs a summary of scale drift — off-scale value counts, token replacement opportunities, affected files. Teams paste this into PRs to justify adoption.
+
+### Interface
+
+```
+npx rhythmguard audit ./src
+npx rhythmguard audit ./src --json
+```
+
+### Behavior
+
+1. Glob `<dir>/**/*.css` (and `*.module.css`, `*.vue`, `*.astro`, `*.svelte` if present)
+2. Run Stylelint programmatically with `use-scale` (warning severity) and `prefer-token` (warning severity) using the recommended config
+3. Aggregate warnings into:
+   - Total files scanned
+   - Files with issues (count and percentage)
+   - Off-scale value histogram (value × count, sorted by frequency)
+   - Token replacement opportunities (raw value → suggested token × count)
+4. Output human-readable table (default) or JSON (`--json`)
+5. Exit code 0 always (read-only, not a gate)
+
+### Example output
+
+```
+Rhythmguard Audit: ./src
+
+Files scanned:     47
+Files with issues: 12 (25%)
+
+Off-scale values: 34
+  13px  ×8
+  7px   ×6
+  15px  ×5
+  11px  ×4
+  ...
+
+Token opportunities: 18
+  16px → var(--spacing-4)  ×9
+  8px  → var(--spacing-2)  ×5
+  12px → var(--spacing-3)  ×4
+
+Run "npx stylelint --fix" to auto-correct.
+```
+
+## 3.2: `npx rhythmguard init`
+
+### What it does
+
+Detects the project stack and writes a `.stylelintrc.json` with the appropriate Rhythmguard config.
+
+### Interface
+
+```
+npx rhythmguard init
+```
+
+### Behavior
+
+1. Detect stack by checking the filesystem:
+   - Tailwind: `tailwind.config.*` exists OR `@tailwindcss` in `package.json` dependencies
+   - Next.js: `next.config.*` exists
+   - CSS Modules: any `*.module.css` file in `src/`
+   - Existing Stylelint config: `.stylelintrc*` or `stylelint` key in `package.json`
+2. If existing Stylelint config found, warn and ask to overwrite (y/n)
+3. Auto-select profile based on detection:
+   - Next.js + Tailwind → `react-tailwind`
+   - Tailwind (no Next.js) → `tailwind`
+   - Neither → `recommended`
+4. Print detected stack and selected profile, ask to confirm (y/n)
+5. Write `.stylelintrc.json`:
+   ```json
+   {
+     "extends": ["stylelint-plugin-rhythmguard/configs/<profile>"]
+   }
+   ```
+6. Print next steps: "Run `npx stylelint \"src/**/*.css\"` to lint."
+
+### Dependencies
+
+Uses `node:readline` for y/n prompts. No external packages.
+
+## 3.3: `npx rhythmguard doctor`
+
+### What it does
+
+Validates the Rhythmguard setup and reports problems with actionable fix suggestions.
+
+### Interface
+
+```
+npx rhythmguard doctor
+```
+
+### Behavior
+
+Runs these checks in order:
+
+1. **Stylelint installed?** — Check `require.resolve('stylelint')`. Pass/fail.
+2. **Rhythmguard config found?** — Look for `.stylelintrc*`, `stylelint.config.*`, or `stylelint` key in `package.json`. Pass/fail.
+3. **Config references Rhythmguard?** — Read the config and check it extends a Rhythmguard config or uses the plugin. Pass/fail.
+4. **Token pattern valid?** — If `tokenPattern` is set, try `new RegExp(pattern)`. Pass/fail.
+5. **Tailwind config exists?** — If `tailwindConfigPath` is set, check the file exists. Pass/fail/skip.
+6. **Custom syntax installed?** — If `customSyntax` is referenced in overrides, check `require.resolve(pkg)`. Pass/fail/skip.
+
+### Example output
+
+```
+Rhythmguard Doctor
+
+✓ stylelint installed (v16.15.0)
+✓ config found (.stylelintrc.json)
+✓ config references rhythmguard
+✓ token pattern valid (^--spacing-)
+✗ tailwind config not found at ./tailwind.config.js
+  → Update tailwindConfigPath or remove tokenMapFromTailwindSpacing
+- custom syntax check skipped (not configured)
+
+1 issue found.
+```
+
+### Exit codes
+
+- 0: all checks pass
+- 1: one or more checks fail (CI-friendly)
+
+## Out of Scope
+
+- No interactive TUI (no ink, no blessed)
+- No watch mode
+- No autofix in audit (users run `stylelint --fix` themselves)
+- No remote/cloud features
+- No custom config generation beyond preset selection in init
+
+## Success Criteria
+
+- `npx rhythmguard audit ./src` produces useful output on a real project within 5 seconds
+- `npx rhythmguard init` writes a working config in under 30 seconds
+- `npx rhythmguard doctor` catches a missing Tailwind config and suggests the fix
+- All three commands work without any extra dependencies beyond what Rhythmguard already ships

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "stylelint-plugin-rhythmguard",
   "version": "1.4.2",
   "description": "Token governance for CSS and Tailwind — enforce spacing scales, require design tokens, catch arbitrary values",
+  "bin": {
+    "rhythmguard": "./src/cli/index.js"
+  },
   "keywords": [
     "stylelint",
     "stylelint-plugin",

--- a/src/cli/audit.js
+++ b/src/cli/audit.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const args = process.argv.slice(3);
+const jsonMode = args.includes('--json');
+const dir = args.find((a) => !a.startsWith('-'));
+
+if (!dir) {
+  process.stderr.write('Usage: rhythmguard audit <dir> [--json]\n');
+  process.exit(1);
+}
+
+const resolvedDir = path.resolve(dir);
+
+if (!fs.existsSync(resolvedDir)) {
+  process.stderr.write(`Directory not found: ${dir}\n`);
+  process.exit(1);
+}
+
+const GLOB_PATTERN = `${resolvedDir}/**/*.{css,module.css}`;
+
+const pluginPath = path.resolve(__dirname, '..', 'index.js');
+
+async function run() {
+  const { default: stylelint } = await import('stylelint');
+
+  let result;
+  try {
+    result = await stylelint.lint({
+      files: GLOB_PATTERN,
+      config: {
+        plugins: [pluginPath],
+        rules: {
+          'rhythmguard/use-scale': [true, { severity: 'warning' }],
+          'rhythmguard/prefer-token': [
+            true,
+            {
+              tokenMapFromCssCustomProperties: true,
+              severity: 'warning',
+            },
+          ],
+        },
+      },
+    });
+  } catch (err) {
+    process.stderr.write(`Lint error: ${err.message}\n`);
+    process.exit(1);
+  }
+
+  const fileResults = result.results || [];
+  const totalFiles = fileResults.length;
+
+  const offScaleValues = {};
+  const tokenOpportunities = {};
+  let filesWithIssues = 0;
+  let totalWarnings = 0;
+
+  for (const fileResult of fileResults) {
+    const warnings = fileResult.warnings || [];
+    if (warnings.length > 0) {
+      filesWithIssues++;
+    }
+
+    for (const warning of warnings) {
+      totalWarnings++;
+      const text = warning.text || '';
+
+      // Extract off-scale values from use-scale messages
+      // Format: Unexpected off-scale value "13px". Use scale values (nearest: 12px or 16px).
+      const offScaleMatch = text.match(
+        /Unexpected off-scale value "([^"]+)"/,
+      );
+      if (offScaleMatch) {
+        const value = offScaleMatch[1];
+        offScaleValues[value] = (offScaleValues[value] || 0) + 1;
+      }
+
+      // Extract token opportunities from prefer-token messages
+      // Format: Unexpected raw scale value "16px". Use design tokens for scale decisions.
+      const tokenMatch = text.match(
+        /Unexpected raw scale value "([^"]+)"/,
+      );
+      if (tokenMatch) {
+        const value = tokenMatch[1];
+        tokenOpportunities[value] = (tokenOpportunities[value] || 0) + 1;
+      }
+    }
+  }
+
+  const sortedOffScale = Object.entries(offScaleValues)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+
+  const sortedTokenOps = Object.entries(tokenOpportunities)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+
+  if (jsonMode) {
+    const output = {
+      directory: dir,
+      totalFiles,
+      filesWithIssues,
+      totalWarnings,
+      offScaleValues: Object.fromEntries(sortedOffScale),
+      tokenOpportunities: Object.fromEntries(sortedTokenOps),
+    };
+    process.stdout.write(JSON.stringify(output, null, 2) + '\n');
+    return;
+  }
+
+  // Human-readable output
+  const pct = totalFiles > 0
+    ? Math.round((filesWithIssues / totalFiles) * 100)
+    : 0;
+
+  const lines = [
+    '',
+    `Rhythmguard Audit: ${dir}`,
+    '',
+    `Files scanned:     ${totalFiles}`,
+    `Files with issues: ${filesWithIssues} (${pct}%)`,
+    '',
+  ];
+
+  if (sortedOffScale.length > 0) {
+    const offScaleTotal = Object.values(offScaleValues).reduce(
+      (a, b) => a + b,
+      0,
+    );
+    lines.push(`Off-scale values: ${offScaleTotal}`);
+    for (const [value, count] of sortedOffScale) {
+      lines.push(`  ${value.padEnd(10)} ×${count}`);
+    }
+    lines.push('');
+  }
+
+  if (sortedTokenOps.length > 0) {
+    const tokenTotal = Object.values(tokenOpportunities).reduce(
+      (a, b) => a + b,
+      0,
+    );
+    lines.push(`Token opportunities: ${tokenTotal}`);
+    for (const [value, count] of sortedTokenOps) {
+      lines.push(`  ${value.padEnd(10)} ×${count}`);
+    }
+    lines.push('');
+  }
+
+  if (totalWarnings === 0) {
+    lines.push('No issues found. Your spacing is on scale.');
+  } else {
+    lines.push('Run "npx stylelint --fix" to auto-correct.');
+  }
+
+  lines.push('');
+  process.stdout.write(lines.join('\n'));
+}
+
+run();

--- a/src/cli/doctor.js
+++ b/src/cli/doctor.js
@@ -1,0 +1,231 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const cwd = process.cwd();
+let issues = 0;
+
+function pass(msg) {
+  process.stdout.write(`✓ ${msg}\n`);
+}
+
+function fail(msg, fix) {
+  issues++;
+  process.stdout.write(`✗ ${msg}\n`);
+  if (fix) {
+    process.stdout.write(`  → ${fix}\n`);
+  }
+}
+
+function skip(msg) {
+  process.stdout.write(`- ${msg}\n`);
+}
+
+// Check 1: Stylelint installed
+function checkStylelint() {
+  try {
+    const stylelintPkg = require.resolve('stylelint/package.json', {
+      paths: [cwd],
+    });
+    const version = require(stylelintPkg).version;
+    pass(`stylelint installed (v${version})`);
+    return true;
+  } catch {
+    fail(
+      'stylelint not installed',
+      'Run: npm install --save-dev stylelint',
+    );
+    return false;
+  }
+}
+
+// Check 2: Config found
+function findConfig() {
+  const configFiles = [
+    '.stylelintrc',
+    '.stylelintrc.json',
+    '.stylelintrc.js',
+    '.stylelintrc.cjs',
+    '.stylelintrc.mjs',
+    '.stylelintrc.yml',
+    '.stylelintrc.yaml',
+    'stylelint.config.js',
+    'stylelint.config.cjs',
+    'stylelint.config.mjs',
+  ];
+
+  for (const file of configFiles) {
+    const fullPath = path.join(cwd, file);
+    if (fs.existsSync(fullPath)) {
+      pass(`config found (${file})`);
+      return fullPath;
+    }
+  }
+
+  // Check package.json
+  const pkgPath = path.join(cwd, 'package.json');
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      if (pkg.stylelint) {
+        pass('config found (package.json stylelint key)');
+        return pkgPath;
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  fail(
+    'no Stylelint config found',
+    'Run: npx rhythmguard init',
+  );
+  return null;
+}
+
+// Check 3: Config references Rhythmguard
+function checkConfigReferences(configPath) {
+  if (!configPath) {
+    skip('config reference check skipped (no config)');
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(configPath, 'utf8');
+
+    if (content.includes('rhythmguard')) {
+      pass('config references rhythmguard');
+      return content;
+    }
+
+    // Check package.json stylelint key
+    if (configPath.endsWith('package.json')) {
+      const pkg = JSON.parse(content);
+      const stylelintConfig = JSON.stringify(pkg.stylelint || {});
+      if (stylelintConfig.includes('rhythmguard')) {
+        pass('config references rhythmguard');
+        return stylelintConfig;
+      }
+    }
+
+    fail(
+      'config does not reference rhythmguard',
+      'Add: "extends": ["stylelint-plugin-rhythmguard/configs/recommended"]',
+    );
+    return content;
+  } catch {
+    fail(
+      'could not read config file',
+      `Check permissions on ${configPath}`,
+    );
+    return null;
+  }
+}
+
+// Check 4: Token pattern valid
+function checkTokenPattern(configContent) {
+  if (!configContent) {
+    skip('token pattern check skipped (no config content)');
+    return;
+  }
+
+  const patternMatch = configContent.match(
+    /tokenPattern['":\s]+['"]([^'"]+)['"]/,
+  );
+
+  if (!patternMatch) {
+    skip('token pattern check skipped (not configured)');
+    return;
+  }
+
+  try {
+    new RegExp(patternMatch[1]);
+    pass(`token pattern valid (${patternMatch[1]})`);
+  } catch {
+    fail(
+      `token pattern invalid: ${patternMatch[1]}`,
+      'Fix the regex in tokenPattern option',
+    );
+  }
+}
+
+// Check 5: Tailwind config exists
+function checkTailwindConfig(configContent) {
+  if (!configContent) {
+    skip('tailwind config check skipped (no config content)');
+    return;
+  }
+
+  const tailwindPathMatch = configContent.match(
+    /tailwindConfigPath['":\s]+['"]([^'"]+)['"]/,
+  );
+
+  if (!tailwindPathMatch) {
+    skip('tailwind config check skipped (not configured)');
+    return;
+  }
+
+  const tailwindPath = path.resolve(cwd, tailwindPathMatch[1]);
+  if (fs.existsSync(tailwindPath)) {
+    pass(`tailwind config found (${tailwindPathMatch[1]})`);
+  } else {
+    fail(
+      `tailwind config not found at ${tailwindPathMatch[1]}`,
+      'Update tailwindConfigPath or remove tokenMapFromTailwindSpacing',
+    );
+  }
+}
+
+// Check 6: Custom syntax installed
+function checkCustomSyntax(configContent) {
+  if (!configContent) {
+    skip('custom syntax check skipped (no config content)');
+    return;
+  }
+
+  const syntaxMatch = configContent.match(
+    /customSyntax['":\s]+['"]([^'"]+)['"]/,
+  );
+
+  if (!syntaxMatch) {
+    skip('custom syntax check skipped (not configured)');
+    return;
+  }
+
+  const pkg = syntaxMatch[1];
+  try {
+    require.resolve(pkg, { paths: [cwd] });
+    pass(`custom syntax installed (${pkg})`);
+  } catch {
+    fail(
+      `custom syntax package not installed: ${pkg}`,
+      `Run: npm install --save-dev ${pkg}`,
+    );
+  }
+}
+
+function run() {
+  process.stdout.write('\nRhythmguard Doctor\n\n');
+
+  const stylelintOk = checkStylelint();
+  const configPath = findConfig();
+  const configContent = checkConfigReferences(configPath);
+  checkTokenPattern(configContent);
+  checkTailwindConfig(configContent);
+  checkCustomSyntax(configContent);
+
+  process.stdout.write('\n');
+
+  if (issues === 0) {
+    process.stdout.write('All checks passed.\n\n');
+  } else {
+    process.stdout.write(
+      `${issues} issue${issues === 1 ? '' : 's'} found.\n\n`,
+    );
+  }
+
+  process.exit(stylelintOk && issues === 0 ? 0 : 1);
+}
+
+run();

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+'use strict';
+
+const command = process.argv[2];
+
+const HELP = `Usage: rhythmguard <command>
+
+Commands:
+  audit <dir>   Report scale drift and token opportunities
+  init          Scaffold a Rhythmguard config for your project
+  doctor        Validate your Rhythmguard setup
+
+Options:
+  --help        Show this help message
+
+Examples:
+  npx rhythmguard audit ./src
+  npx rhythmguard audit ./src --json
+  npx rhythmguard init
+  npx rhythmguard doctor
+`;
+
+if (!command || command === '--help' || command === '-h') {
+  process.stdout.write(HELP);
+  process.exit(0);
+}
+
+if (command === 'audit') {
+  require('./audit');
+} else if (command === 'init') {
+  require('./init');
+} else if (command === 'doctor') {
+  require('./doctor');
+} else {
+  process.stderr.write(`Unknown command: ${command}\n\n`);
+  process.stdout.write(HELP);
+  process.exit(1);
+}

--- a/src/cli/init.js
+++ b/src/cli/init.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const readline = require('node:readline');
+
+function ask(question) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase());
+    });
+  });
+}
+
+function detect() {
+  const cwd = process.cwd();
+  const pkgPath = path.join(cwd, 'package.json');
+
+  let pkg = {};
+  if (fs.existsSync(pkgPath)) {
+    try {
+      pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    } catch {
+      // ignore
+    }
+  }
+
+  const allDeps = {
+    ...pkg.dependencies,
+    ...pkg.devDependencies,
+  };
+
+  const hasTailwindConfig =
+    fs.existsSync(path.join(cwd, 'tailwind.config.js')) ||
+    fs.existsSync(path.join(cwd, 'tailwind.config.cjs')) ||
+    fs.existsSync(path.join(cwd, 'tailwind.config.mjs')) ||
+    fs.existsSync(path.join(cwd, 'tailwind.config.ts'));
+
+  const hasTailwindDep = Boolean(
+    allDeps.tailwindcss || allDeps['@tailwindcss/postcss'],
+  );
+
+  const hasNextConfig =
+    fs.existsSync(path.join(cwd, 'next.config.js')) ||
+    fs.existsSync(path.join(cwd, 'next.config.mjs')) ||
+    fs.existsSync(path.join(cwd, 'next.config.ts'));
+
+  const hasExistingConfig =
+    fs.existsSync(path.join(cwd, '.stylelintrc')) ||
+    fs.existsSync(path.join(cwd, '.stylelintrc.json')) ||
+    fs.existsSync(path.join(cwd, '.stylelintrc.js')) ||
+    fs.existsSync(path.join(cwd, '.stylelintrc.cjs')) ||
+    fs.existsSync(path.join(cwd, '.stylelintrc.mjs')) ||
+    fs.existsSync(path.join(cwd, '.stylelintrc.yml')) ||
+    fs.existsSync(path.join(cwd, '.stylelintrc.yaml')) ||
+    fs.existsSync(path.join(cwd, 'stylelint.config.js')) ||
+    fs.existsSync(path.join(cwd, 'stylelint.config.cjs')) ||
+    fs.existsSync(path.join(cwd, 'stylelint.config.mjs')) ||
+    Boolean(pkg.stylelint);
+
+  const tailwind = hasTailwindConfig || hasTailwindDep;
+  const nextjs = hasNextConfig;
+
+  return { tailwind, nextjs, hasExistingConfig };
+}
+
+function selectProfile(stack) {
+  if (stack.nextjs && stack.tailwind) {
+    return 'react-tailwind';
+  }
+  if (stack.tailwind) {
+    return 'tailwind';
+  }
+  return 'recommended';
+}
+
+async function run() {
+  process.stdout.write('\nRhythmguard Init\n\n');
+
+  const stack = detect();
+
+  // Report detection
+  const detected = [];
+  if (stack.tailwind) detected.push('Tailwind CSS');
+  if (stack.nextjs) detected.push('Next.js');
+  if (detected.length > 0) {
+    process.stdout.write(`Detected: ${detected.join(', ')}\n`);
+  } else {
+    process.stdout.write('Detected: plain CSS project\n');
+  }
+
+  // Warn about existing config
+  if (stack.hasExistingConfig) {
+    process.stdout.write('\n⚠ Existing Stylelint config found.\n');
+    const answer = await ask('Overwrite? (y/n) ');
+    if (answer !== 'y' && answer !== 'yes') {
+      process.stdout.write('Aborted.\n');
+      process.exit(0);
+    }
+  }
+
+  const profile = selectProfile(stack);
+  process.stdout.write(`\nProfile: ${profile}\n`);
+
+  const answer = await ask('Write .stylelintrc.json? (y/n) ');
+  if (answer !== 'y' && answer !== 'yes') {
+    process.stdout.write('Aborted.\n');
+    process.exit(0);
+  }
+
+  const config = {
+    extends: [`stylelint-plugin-rhythmguard/configs/${profile}`],
+  };
+
+  const configPath = path.join(process.cwd(), '.stylelintrc.json');
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+
+  process.stdout.write(`\n✓ Wrote ${configPath}\n`);
+  process.stdout.write(`\nNext steps:\n`);
+  process.stdout.write(`  npx stylelint "src/**/*.css"\n\n`);
+}
+
+run();


### PR DESCRIPTION
## Summary

Three new CLI commands accessible via `npx rhythmguard`:

- **audit**: Scans a directory and reports off-scale values + token opportunities. Supports `--json` for CI.
- **init**: Detects your stack (Tailwind, Next.js) and writes `.stylelintrc.json` with the right config.
- **doctor**: Validates setup — checks Stylelint install, config, token patterns, Tailwind config paths.

Zero new dependencies. All use Node builtins only.

## Test plan

- [x] 58/58 existing tests pass
- [x] Lint clean
- [x] `npx rhythmguard --help` shows usage
- [x] `npx rhythmguard audit /tmp/test` detects off-scale values and token opportunities
- [x] `npx rhythmguard audit /tmp/test --json` outputs valid JSON
- [x] `npx rhythmguard doctor` reports missing config with fix suggestion
- [x] CLI entry point is executable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `audit` command to scan CSS files for violations with human-readable and JSON output options
  * Added `init` command for automated project detection and Stylelint configuration generation
  * Added `doctor` command to validate Rhythmguard installation and configuration integrity

* **Documentation**
  * Added Phase 3 CLI tools design specification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->