### PR TITLE
[codex] Clarify Tailwind arbitrary value governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,13 +506,13 @@ The `tailwind` config preset automatically extracts spacing tokens from Tailwind
 
 See [`docs/TAILWIND.md`](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/TAILWIND.md) for full setup.
 
-### What Rhythmguard does not cover
+### What the Stylelint layer does not cover
 
 - Tailwind class strings in templates/JSX/TSX, for example:
   - `class="p-4 gap-2"`
   - `class="p-[13px] translate-y-[18px]"`
 
-Those are not Stylelint declaration nodes, so they are outside Stylelint rule scope.
+Those are not Stylelint declaration nodes, so they are outside Stylelint rule scope. Use the ESLint companion rule below for scale-aware class-string enforcement.
 
 ### Companion ESLint layer for class strings
 
@@ -566,7 +566,7 @@ Suggested setup:
 Then pair with:
 
 - `stylelint-plugin-rhythmguard/eslint` for arbitrary spacing class-string scale enforcement.
-- `eslint-plugin-tailwindcss` for broader class-string linting and conventions.
+- `eslint-plugin-tailwindcss` for broader class-string linting and conventions. If your policy is to ban every arbitrary value, enable its `tailwindcss/no-arbitrary-value` rule; use Rhythmguard when you want spacing-specific scale checks and nearest-value fixes.
 - `prettier-plugin-tailwindcss` for deterministic class ordering.
 
 Detailed setup reference: [`docs/TAILWIND.md`](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/TAILWIND.md).

--- a/docs/DEVTO_SHADCN_PLAYGROUND_2026.md
+++ b/docs/DEVTO_SHADCN_PLAYGROUND_2026.md
@@ -53,7 +53,7 @@ $ grep -rE '-\[.*(rem|px)\]' apps/v4 --include="*.css" \
 <div className="pl-2 has-[>button]:ml-[-0.3rem] has-[>kbd]:ml-[-0.15rem]" />
 ```
 
-Stylelint doesn't see these. Prettier doesn't see these. `eslint-plugin-tailwindcss` doesn't see these either — it governs class names, not the numbers inside `[arbitrary]` brackets.
+Stylelint doesn't see these. Prettier doesn't see these. `eslint-plugin-tailwindcss` can be configured to ban arbitrary brackets entirely, but that is a blanket policy. It does not give spacing-specific scale checks and nearest-value fixes for the numbers inside `[arbitrary]` brackets.
 
 Full audit writeup with sources: [gist.github.com/PetriLahdelma/2ad44d6dc2022f48c67f839c6440745c](https://gist.github.com/PetriLahdelma/2ad44d6dc2022f48c67f839c6440745c)
 

--- a/docs/DEVTO_WHY_RHYTHMGUARD_2026.md
+++ b/docs/DEVTO_WHY_RHYTHMGUARD_2026.md
@@ -172,9 +172,9 @@ Framework configs for [React/Next.js, Vue, Lit, Astro, SvelteKit](https://github
 
 **Prettier** orders your classes. It doesn't know if `p-[13px]` is on your scale.
 
-**eslint-plugin-tailwindcss** checks class name conventions. It doesn't enforce *which values* are allowed in arbitrary brackets.
+**eslint-plugin-tailwindcss** checks class name conventions and can reject arbitrary brackets entirely with `tailwindcss/no-arbitrary-value`. That is useful for teams that want a blanket ban, but it does not answer the scale-governance question: is `p-[13px]` off your allowed spacing rhythm, and what should it become?
 
-**Rhythmguard** is the only tool that governs the actual spacing values — in CSS declarations AND in Tailwind class strings.
+**Rhythmguard** gives you scale-aware spacing governance — in CSS declarations AND in Tailwind class strings.
 
 ## Get started
 

--- a/docs/TAILWIND.md
+++ b/docs/TAILWIND.md
@@ -70,7 +70,7 @@ export default [
 
 Then layer on:
 
-- `eslint-plugin-tailwindcss` for broader class-string governance and conventions.
+- `eslint-plugin-tailwindcss` for broader class-string governance and conventions. Its `tailwindcss/no-arbitrary-value` rule is useful when a project wants to reject all arbitrary values; Rhythmguard's companion rule is narrower and checks arbitrary spacing values against your configured scale.
 
 Use Prettier for deterministic ordering:
 

--- a/src/eslint/rules/tailwind-class-use-scale.js
+++ b/src/eslint/rules/tailwind-class-use-scale.js
@@ -48,8 +48,63 @@ function findClassSegments(value) {
   return segments;
 }
 
+function findLastVariantSeparator(token) {
+  let bracketDepth = 0;
+  let separatorIndex = -1;
+
+  for (let index = 0; index < token.length; index++) {
+    const character = token[index];
+
+    if (character === '[') {
+      bracketDepth++;
+      continue;
+    }
+
+    if (character === ']' && bracketDepth > 0) {
+      bracketDepth--;
+      continue;
+    }
+
+    if (character === ':' && bracketDepth === 0) {
+      separatorIndex = index;
+    }
+  }
+
+  return separatorIndex;
+}
+
+function parseClassToken(token) {
+  const separatorIndex = findLastVariantSeparator(token);
+  const prefix = separatorIndex === -1
+    ? ''
+    : token.slice(0, separatorIndex + 1);
+  let candidate = separatorIndex === -1
+    ? token
+    : token.slice(separatorIndex + 1);
+  let leadingImportant = '';
+  let trailingImportant = '';
+
+  if (candidate.startsWith('!')) {
+    leadingImportant = '!';
+    candidate = candidate.slice(1);
+  }
+
+  if (candidate.endsWith('!')) {
+    trailingImportant = '!';
+    candidate = candidate.slice(0, -1);
+  }
+
+  return {
+    candidate,
+    leadingImportant,
+    prefix,
+    trailingImportant,
+  };
+}
+
 function analyzeToken(token, options, scalePx) {
-  const match = token.match(ARBITRARY_SPACING_CLASS);
+  const parsedToken = parseClassToken(token);
+  const match = parsedToken.candidate.match(ARBITRARY_SPACING_CLASS);
   if (!match || !match.groups) {
     return null;
   }
@@ -96,7 +151,8 @@ function analyzeToken(token, options, scalePx) {
     : replacementValuePx / options.baseFontSize;
 
   const replacementValue = formatLength(replacementNumber, parsedLength.unit);
-  const fixedToken = token.replace(match.groups.rawValue, replacementValue);
+  const fixedCandidate = parsedToken.candidate.replace(match.groups.rawValue, replacementValue);
+  const fixedToken = `${parsedToken.prefix}${parsedToken.leadingImportant}${fixedCandidate}${parsedToken.trailingImportant}`;
 
   return {
     fixedToken,
@@ -128,12 +184,35 @@ function maybeCheckNodeText(node, sourceCode, context, options, scalePx, allowFi
   if (segments.length === 0) {
     return;
   }
+
+  const findings = [];
+  let fixedValue = value;
+  let fixedValueOffset = 0;
+
   for (const segment of segments) {
     const analysis = analyzeToken(segment.token, options, scalePx);
     if (!analysis) {
       continue;
     }
 
+    findings.push({ analysis, segment });
+
+    if (allowFix && analysis.reason !== 'negative' && node.type === 'Literal') {
+      const replacementStart = segment.start + fixedValueOffset;
+      fixedValue = `${fixedValue.slice(0, replacementStart)}${analysis.fixedToken}${fixedValue.slice(replacementStart + segment.token.length)}`;
+      fixedValueOffset += analysis.fixedToken.length - segment.token.length;
+    }
+  }
+
+  if (findings.length === 0) {
+    return;
+  }
+
+  const fixedText = allowFix && node.type === 'Literal' && fixedValue !== value
+    ? `${quote}${fixedValue.replace(new RegExp(quote, 'g'), `\\${quote}`)}${quote}`
+    : null;
+
+  for (const { analysis, segment } of findings) {
     const lower = analysis.nearest
       ? formatLength(analysis.nearest.lower, 'px')
       : 'n/a';
@@ -147,12 +226,8 @@ function maybeCheckNodeText(node, sourceCode, context, options, scalePx, allowFi
           : `Unexpected Tailwind arbitrary spacing value "${segment.token}". Use scale values (nearest: ${lower} or ${upper}).`,
       node,
       fix:
-        allowFix && analysis.reason !== 'negative' && node.type === 'Literal'
-          ? (fixer) => {
-            const nextValue = `${value.slice(0, segment.start)}${analysis.fixedToken}${value.slice(segment.start + segment.token.length)}`;
-            const escaped = nextValue.replace(new RegExp(quote, 'g'), `\\${quote}`);
-            return fixer.replaceText(node, `${quote}${escaped}${quote}`);
-          }
+        fixedText && analysis.reason !== 'negative'
+          ? (fixer) => fixer.replaceText(node, fixedText)
           : null,
     });
   }

--- a/test/eslint-utility-functions.test.js
+++ b/test/eslint-utility-functions.test.js
@@ -82,3 +82,38 @@ test('eslint rule detects arbitrary spacing in JSX className with cn()', () => {
     ],
   });
 });
+
+test('eslint rule detects arbitrary spacing after Tailwind variants and important modifiers', () => {
+  tester.run('tailwind-class-use-scale', rule, {
+    valid: [],
+    invalid: [
+      {
+        code: 'const cls = "md:p-[13px] hover:!gap-[18px] lg:p-[13px]!";',
+        output: 'const cls = "md:p-[12px] hover:!gap-[16px] lg:p-[12px]!";',
+        errors: [
+          { message: /Unexpected Tailwind arbitrary spacing/ },
+          { message: /Unexpected Tailwind arbitrary spacing/ },
+          { message: /Unexpected Tailwind arbitrary spacing/ },
+        ],
+      },
+    ],
+  });
+});
+
+test('eslint rule ignores arbitrary variants while checking their spacing utilities', () => {
+  tester.run('tailwind-class-use-scale', rule, {
+    valid: [
+      'const cls = "data-[state=open]:pb-8 aria-[sort=ascending]:text-sm";',
+    ],
+    invalid: [
+      {
+        code: 'const cls = "has-[>button]:ml-[-0.3rem] data-[state=open]:pb-8 [&:nth-child(3)]:mt-[13px]";',
+        output: 'const cls = "has-[>button]:ml-[-0.25rem] data-[state=open]:pb-8 [&:nth-child(3)]:mt-[12px]";',
+        errors: [
+          { message: /Unexpected Tailwind arbitrary spacing/ },
+          { message: /Unexpected Tailwind arbitrary spacing/ },
+        ],
+      },
+    ],
+  });
+});


### PR DESCRIPTION
## Summary

- Clarifies that Stylelint covers CSS declarations while the Rhythmguard ESLint companion covers Tailwind class strings.
- Documents eslint-plugin-tailwindcss/no-arbitrary-value as a blanket-ban option rather than scale-aware spacing governance.
- Extends the ESLint Tailwind rule to handle variant prefixes, arbitrary variants, and important modifiers while preserving nearest-scale autofixes.

## Validation

- npm run lint
- npm test
- npm run scales:validate

## Target

Repository has no production branch; this PR targets main as the production branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance on ESLint and Stylelint plugins for Tailwind enforcement.
  * Explained how Rhythmguard complements existing tools for spacing-scale validation.

* **Bug Fixes**
  * Improved handling of Tailwind variant prefixes and important modifiers in arbitrary value detection and fixes.

* **Tests**
  * Added test coverage for arbitrary spacing validation with variants and important markers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PetriLahdelma/stylelint-plugin-rhythmguard/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->