### PR TITLE
[codex] Prevent audit scans from walking unbounded trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-05-23
+
+### Fixed
+
+- Added `rhythmguard audit --ignore` for pruning root-relative paths before scanning large repositories.
+- Scoped audit traversal to scan-relevant CSS and template files instead of collecting every file under the audit root first.
+- Added default audit skips for common generated directories such as `.svelte-kit`, `.turbo`, and `.vercel`.
+
 ## [1.6.0] - 2026-05-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ Use the audit CLI to create a design-system drift report before turning rules in
 npx rhythmguard audit ./src
 npx rhythmguard audit ./src --format markdown
 npx rhythmguard audit ./src --json
+npx rhythmguard audit . --ignore "apps/legacy/**" --ignore "vendor/**"
 ```
 
-The report covers authored CSS declarations and Tailwind arbitrary spacing values in common template/source files. Markdown output is PR-ready for UX developers, UX designers, and design-system owners:
+The report covers authored CSS declarations and Tailwind arbitrary spacing values in common template/source files. Scan paths are scoped to the directory argument, and `--ignore` accepts repeatable, root-relative glob patterns for large generated or legacy subtrees. Markdown output is PR-ready for UX developers, UX designers, and design-system owners:
 
 ```md
 # Rhythmguard Design-System Audit

--- a/docs/AUDIT_2_VALIDATION.md
+++ b/docs/AUDIT_2_VALIDATION.md
@@ -31,6 +31,7 @@ Audit 2.0 serves both groups by scanning:
 npx rhythmguard audit ./src
 npx rhythmguard audit ./src --format markdown
 npx rhythmguard audit ./src --json
+npx rhythmguard audit . --ignore "apps/legacy/**"
 ```
 
 The report includes:
@@ -44,6 +45,7 @@ The report includes:
 - Top affected files.
 - JSON findings for downstream tooling.
 - Markdown output for pull requests and design-system reviews.
+- Root-relative `--ignore` globs for pruning generated, vendor, or legacy paths before scanning.
 
 ## Follow-Up Roadmap
 
@@ -60,4 +62,3 @@ The report includes:
    - `--min-cleanliness`
    - `--fail-on-new-drift`
 5. Add Figma-friendly export after the code-side contract stabilizes.
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stylelint-plugin-rhythmguard",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint-plugin-rhythmguard",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "known-css-properties": "^0.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-rhythmguard",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Token governance for CSS and Tailwind — enforce spacing scales, require design tokens, catch arbitrary values",
   "bin": {
     "rhythmguard": "src/cli/index.js"

--- a/src/cli/audit.js
+++ b/src/cli/audit.js
@@ -17,6 +17,9 @@ const SKIP_DIRS = new Set([
   '.next',
   '.nuxt',
   '.omx',
+  '.svelte-kit',
+  '.turbo',
+  '.vercel',
   'build',
   'coverage',
   'dist',
@@ -41,6 +44,7 @@ Options:
   --format <text|json|markdown>  Output format (default: text)
   --json                         Alias for --format json
   --markdown                     Alias for --format markdown
+  --ignore <pattern>             Exclude root-relative path/glob (repeatable, comma-separated)
   --scale <values>               Comma-separated scale values (default: 0,4,8,12,16,24,32)
   --base-font-size <number>      px base for rem/em conversion (default: 16)
 `;
@@ -50,6 +54,7 @@ function parseArgs(argv) {
     baseFontSize: DEFAULT_BASE_FONT_SIZE,
     dir: null,
     format: 'text',
+    ignorePatterns: [],
     scale: DEFAULT_SCALE,
   };
 
@@ -68,6 +73,16 @@ function parseArgs(argv) {
 
     if (arg === '--markdown') {
       parsed.format = 'markdown';
+      continue;
+    }
+
+    if (arg === '--ignore') {
+      parsed.ignorePatterns.push(...parseIgnorePatterns(argv[++index]));
+      continue;
+    }
+
+    if (arg.startsWith('--ignore=')) {
+      parsed.ignorePatterns.push(...parseIgnorePatterns(arg.slice('--ignore='.length)));
       continue;
     }
 
@@ -116,6 +131,31 @@ function parseArgs(argv) {
   return parsed;
 }
 
+function parseIgnorePatterns(raw) {
+  if (!raw) {
+    throw new Error('Missing value for --ignore.');
+  }
+
+  const patterns = String(raw).split(',')
+    .map((pattern) => normalizeIgnorePattern(pattern))
+    .filter(Boolean);
+
+  if (patterns.length === 0) {
+    throw new Error('--ignore must include at least one pattern.');
+  }
+
+  return patterns;
+}
+
+function normalizeIgnorePattern(pattern) {
+  return String(pattern)
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/^\.\//, '')
+    .replace(/\/+$/, '');
+}
+
 function parseScale(raw) {
   if (!raw) {
     throw new Error('Missing value for --scale.');
@@ -157,29 +197,125 @@ function assertDirectory(dir) {
     process.exit(1);
   }
 
+  if (!fs.statSync(resolvedDir).isDirectory()) {
+    process.stderr.write(`Not a directory: ${dir}\n`);
+    process.exit(1);
+  }
+
   return resolvedDir;
 }
 
-function walkFiles(rootDir) {
-  const files = [];
+function walkFiles(rootDir, ignorePatterns = []) {
+  const cssFiles = [];
+  const templateFiles = [];
+  const ignoreMatchers = createIgnoreMatchers(ignorePatterns);
 
   function walk(currentDir) {
     for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+      const fullPath = path.join(currentDir, entry.name);
+      const relativePath = toPosixRelativePath(rootDir, fullPath);
+
+      if (shouldIgnorePath(relativePath, entry, ignoreMatchers)) {
+        continue;
+      }
+
       if (entry.isDirectory()) {
-        if (!SKIP_DIRS.has(entry.name)) {
-          walk(path.join(currentDir, entry.name));
-        }
+        walk(fullPath);
         continue;
       }
 
       if (entry.isFile()) {
-        files.push(path.join(currentDir, entry.name));
+        if (isCssFile(fullPath)) {
+          cssFiles.push(fullPath);
+        } else if (isTemplateFile(fullPath)) {
+          templateFiles.push(fullPath);
+        }
       }
     }
   }
 
   walk(rootDir);
-  return files;
+  return { cssFiles, templateFiles };
+}
+
+function shouldIgnorePath(relativePath, entry, ignoreMatchers) {
+  return ignoreMatchers.some((matcher) => matcher.test(relativePath))
+    || (entry.isDirectory() && SKIP_DIRS.has(entry.name));
+}
+
+function createIgnoreMatchers(patterns) {
+  const variants = new Set();
+
+  for (const pattern of patterns) {
+    addIgnorePatternVariants(variants, pattern);
+  }
+
+  return Array.from(variants, (pattern) => globToRegExp(pattern));
+}
+
+function addIgnorePatternVariants(variants, pattern) {
+  if (!pattern) {
+    return;
+  }
+
+  variants.add(pattern);
+
+  if (!pattern.includes('/')) {
+    variants.add(`${pattern}/**`);
+    variants.add(`**/${pattern}`);
+    variants.add(`**/${pattern}/**`);
+    return;
+  }
+
+  if (pattern.endsWith('/**')) {
+    variants.add(pattern.slice(0, -3));
+    return;
+  }
+
+  if (!hasGlob(pattern)) {
+    variants.add(`${pattern}/**`);
+  }
+}
+
+function hasGlob(pattern) {
+  return /[*?]/.test(pattern);
+}
+
+function globToRegExp(pattern) {
+  let source = '^';
+
+  for (let index = 0; index < pattern.length; index++) {
+    const char = pattern[index];
+    const nextChar = pattern[index + 1];
+
+    if (char === '*' && nextChar === '*') {
+      source += '.*';
+      index++;
+      continue;
+    }
+
+    if (char === '*') {
+      source += '[^/]*';
+      continue;
+    }
+
+    if (char === '?') {
+      source += '[^/]';
+      continue;
+    }
+
+    source += escapeRegExp(char);
+  }
+
+  return new RegExp(`${source}$`);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+}
+
+function toPosixRelativePath(rootDir, filePath) {
+  return path.relative(rootDir, filePath).split(path.sep).join('/');
 }
 
 function isCssFile(filePath) {
@@ -605,9 +741,7 @@ async function run() {
   }
 
   const resolvedDir = assertDirectory(parsed.dir);
-  const allFiles = walkFiles(resolvedDir);
-  const cssFiles = allFiles.filter(isCssFile);
-  const templateFiles = allFiles.filter(isTemplateFile);
+  const { cssFiles, templateFiles } = walkFiles(resolvedDir, parsed.ignorePatterns);
   const options = {
     baseFontSize: parsed.baseFontSize,
     scale: parsed.scale,

--- a/test/audit-cli.test.js
+++ b/test/audit-cli.test.js
@@ -77,3 +77,50 @@ test('audit CLI markdown emits a PR-ready design-system report', () => {
   assert.match(result.stdout, /`md:p-\[13px\]`/);
   assert.match(result.stdout, /`md:p-\[12px\]`/);
 });
+
+test('audit CLI ignores root-relative paths before scanning', () => {
+  const fixtureDir = createAuditFixture();
+  const ignoredDir = path.join(fixtureDir, 'src', 'legacy');
+  fs.mkdirSync(ignoredDir);
+  fs.writeFileSync(
+    path.join(ignoredDir, 'ignored.css'),
+    '.legacy { padding: 13px; gap: 16px; }\n',
+  );
+  fs.writeFileSync(
+    path.join(ignoredDir, 'Ignored.tsx'),
+    'export const ignored = <div className="p-[13px]" />;\n',
+  );
+  const vendorDir = path.join(fixtureDir, 'src', 'vendor');
+  fs.mkdirSync(vendorDir);
+  fs.writeFileSync(
+    path.join(vendorDir, 'vendor.css'),
+    '.vendor { padding: 13px; }\n',
+  );
+
+  const result = runAudit(fixtureDir, '--format', 'json', '--ignore', 'legacy/**,vendor');
+
+  assert.equal(result.status, 0, result.stderr);
+
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.cssFilesScanned, 1);
+  assert.equal(report.templateFilesScanned, 1);
+  assert.equal(report.findings.css.some(({ file }) => file.includes('legacy/')), false);
+  assert.equal(report.findings.css.some(({ file }) => file.includes('vendor/')), false);
+  assert.equal(report.findings.tailwind.some(({ file }) => file.includes('legacy/')), false);
+});
+
+test('audit CLI scopes traversal to the requested directory', () => {
+  const fixtureDir = createAuditFixture();
+  fs.writeFileSync(
+    path.join(fixtureDir, 'outside.css'),
+    '.outside { padding: 13px; gap: 16px; }\n',
+  );
+
+  const result = runAudit(fixtureDir, '--format', 'json');
+
+  assert.equal(result.status, 0, result.stderr);
+
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.cssFilesScanned, 1);
+  assert.equal(report.findings.css.some(({ file }) => file.endsWith('outside.css')), false);
+});


### PR DESCRIPTION
## Summary

- what changed: add `rhythmguard audit --ignore`, prune ignored/generated directories before descent, filter scan candidates during traversal, and bump the package to `1.6.1`
- why it changed: large repositories could make the audit command stall because it walked every file under the audit root before filtering

## Release

- Patch release: `1.6.1`
- npm dry run passed with provenance enabled
- `1.6.1` is not currently published on npm

## Checklist

- [x] `npm run lint`
- [x] `npm test`
- [ ] `npm run scales:validate` (not needed; community scales unchanged)
- [x] README/docs updated where needed
- [x] CHANGELOG updated for user-facing behavior changes
