### PR TITLE
[codex] Normalize npm bin metadata for 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.6.0",
   "description": "Token governance for CSS and Tailwind — enforce spacing scales, require design tokens, catch arbitrary values",
   "bin": {
-    "rhythmguard": "./src/cli/index.js"
+    "rhythmguard": "src/cli/index.js"
   },
   "keywords": [
     "stylelint",


### PR DESCRIPTION
## Summary

- Normalizes the `bin.rhythmguard` path to the package metadata npm publishes.
- Prevents the `1.6.0` npm artifact from diverging from `main` after npm auto-correction.

## Validation

- `npm pack --dry-run`

## Release

This PR is required before publishing `stylelint-plugin-rhythmguard@1.6.0`.