### PR TITLE
[codex] Align repository URL for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/petrilahdelma/stylelint-plugin-rhythmguard.git"
+    "url": "https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard"
   },
   "homepage": "https://github.com/petrilahdelma/stylelint-plugin-rhythmguard#readme",
   "bugs": {


### PR DESCRIPTION
## Summary

- Updates `package.json` repository URL to match the GitHub source URL used in npm provenance validation.
- Unblocks `stylelint-plugin-rhythmguard@1.6.0` publish via the release workflow.

## Validation

- `npm pack --dry-run`
- `git diff --check`