### PR TITLE
Add opt-in motion rhythm governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-05-23
+
+### Added
+
+- Added opt-in `rhythmguard/use-motion-scale` for duration/delay scale enforcement and raw easing reporting.
+- Added `stylelint-plugin-rhythmguard/configs/motion`.
+- Added ESLint companion rule `rhythmguard-tailwind/tailwind-class-use-motion-scale` for Tailwind `duration-[...]`, `delay-[...]`, and `ease-[...]` arbitrary values.
+- Added `rhythmguard audit --include-motion` and `.rhythmguardrc.json` `includeMotion` support.
+
 ## [1.8.0] - 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This gives you spacing governance in both CSS files and JSX/TSX templates.
 | `rhythmguard/use-scale` | Enforces spacing values must be on your configured scale | Yes, nearest safe value |
 | `rhythmguard/prefer-token` | Enforces token usage over raw spacing literals | Yes, with `tokenMap` |
 | `rhythmguard/no-offscale-transform` | Enforces scale-aligned `translate*` motion offsets | Yes, nearest safe value |
+| `rhythmguard/use-motion-scale` | Enforces opt-in duration/delay rhythm and flags raw easing curves | Yes, for duration/delay values |
 
 ## Demo
 
@@ -95,6 +96,7 @@ npx rhythmguard audit ./src --since-baseline --fail-on-new-drift
 npx rhythmguard audit ./src --staged --max-findings 0
 npx rhythmguard audit ./src --token-source ./tokens.json
 npx rhythmguard audit ./src --token-source ./theme.css --token-source-format css
+npx rhythmguard audit ./src --include-motion
 ```
 
 The report covers authored CSS declarations, Tailwind arbitrary spacing values in common template/source files, and token-contract drift such as missing spacing tokens, unused spacing tokens, repeated raw values that deserve token review, raw values that match known tokens, and conflicting token values. Scan paths are scoped to the directory argument. Use `--ignore`, `.rhythmguardignore`, or `--ignore-path` for generated or legacy subtrees, then add baselines and CI thresholds when you are ready to gate new drift. Markdown output is PR-ready for UX developers, UX designers, and design-system owners:
@@ -125,6 +127,7 @@ For large codebases, put shared audit settings in `.rhythmguardrc.json`:
       { "path": "./src/theme.css", "format": "css" }
     ],
     "tokenKind": "spacing",
+    "includeMotion": false,
     "tokenCandidateMinCount": 2,
     "minCleanliness": 90
   }
@@ -221,6 +224,16 @@ npm install --save-dev stylelint-plugin-rhythmguard
 
 `react-tailwind` extends the tailwind config with CSS Modules overrides (spacing + radius enforcement) and ignores Next.js build directories.
 
+### Motion config
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/motion"]
+}
+```
+
+`motion` enables opt-in duration/delay rhythm checks with `rhythmguard/use-motion-scale`.
+
 Stable shared config entry points:
 
 - `stylelint-plugin-rhythmguard/configs/recommended`
@@ -230,6 +243,7 @@ Stable shared config entry points:
 - `stylelint-plugin-rhythmguard/configs/expanded`
 - `stylelint-plugin-rhythmguard/configs/logical`
 - `stylelint-plugin-rhythmguard/configs/migration`
+- `stylelint-plugin-rhythmguard/configs/motion`
 
 Framework-specific setup for Vue, Lit, Astro, and SvelteKit: [`docs/FRAMEWORKS.md`](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/FRAMEWORKS.md)
 
@@ -471,7 +485,7 @@ Options:
 | `enforceInsideMathFunctions` | `boolean` | `false` | Lints `calc()/clamp()/min()/max()` internals |
 | `mathFunctionArguments` | `Record<mathFn, number[]>` | `{}` | Restricts linting to specific 1-based argument indexes per math function |
 | `ignoreMathFunctionArguments` | `Record<mathFn, number[]>` | `{}` | Excludes specific 1-based argument indexes per math function |
-| `propertyGroups` | `Array<'spacing' \| 'radius' \| 'typography' \| 'size'>` | `['spacing']` | Selects built-in property groups when `properties` is not provided |
+| `propertyGroups` | `Array<'spacing' \| 'radius' \| 'typography' \| 'size' \| 'motion'>` | `['spacing']` | Selects built-in property groups when `properties` is not provided |
 | `properties` | `Array<string|RegExp>` | built-in spacing patterns | Override targeted property set; string values may be supported property names or regex-like strings (`/pattern/flags`) |
 | `propertyScales` | `Record<propertyOrRegex, scaleOrPreset>` | `{}` | Per-property scale overrides (supports exact names or `/regex/flags` keys; stateful `g`/`y` flags are normalized for deterministic matching) |
 
@@ -542,6 +556,35 @@ Example:
 Options:
 
 `rhythmguard/no-offscale-transform` accepts the same scale options as `rhythmguard/use-scale` (including `unitStrategy`, math argument targeting, and deterministic autofix), but only for transform translation properties. Its secondary options are also validated for unknown keys and invalid value shapes.
+
+### `rhythmguard/use-motion-scale`
+
+Opt-in guardrail for duration, delay, and easing rhythm.
+
+Example:
+
+```css
+/* ❌ Off-scale timing + raw easing */
+.button {
+  transition: opacity 175ms cubic-bezier(.2, 0, 0, 1);
+}
+
+/* ✅ Timing on motion scale */
+.button {
+  transition: opacity 150ms var(--ease-snappy);
+}
+```
+
+Options:
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `durationScale` | `number[]` | `[0,75,100,150,200,300,500,700,1000]` | Allowed duration and delay values in milliseconds |
+| `durationUnits` | `Array<'ms' \| 's'>` | `['ms','s']` | Time units considered by the rule |
+| `fixToScale` | `boolean` | `true` | Autofixes simple duration/delay values to the nearest scale value |
+| `easingTokenMap` | `Record<string,string>` | `{}` | Optional exact replacements for raw easing functions |
+
+Tailwind class strings can use the ESLint companion rule `rhythmguard-tailwind/tailwind-class-use-motion-scale` for `duration-[...]`, `delay-[...]`, and `ease-[...]` arbitrary values.
 
 ## Tailwind CSS Integration
 

--- a/docs/AUDIT_2_VALIDATION.md
+++ b/docs/AUDIT_2_VALIDATION.md
@@ -37,6 +37,7 @@ npx rhythmguard audit ./src --since-baseline --fail-on-new-drift
 npx rhythmguard audit ./src --since origin/main --max-findings 0
 npx rhythmguard audit ./src --token-source ./tokens.json
 npx rhythmguard audit ./src --config ./configs/rhythmguard.json
+npx rhythmguard audit ./src --include-motion
 ```
 
 The report includes:
@@ -57,10 +58,11 @@ The report includes:
 - Token contract reporting for missing, unused, and candidate spacing tokens.
 - External token-source contract checks for canonical tokens that live outside the scanned source tree.
 - `.rhythmguardrc.json` audit config for reusable ignores, thresholds, token sources, and token-kind selection.
+- Opt-in motion rhythm reporting for CSS duration/delay drift, raw easing curves, and Tailwind arbitrary motion utilities.
 - CI gates with `--max-findings`, `--min-cleanliness`, and `--fail-on-new-drift`.
 
 ## Follow-Up Roadmap
 
 1. Add HTML report output for design reviews.
 2. Add Figma-friendly export after the code-side contract stabilizes.
-3. Add opt-in motion rhythm reporting for duration, delay, and easing drift.
+3. Stabilize the audit JSON contract and add HTML output for design reviews.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stylelint-plugin-rhythmguard",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint-plugin-rhythmguard",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "known-css-properties": "^0.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-rhythmguard",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Token governance for CSS and Tailwind — enforce spacing scales, require design tokens, catch arbitrary values",
   "bin": {
     "rhythmguard": "src/cli/index.js"
@@ -49,6 +49,10 @@
       "require": "./src/configs/migration.js",
       "import": "./src/configs/migration.mjs"
     },
+    "./configs/motion": {
+      "require": "./src/configs/motion.js",
+      "import": "./src/configs/motion.mjs"
+    },
     "./configs/react-tailwind": {
       "require": "./src/configs/react-tailwind.js",
       "import": "./src/configs/react-tailwind.mjs"
@@ -68,6 +72,10 @@
     "./rules/no-offscale-transform": {
       "require": "./src/rules/no-offscale-transform/index.js",
       "import": "./src/rules/no-offscale-transform/index.mjs"
+    },
+    "./rules/use-motion-scale": {
+      "require": "./src/rules/use-motion-scale/index.js",
+      "import": "./src/rules/use-motion-scale/index.mjs"
     },
     "./eslint": {
       "require": "./src/eslint/index.js",

--- a/src/cli/audit.js
+++ b/src/cli/audit.js
@@ -6,6 +6,8 @@ const path = require('node:path');
 
 const { formatLength } = require('../utils/length');
 const { createTailwindClassAnalyzer } = require('../utils/tailwind-class-analysis');
+const { createTailwindMotionAnalyzer } = require('../utils/tailwind-motion-analysis');
+const { formatTime } = require('../utils/time');
 const {
   addDefinition,
   createTokenKindMatcher,
@@ -69,9 +71,10 @@ Options:
   --min-cleanliness <percent>    Exit 1 when scale cleanliness is lower than this percent
   --since <git-ref>              Scan only changed files since a git ref
   --staged                       Scan only staged files
+  --include-motion               Include opt-in motion duration/easing drift
   --token-source <file>          External token source (repeatable, comma-separated)
   --token-source-format <format> Token source format: auto, css, flat-json, style-dictionary, dtcg (default: auto)
-  --token-kind <kind>            Token kind: spacing, radius, typography, size, all (default: spacing)
+  --token-kind <kind>            Token kind: spacing, radius, typography, size, motion, all (default: spacing)
   --token-candidate-min-count <n> Minimum repeated raw value count for token candidates (default: 2)
   --scale <values>               Comma-separated scale values (default: 0,4,8,12,16,24,32)
   --base-font-size <number>      px base for rem/em conversion (default: 16)
@@ -89,6 +92,7 @@ function parseArgs(argv) {
     format: 'text',
     ignorePath: DEFAULT_IGNORE_PATH,
     ignorePatterns: [],
+    includeMotion: false,
     maxFindings: null,
     minCleanliness: null,
     noConfig: false,
@@ -258,6 +262,12 @@ function parseArgs(argv) {
     if (arg === '--staged') {
       parsed.staged = true;
       parsed.cliOptions.add('staged');
+      continue;
+    }
+
+    if (arg === '--include-motion') {
+      parsed.includeMotion = true;
+      parsed.cliOptions.add('includeMotion');
       continue;
     }
 
@@ -572,6 +582,7 @@ function applyAuditConfig(parsed, configResult) {
   applyConfigScalar(next, audit, cliOptions, 'tokenCandidateMinCount', 'tokenCandidateMinCount', parsePositiveInteger);
   applyConfigScalar(next, audit, cliOptions, 'tokenKind', 'tokenKind', normalizeTokenKind);
   applyConfigScalar(next, audit, cliOptions, 'baseFontSize', 'baseFontSize', parseBaseFontSize);
+  applyConfigScalar(next, audit, cliOptions, 'includeMotion', 'includeMotion', parseBooleanOption);
   applyConfigScalar(next, audit, cliOptions, 'scale', 'scale', (value) => {
     if (Array.isArray(value)) {
       return value;
@@ -589,6 +600,14 @@ function applyConfigScalar(target, audit, cliOptions, targetKey, configKey, pars
   }
 
   target[targetKey] = parser(audit[configKey], configKey);
+}
+
+function parseBooleanOption(value, optionName) {
+  if (typeof value !== 'boolean') {
+    throw new Error(`${optionName} must be a boolean.`);
+  }
+
+  return value;
 }
 
 function normalizeCliTokenSources(sources, format) {
@@ -866,31 +885,41 @@ async function runStylelintAudit(cssFiles, options) {
   }
 
   const { default: stylelint } = await import('stylelint');
+  const rules = {
+    'rhythmguard/use-scale': [
+      true,
+      {
+        baseFontSize: options.baseFontSize,
+        scale: options.scale,
+        severity: 'warning',
+      },
+    ],
+    'rhythmguard/prefer-token': [
+      true,
+      {
+        baseFontSize: options.baseFontSize,
+        scale: options.scale,
+        severity: 'warning',
+        tokenMapFromCssCustomProperties: true,
+        tokenPattern: '^--spac(e|ing)-',
+      },
+    ],
+  };
+
+  if (options.includeMotion) {
+    rules['rhythmguard/use-motion-scale'] = [
+      true,
+      {
+        severity: 'warning',
+      },
+    ];
+  }
 
   const result = await stylelint.lint({
     files: cssFiles,
     config: {
       plugins: [pluginPath],
-      rules: {
-        'rhythmguard/use-scale': [
-          true,
-          {
-            baseFontSize: options.baseFontSize,
-            scale: options.scale,
-            severity: 'warning',
-          },
-        ],
-        'rhythmguard/prefer-token': [
-          true,
-          {
-            baseFontSize: options.baseFontSize,
-            scale: options.scale,
-            severity: 'warning',
-            tokenMapFromCssCustomProperties: true,
-            tokenPattern: '^--spac(e|ing)-',
-          },
-        ],
-      },
+      rules,
     },
   });
 
@@ -909,6 +938,12 @@ function collectCssFindings(fileResults) {
       const tokenMatch = text.match(
         /Unexpected raw scale value "([^"]+)"/,
       );
+      const motionDurationMatch = text.match(
+        /Unexpected (?:motion duration|negative motion duration) "([^"]+)"/,
+      );
+      const motionEasingMatch = text.match(
+        /Unexpected raw motion easing "([^"]+)"/,
+      );
 
       findings.push({
         column: warning.column || 1,
@@ -916,13 +951,59 @@ function collectCssFindings(fileResults) {
         line: warning.line || 1,
         rule: warning.rule || 'rhythmguard',
         text,
-        type: tokenMatch ? 'token-opportunity' : 'off-scale',
-        value: tokenMatch ? tokenMatch[1] : offScaleMatch ? offScaleMatch[1] : null,
+        type: getCssFindingType({ motionDurationMatch, motionEasingMatch, tokenMatch }),
+        value: getCssFindingValue({
+          motionDurationMatch,
+          motionEasingMatch,
+          offScaleMatch,
+          tokenMatch,
+        }),
       });
     }
   }
 
   return findings;
+}
+
+function getCssFindingValue({
+  motionDurationMatch,
+  motionEasingMatch,
+  offScaleMatch,
+  tokenMatch,
+}) {
+  if (tokenMatch) {
+    return tokenMatch[1];
+  }
+
+  if (offScaleMatch) {
+    return offScaleMatch[1];
+  }
+
+  if (motionDurationMatch) {
+    return motionDurationMatch[1];
+  }
+
+  if (motionEasingMatch) {
+    return motionEasingMatch[1];
+  }
+
+  return null;
+}
+
+function getCssFindingType({ motionDurationMatch, motionEasingMatch, tokenMatch }) {
+  if (motionDurationMatch) {
+    return 'motion-duration';
+  }
+
+  if (motionEasingMatch) {
+    return 'motion-easing';
+  }
+
+  if (tokenMatch) {
+    return 'token-opportunity';
+  }
+
+  return 'off-scale';
 }
 
 function collectTailwindFindings(templateFiles, options) {
@@ -967,6 +1048,66 @@ function collectTailwindFindings(templateFiles, options) {
   }
 
   return findings;
+}
+
+function collectTailwindMotionFindings(templateFiles, options) {
+  if (!options.includeMotion) {
+    return [];
+  }
+
+  const analyzer = createTailwindMotionAnalyzer(options);
+  const findings = [];
+
+  for (const filePath of templateFiles) {
+    let source = '';
+    try {
+      source = fs.readFileSync(filePath, 'utf8');
+    } catch {
+      continue;
+    }
+
+    const lineStarts = getLineStarts(source);
+
+    for (const literal of findStringLiterals(source)) {
+      for (const { analysis, segment } of analyzer.analyzeClassString(literal.value)) {
+        const position = offsetToLineColumn(lineStarts, literal.valueStart + segment.start);
+        findings.push({
+          column: position.column,
+          file: formatPath(filePath),
+          fixedToken: analysis.fixedToken,
+          line: position.line,
+          nearest: analysis.nearest
+            ? {
+              lower: formatTime(analysis.nearest.lower, 'ms'),
+              upper: formatTime(analysis.nearest.upper, 'ms'),
+            }
+            : null,
+          rawValue: analysis.rawValue,
+          rule: 'rhythmguard-tailwind/tailwind-class-use-motion-scale',
+          text: buildTailwindMotionFindingText(segment.token, analysis),
+          token: segment.token,
+          type: analysis.reason === 'easing'
+            ? 'tailwind-motion-easing'
+            : 'tailwind-motion-duration',
+          utility: analysis.utility,
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+function buildTailwindMotionFindingText(token, analysis) {
+  if (analysis.reason === 'easing') {
+    return `Unexpected Tailwind arbitrary motion easing "${token}". Use motion tokens for easing decisions.`;
+  }
+
+  if (analysis.reason === 'negative') {
+    return `Unexpected Tailwind arbitrary motion duration "${token}". Use non-negative duration values.`;
+  }
+
+  return `Unexpected Tailwind arbitrary motion duration "${token}". Use duration scale values.`;
 }
 
 function findStringLiterals(source) {
@@ -1250,6 +1391,8 @@ function buildReport({
   cssFindings,
   dir,
   externalTokenDefinitions,
+  includeMotion,
+  motionFindings,
   scanScope,
   templateFiles,
   tailwindFindings,
@@ -1266,17 +1409,21 @@ function buildReport({
     .map((finding) => finding.value));
   const tailwindArbitraryValues = countByValue(tailwindFindings
     .map((finding) => finding.rawValue));
+  const motionValues = countByValue(motionFindings
+    .map((finding) => finding.value || finding.rawValue));
   const issueFiles = new Set([
     ...cssFindings.map((finding) => finding.file),
+    ...motionFindings.map((finding) => finding.file),
     ...tailwindFindings.map((finding) => finding.file),
   ]);
   const topAffectedFiles = sortCountMap(countByValue([
     ...cssFindings.map((finding) => finding.file),
+    ...motionFindings.map((finding) => finding.file),
     ...tailwindFindings.map((finding) => finding.file),
   ])).slice(0, 10);
 
   const totalFiles = cssFiles.length + templateFiles.length;
-  const totalWarnings = cssFindings.length + tailwindFindings.length;
+  const totalWarnings = cssFindings.length + motionFindings.length + tailwindFindings.length;
   const filesWithIssues = issueFiles.size;
   const scaleCleanliness = totalFiles > 0
     ? Math.max(0, Math.round(((totalFiles - filesWithIssues) / totalFiles) * 100))
@@ -1299,9 +1446,15 @@ function buildReport({
     filesWithIssues,
     findings: {
       css: cssFindings,
+      motion: motionFindings,
       tailwind: tailwindFindings,
     },
-    formatVersion: 4,
+    formatVersion: 5,
+    motion: {
+      enabled: includeMotion,
+      findings: motionFindings.length,
+      values: Object.fromEntries(sortCountMap(motionValues).slice(0, 10)),
+    },
     offScaleValues: Object.fromEntries(sortCountMap(offScaleValues).slice(0, 10)),
     scaleCleanliness,
     scanScope,
@@ -1313,6 +1466,7 @@ function buildReport({
     summary: {
       cssWarnings: cssFindings.length,
       filesWithIssues,
+      motionFindings: motionFindings.length,
       rawValueMatches: tokenContract.summary.rawValueMatches,
       missingTokens: tokenContract.summary.missingTokens,
       rawValueCandidates: tokenContract.summary.rawValueCandidates,
@@ -1405,6 +1559,7 @@ function writeBaseline(report, baselinePath) {
 function getAllFindings(report) {
   return [
     ...report.findings.css,
+    ...report.findings.motion,
     ...report.findings.tailwind,
   ];
 }
@@ -1470,6 +1625,7 @@ function renderText(report) {
   appendHistogram(lines, 'CSS OFF-SCALE VALUES', report.offScaleValues);
   appendHistogram(lines, 'CSS TOKEN OPPORTUNITIES', report.tokenOpportunities);
   appendHistogram(lines, 'TAILWIND CLASS-STRING DRIFT', report.tailwindArbitraryValues);
+  appendHistogram(lines, 'MOTION RHYTHM DRIFT', report.motion.values);
   appendTokenContractText(lines, report.tokenContract);
   appendBaselineText(lines, report);
 
@@ -1622,6 +1778,7 @@ function renderMarkdown(report) {
   appendMarkdownCounts(lines, 'CSS Off-Scale Values', report.offScaleValues);
   appendMarkdownCounts(lines, 'CSS Token Opportunities', report.tokenOpportunities);
   appendMarkdownCounts(lines, 'Tailwind Class-String Drift', report.tailwindArbitraryValues);
+  appendMarkdownCounts(lines, 'Motion Rhythm Drift', report.motion.values);
   appendTokenContractMarkdown(lines, report.tokenContract);
   appendBaselineMarkdown(lines, report);
 
@@ -1872,6 +2029,7 @@ async function run() {
   const { cssFiles, scanScope, templateFiles } = scanFiles;
   const options = {
     baseFontSize: parsed.baseFontSize,
+    includeMotion: parsed.includeMotion,
     scale: parsed.scale,
   };
 
@@ -1888,14 +2046,22 @@ async function run() {
     sources: parsed.tokenSources,
     tokenKind: parsed.tokenKind,
   });
+  const stylelintFindings = collectCssFindings(cssResults);
+  const cssFindings = stylelintFindings.filter((finding) => !finding.type.startsWith('motion-'));
+  const motionFindings = [
+    ...stylelintFindings.filter((finding) => finding.type.startsWith('motion-')),
+    ...collectTailwindMotionFindings(templateFiles, options),
+  ];
 
   const report = buildReport({
     baseFontSize: parsed.baseFontSize,
     config: parsed.config,
     cssFiles,
-    cssFindings: collectCssFindings(cssResults),
+    cssFindings,
     dir: parsed.dir,
     externalTokenDefinitions: tokenSourceResult.definitions,
+    includeMotion: parsed.includeMotion,
+    motionFindings,
     scanScope,
     tailwindFindings: collectTailwindFindings(templateFiles, options),
     templateFiles,

--- a/src/configs/motion.js
+++ b/src/configs/motion.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  plugins: ['stylelint-plugin-rhythmguard'],
+  rules: {
+    'rhythmguard/use-motion-scale': [
+      true,
+      {
+        durationScale: [0, 75, 100, 150, 200, 300, 500, 700, 1000],
+      },
+    ],
+  },
+};

--- a/src/configs/motion.mjs
+++ b/src/configs/motion.mjs
@@ -1,0 +1,4 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const config = require('./motion.js');
+export default config;

--- a/src/eslint/index.js
+++ b/src/eslint/index.js
@@ -1,15 +1,18 @@
 'use strict';
 
 const tailwindClassUseScale = require('./rules/tailwind-class-use-scale');
+const tailwindClassUseMotionScale = require('./rules/tailwind-class-use-motion-scale');
 
 module.exports = {
   rules: {
     'tailwind-class-use-scale': tailwindClassUseScale,
+    'tailwind-class-use-motion-scale': tailwindClassUseMotionScale,
   },
   configs: {
     recommended: {
       rules: {
         'rhythmguard-tailwind/tailwind-class-use-scale': 'warn',
+        'rhythmguard-tailwind/tailwind-class-use-motion-scale': 'off',
       },
     },
   },

--- a/src/eslint/rules/tailwind-class-use-motion-scale.js
+++ b/src/eslint/rules/tailwind-class-use-motion-scale.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const { formatTime } = require('../../utils/time');
+const { createTailwindMotionAnalyzer } = require('../../utils/tailwind-motion-analysis');
+
+const RULE_NAME = 'tailwind-class-use-motion-scale';
+
+function maybeCheckNodeText(node, sourceCode, context, analyzer, allowFix) {
+  const rawText = sourceCode.getText(node);
+  let value = null;
+  let quote = null;
+
+  if (node.type === 'Literal' && typeof node.value === 'string') {
+    value = node.value;
+    quote = rawText[0] === '"' || rawText[0] === "'" ? rawText[0] : '"';
+  }
+
+  if (node.type === 'TemplateElement') {
+    value = node.value.raw;
+  }
+
+  if (!value || typeof value !== 'string') {
+    return;
+  }
+
+  const findings = analyzer.analyzeClassString(value);
+  if (findings.length === 0) {
+    return;
+  }
+
+  let fixedValue = value;
+  let fixedValueOffset = 0;
+
+  for (const { analysis, segment } of findings) {
+    if (allowFix && analysis.reason === 'duration' && node.type === 'Literal') {
+      const replacementStart = segment.start + fixedValueOffset;
+      fixedValue = `${fixedValue.slice(0, replacementStart)}${analysis.fixedToken}${fixedValue.slice(replacementStart + segment.token.length)}`;
+      fixedValueOffset += analysis.fixedToken.length - segment.token.length;
+    }
+  }
+
+  const fixedText = allowFix && node.type === 'Literal' && fixedValue !== value
+    ? `${quote}${fixedValue.replace(new RegExp(quote, 'g'), `\\${quote}`)}${quote}`
+    : null;
+
+  for (const { analysis, segment } of findings) {
+    const lower = analysis.nearest
+      ? formatTime(analysis.nearest.lower, 'ms')
+      : 'n/a';
+    const upper = analysis.nearest
+      ? formatTime(analysis.nearest.upper, 'ms')
+      : 'n/a';
+    context.report({
+      message: buildMessage(analysis, segment, lower, upper),
+      node,
+      fix:
+        fixedText && analysis.reason === 'duration'
+          ? (fixer) => fixer.replaceText(node, fixedText)
+          : null,
+    });
+  }
+}
+
+function buildMessage(analysis, segment, lower, upper) {
+  if (analysis.reason === 'easing') {
+    return `Unexpected Tailwind arbitrary motion easing "${segment.token}". Use motion tokens for easing decisions.`;
+  }
+
+  if (analysis.reason === 'negative') {
+    return `Unexpected Tailwind arbitrary motion duration "${segment.token}". Use non-negative duration values.`;
+  }
+
+  return `Unexpected Tailwind arbitrary motion duration "${segment.token}". Use duration scale values (nearest: ${lower} or ${upper}).`;
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Enforce duration scale for Tailwind arbitrary motion utilities in class strings',
+    },
+    fixable: 'code',
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          durationScale: {
+            items: { type: 'number' },
+            type: 'array',
+          },
+          durationUnits: {
+            items: {
+              enum: ['ms', 's'],
+              type: 'string',
+            },
+            type: 'array',
+          },
+        },
+        type: 'object',
+      },
+    ],
+  },
+  create(context) {
+    const analyzer = createTailwindMotionAnalyzer(context.options && context.options[0]);
+    const sourceCode = context.sourceCode || context.getSourceCode();
+
+    return {
+      Literal(node) {
+        maybeCheckNodeText(node, sourceCode, context, analyzer, true);
+      },
+      TemplateElement(node) {
+        maybeCheckNodeText(node, sourceCode, context, analyzer, false);
+      },
+    };
+  },
+  ruleName: RULE_NAME,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,16 @@
 const useScale = require('./rules/use-scale');
 const preferToken = require('./rules/prefer-token');
 const noOffscaleTransform = require('./rules/no-offscale-transform');
+const useMotionScale = require('./rules/use-motion-scale');
 
-const rules = [useScale, preferToken, noOffscaleTransform];
+const rules = [useScale, preferToken, noOffscaleTransform, useMotionScale];
 
 module.exports = rules;
 module.exports.rules = {
   [useScale.ruleName]: useScale,
   [preferToken.ruleName]: preferToken,
   [noOffscaleTransform.ruleName]: noOffscaleTransform,
+  [useMotionScale.ruleName]: useMotionScale,
 };
 module.exports.configs = {
   recommended: require('./configs/recommended'),
@@ -19,6 +21,7 @@ module.exports.configs = {
   expanded: require('./configs/expanded'),
   logical: require('./configs/logical'),
   migration: require('./configs/migration'),
+  motion: require('./configs/motion'),
 };
 module.exports.eslint = require('./eslint');
 module.exports.presets = require('./presets');

--- a/src/rules/use-motion-scale/index.js
+++ b/src/rules/use-motion-scale/index.js
@@ -1,0 +1,245 @@
+'use strict';
+
+const stylelint = require('stylelint');
+const valueParser = require('postcss-value-parser');
+const {
+  nearestScaleValues,
+  numbersEqual,
+} = require('../../utils/length');
+const {
+  declarationValueIndex,
+  walkRootValueNodes,
+} = require('../../utils/value-utils');
+const {
+  formatTime,
+  fromMs,
+  normalizeDurationScale,
+  normalizeDurationUnits,
+  parseTimeToken,
+  toMs,
+} = require('../../utils/time');
+
+const ruleName = 'rhythmguard/use-motion-scale';
+const DURATION_PROPERTIES = new Set([
+  'transition-duration',
+  'transition-delay',
+  'animation-duration',
+  'animation-delay',
+  'transition',
+  'animation',
+]);
+const EASING_PROPERTIES = new Set([
+  'transition-timing-function',
+  'animation-timing-function',
+  'transition',
+  'animation',
+]);
+const EASING_FUNCTIONS = new Set(['cubic-bezier', 'linear', 'steps']);
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  invalidDuration: (value) =>
+    `Unexpected negative motion duration "${value}". Use non-negative duration values.`,
+  rejectedDuration: (value, lower, upper) =>
+    `Unexpected motion duration "${value}". Use duration scale values (nearest: ${lower} or ${upper}).`,
+  rejectedEasing: (value) =>
+    `Unexpected raw motion easing "${value}". Use motion tokens for easing decisions.`,
+});
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function buildOptions(rawOptions) {
+  const options = rawOptions || {};
+
+  return {
+    durationScale: normalizeDurationScale(options.durationScale),
+    durationUnits: normalizeDurationUnits(options.durationUnits),
+    easingTokenMap: isPlainObject(options.easingTokenMap) ? options.easingTokenMap : {},
+    fixToScale: options.fixToScale !== false,
+  };
+}
+
+function validateSecondaryOptions(result, secondaryOptions) {
+  return stylelint.utils.validateOptions(result, ruleName, {
+    actual: secondaryOptions,
+    optional: true,
+    possible: {
+      durationScale: [(value) =>
+        typeof value === 'number' &&
+        Number.isFinite(value) &&
+        value >= 0],
+      durationUnits: [(value) => value === 'ms' || value === 's'],
+      easingTokenMap: [(value) =>
+        isPlainObject(value) &&
+        Object.values(value).every((entry) =>
+          typeof entry === 'string' && entry.trim().length > 0,
+        )],
+      fixToScale: [true, false],
+    },
+  });
+}
+
+function getFixedNodeValue(parsedTime, nearestMs, options) {
+  if (!options.durationUnits.includes(parsedTime.unit)) {
+    return null;
+  }
+
+  const converted = fromMs(nearestMs, parsedTime.unit);
+  if (converted === null) {
+    return null;
+  }
+
+  return formatTime(converted, parsedTime.unit);
+}
+
+function functionToString(node) {
+  return valueParser.stringify(node);
+}
+
+const ruleFunction = (primary, secondaryOptions) => {
+  return (root, result) => {
+    const valid = stylelint.utils.validateOptions(result, ruleName, {
+      actual: primary,
+      possible: [true],
+    });
+
+    if (!valid || !validateSecondaryOptions(result, secondaryOptions)) {
+      return;
+    }
+
+    const options = buildOptions(secondaryOptions);
+
+    root.walkDecls((decl) => {
+      const prop = decl.prop.toLowerCase();
+      if (!DURATION_PROPERTIES.has(prop) && !EASING_PROPERTIES.has(prop)) {
+        return;
+      }
+
+      const parsed = valueParser(decl.value);
+      let changed = false;
+
+      const reportDuration = (node, nearest, fixedValue = null) => {
+        const index = declarationValueIndex(decl) + node.sourceIndex;
+        const payload = {
+          endIndex: index + node.value.length,
+          index,
+          message: nearest
+            ? messages.rejectedDuration(
+              node.value,
+              formatTime(nearest.lower, 'ms'),
+              formatTime(nearest.upper, 'ms'),
+            )
+            : messages.invalidDuration(node.value),
+          node: decl,
+          result,
+          ruleName,
+        };
+
+        if (fixedValue) {
+          payload.fix = () => {
+            node.value = fixedValue;
+            return true;
+          };
+        }
+
+        stylelint.utils.report(payload);
+      };
+
+      const reportEasing = (node, replacement = null) => {
+        const source = functionToString(node);
+        const index = declarationValueIndex(decl) + node.sourceIndex;
+        const payload = {
+          endIndex: index + source.length,
+          index,
+          message: messages.rejectedEasing(source),
+          node: decl,
+          result,
+          ruleName,
+        };
+
+        if (replacement) {
+          payload.fix = () => {
+            node.type = 'word';
+            node.value = replacement;
+            delete node.nodes;
+            return true;
+          };
+        }
+
+        stylelint.utils.report(payload);
+      };
+
+      walkRootValueNodes(parsed, (node) => {
+        if (node.type === 'function') {
+          const functionName = node.value.toLowerCase();
+          if (!EASING_PROPERTIES.has(prop) || !EASING_FUNCTIONS.has(functionName)) {
+            return false;
+          }
+
+          const source = functionToString(node);
+          reportEasing(node, options.easingTokenMap[source] || null);
+          changed = changed || Boolean(options.easingTokenMap[source]);
+          return true;
+        }
+
+        if (node.type !== 'word' || !DURATION_PROPERTIES.has(prop)) {
+          return false;
+        }
+
+        const parsedTime = parseTimeToken(node.value);
+        if (!parsedTime) {
+          return false;
+        }
+
+        if (parsedTime.number < 0) {
+          reportDuration(node, null);
+          return false;
+        }
+
+        if (!options.durationUnits.includes(parsedTime.unit)) {
+          return false;
+        }
+
+        const msValue = toMs(parsedTime.number, parsedTime.unit);
+        if (msValue === null) {
+          return false;
+        }
+
+        const isOnScale = options.durationScale.some((scaleValue) => numbersEqual(scaleValue, msValue));
+        if (isOnScale) {
+          return false;
+        }
+
+        const nearest = nearestScaleValues(msValue, options.durationScale);
+        if (!nearest) {
+          return false;
+        }
+
+        const fixedValue = options.fixToScale
+          ? getFixedNodeValue(parsedTime, nearest.nearest, options)
+          : null;
+
+        reportDuration(node, nearest, fixedValue);
+        changed = changed || Boolean(fixedValue);
+        return false;
+      });
+
+      if (changed) {
+        decl.value = parsed.toString();
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = {
+  fixable: true,
+  url: 'https://github.com/petrilahdelma/stylelint-plugin-rhythmguard#rhythmguarduse-motion-scale',
+};
+
+module.exports = stylelint.createPlugin(ruleName, ruleFunction);
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;
+module.exports.meta = ruleFunction.meta;

--- a/src/rules/use-motion-scale/index.mjs
+++ b/src/rules/use-motion-scale/index.mjs
@@ -1,0 +1,7 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const rule = require('./index.js');
+export default rule;
+export const ruleName = rule.ruleName;
+export const messages = rule.messages;
+export const meta = rule.meta;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -35,6 +35,10 @@ const PROPERTY_GROUP_PATTERNS = Object.freeze({
     /^letter-spacing$/,
     /^word-spacing$/,
   ]),
+  motion: Object.freeze([
+    /^transition(?:-.+)?$/,
+    /^animation(?:-.+)?$/,
+  ]),
 });
 
 const DEFAULT_PROPERTY_GROUPS = Object.freeze(['spacing']);

--- a/src/utils/tailwind-motion-analysis.js
+++ b/src/utils/tailwind-motion-analysis.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const {
+  nearestScaleValues,
+  numbersEqual,
+} = require('./length');
+const {
+  formatTime,
+  fromMs,
+  normalizeDurationScale,
+  normalizeDurationUnits,
+  parseTimeToken,
+  toMs,
+} = require('./time');
+const { findClassSegments } = require('./tailwind-class-analysis');
+
+const ARBITRARY_MOTION_CLASS = /^(?<utility>duration|delay|ease)-\[(?<rawValue>[^\]]+)\]$/;
+
+function normalizeTailwindMotionOptions(option = {}) {
+  return {
+    durationScale: normalizeDurationScale(option.durationScale),
+    durationUnits: normalizeDurationUnits(option.durationUnits),
+  };
+}
+
+function findLastVariantSeparator(token) {
+  let bracketDepth = 0;
+  let separatorIndex = -1;
+
+  for (let index = 0; index < token.length; index++) {
+    const character = token[index];
+
+    if (character === '[') {
+      bracketDepth++;
+      continue;
+    }
+
+    if (character === ']' && bracketDepth > 0) {
+      bracketDepth--;
+      continue;
+    }
+
+    if (character === ':' && bracketDepth === 0) {
+      separatorIndex = index;
+    }
+  }
+
+  return separatorIndex;
+}
+
+function parseClassToken(token) {
+  const separatorIndex = findLastVariantSeparator(token);
+  const prefix = separatorIndex === -1
+    ? ''
+    : token.slice(0, separatorIndex + 1);
+  let candidate = separatorIndex === -1
+    ? token
+    : token.slice(separatorIndex + 1);
+  let leadingImportant = '';
+  let trailingImportant = '';
+
+  if (candidate.startsWith('!')) {
+    leadingImportant = '!';
+    candidate = candidate.slice(1);
+  }
+
+  if (candidate.endsWith('!')) {
+    trailingImportant = '!';
+    candidate = candidate.slice(0, -1);
+  }
+
+  return {
+    candidate,
+    leadingImportant,
+    prefix,
+    trailingImportant,
+  };
+}
+
+function analyzeMotionToken(token, options) {
+  const parsedToken = parseClassToken(token);
+  const match = parsedToken.candidate.match(ARBITRARY_MOTION_CLASS);
+  if (!match || !match.groups) {
+    return null;
+  }
+
+  if (match.groups.utility === 'ease') {
+    return {
+      fixedToken: null,
+      rawValue: match.groups.rawValue,
+      reason: 'easing',
+      utility: match.groups.utility,
+    };
+  }
+
+  const parsedTime = parseTimeToken(match.groups.rawValue);
+  if (!parsedTime) {
+    return null;
+  }
+
+  if (parsedTime.number < 0) {
+    return {
+      fixedToken: null,
+      nearest: null,
+      rawValue: match.groups.rawValue,
+      reason: 'negative',
+      utility: match.groups.utility,
+    };
+  }
+
+  if (!options.durationUnits.includes(parsedTime.unit)) {
+    return null;
+  }
+
+  const msValue = toMs(parsedTime.number, parsedTime.unit);
+  if (msValue === null) {
+    return null;
+  }
+
+  const isOnScale = options.durationScale.some((entry) => numbersEqual(entry, msValue));
+  if (isOnScale) {
+    return null;
+  }
+
+  const nearest = nearestScaleValues(msValue, options.durationScale);
+  if (!nearest) {
+    return null;
+  }
+
+  const converted = fromMs(nearest.nearest, parsedTime.unit);
+  if (converted === null) {
+    return null;
+  }
+
+  const replacementValue = formatTime(converted, parsedTime.unit);
+  const fixedCandidate = parsedToken.candidate.replace(match.groups.rawValue, replacementValue);
+  const fixedToken = `${parsedToken.prefix}${parsedToken.leadingImportant}${fixedCandidate}${parsedToken.trailingImportant}`;
+
+  return {
+    fixedToken,
+    nearest,
+    rawValue: match.groups.rawValue,
+    reason: 'duration',
+    utility: match.groups.utility,
+  };
+}
+
+function createTailwindMotionAnalyzer(option = {}) {
+  const options = normalizeTailwindMotionOptions(option);
+
+  return {
+    analyzeClassString(value) {
+      const findings = [];
+
+      for (const segment of findClassSegments(value)) {
+        const analysis = analyzeMotionToken(segment.token, options);
+        if (analysis) {
+          findings.push({ analysis, segment });
+        }
+      }
+
+      return findings;
+    },
+    analyzeToken(token) {
+      return analyzeMotionToken(token, options);
+    },
+    options,
+  };
+}
+
+module.exports = {
+  createTailwindMotionAnalyzer,
+  normalizeTailwindMotionOptions,
+};

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const TIME_RE = /^(-?(?:\d+|\d*\.\d+))(ms|s)$/i;
+
+function parseTimeToken(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const match = value.trim().match(TIME_RE);
+  if (!match) {
+    return null;
+  }
+
+  const number = Number(match[1]);
+  if (!Number.isFinite(number)) {
+    return null;
+  }
+
+  return {
+    number,
+    unit: match[2].toLowerCase(),
+  };
+}
+
+function toMs(number, unit) {
+  if (unit === 'ms') {
+    return number;
+  }
+
+  if (unit === 's') {
+    return number * 1000;
+  }
+
+  return null;
+}
+
+function fromMs(ms, unit) {
+  if (unit === 'ms') {
+    return ms;
+  }
+
+  if (unit === 's') {
+    return ms / 1000;
+  }
+
+  return null;
+}
+
+function formatTime(number, unit) {
+  const normalized = Object.is(number, -0) ? 0 : number;
+  if (Number.isInteger(normalized)) {
+    return `${normalized}${unit}`;
+  }
+
+  return `${Number(normalized.toFixed(4)).toString()}${unit}`;
+}
+
+function normalizeDurationScale(scale) {
+  const source = Array.isArray(scale) && scale.length > 0
+    ? scale
+    : [0, 75, 100, 150, 200, 300, 500, 700, 1000];
+
+  return [...new Set(source
+    .map((entry) => Number(entry))
+    .filter((entry) => Number.isFinite(entry) && entry >= 0))]
+    .sort((a, b) => a - b);
+}
+
+function normalizeDurationUnits(units) {
+  const source = Array.isArray(units) && units.length > 0
+    ? units
+    : ['ms', 's'];
+
+  const normalized = source
+    .map((unit) => String(unit).trim().toLowerCase())
+    .filter((unit) => unit === 'ms' || unit === 's');
+
+  return normalized.length > 0 ? [...new Set(normalized)] : ['ms', 's'];
+}
+
+module.exports = {
+  formatTime,
+  fromMs,
+  normalizeDurationScale,
+  normalizeDurationUnits,
+  parseTimeToken,
+  toMs,
+};

--- a/src/utils/token-sources.js
+++ b/src/utils/token-sources.js
@@ -22,12 +22,14 @@ const VALID_TOKEN_KINDS = new Set([
   'radius',
   'typography',
   'size',
+  'motion',
   'all',
 ]);
 
 const TOKEN_KIND_PATTERNS = Object.freeze({
   all: /^--/,
   radius: /^--radius-/,
+  motion: /^--(?:motion|duration|delay|ease|easing)-/,
   size: /^--(?:size|width|height|container)-/,
   spacing: /^--(?:space|spacing)-/,
   typography: /^--(?:font|font-size|line-height|leading|tracking|typography)-/,
@@ -53,7 +55,7 @@ function normalizeTokenSourceFormat(format) {
 function normalizeTokenKind(kind) {
   const normalized = String(kind || 'spacing').trim().toLowerCase();
   if (!VALID_TOKEN_KINDS.has(normalized)) {
-    throw new Error(`Invalid token kind "${kind}". Expected spacing, radius, typography, size, or all.`);
+    throw new Error(`Invalid token kind "${kind}". Expected spacing, radius, typography, size, motion, or all.`);
   }
 
   return normalized;

--- a/test/audit-cli.test.js
+++ b/test/audit-cli.test.js
@@ -68,7 +68,7 @@ test('audit CLI JSON reports CSS and Tailwind design-system drift', () => {
   assert.equal(result.status, 0, result.stderr);
 
   const report = JSON.parse(result.stdout);
-  assert.equal(report.formatVersion, 4);
+  assert.equal(report.formatVersion, 5);
   assert.equal(report.cssFilesScanned, 1);
   assert.equal(report.templateFilesScanned, 1);
   assert.equal(report.offScaleValues['13px'], 1);
@@ -455,6 +455,91 @@ test('audit CLI supports threshold exit gates', () => {
   assert.match(result.stderr, /Audit failed:/);
   assert.match(result.stderr, /--max-findings 0/);
   assert.match(result.stderr, /--min-cleanliness 100%/);
+});
+
+test('audit CLI includes motion drift only when requested', () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-audit-motion-'));
+  fs.mkdirSync(path.join(fixtureDir, 'src'));
+  fs.writeFileSync(
+    path.join(fixtureDir, 'src', 'motion.css'),
+    '.button { transition: opacity 175ms cubic-bezier(.2, 0, 0, 1); }\n',
+  );
+  fs.writeFileSync(
+    path.join(fixtureDir, 'src', 'Button.tsx'),
+    'export const Button = <button className="duration-[175ms] ease-[cubic-bezier(.2,0,0,1)]" />;\n',
+  );
+
+  const defaultResult = runAuditCommand(fixtureDir, 'src', '--format', 'json');
+  assert.equal(defaultResult.status, 0, defaultResult.stderr);
+  assert.equal(JSON.parse(defaultResult.stdout).summary.motionFindings, 0);
+
+  const result = runAuditCommand(fixtureDir, 'src', '--format', 'json', '--include-motion');
+  assert.equal(result.status, 0, result.stderr);
+
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.motion.enabled, true);
+  assert.equal(report.summary.motionFindings, 4);
+  assert.equal(report.findings.motion.length, 4);
+  assert.equal(report.motion.values['175ms'], 2);
+  assert.ok(report.motion.values['cubic-bezier(.2,0,0,1)'] || report.motion.values['cubic-bezier(.2, 0, 0, 1)']);
+});
+
+test('audit CLI compares motion findings in baselines', () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-audit-motion-baseline-'));
+  const baselinePath = path.join(fixtureDir, 'baseline.json');
+  fs.mkdirSync(path.join(fixtureDir, 'src'));
+  fs.writeFileSync(path.join(fixtureDir, 'src', 'motion.css'), '.button { transition-duration: 150ms; }\n');
+
+  const writeResult = runAuditCommand(
+    fixtureDir,
+    'src',
+    '--format',
+    'json',
+    '--include-motion',
+    '--write-baseline',
+    baselinePath,
+  );
+  assert.equal(writeResult.status, 0, writeResult.stderr);
+
+  fs.writeFileSync(path.join(fixtureDir, 'src', 'motion.css'), '.button { transition-duration: 175ms; }\n');
+  const result = runAuditCommand(
+    fixtureDir,
+    'src',
+    '--format',
+    'json',
+    '--include-motion',
+    '--since-baseline',
+    baselinePath,
+    '--fail-on-new-drift',
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /new drift found/);
+
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.baseline.newFindingsCount, 1);
+  assert.equal(report.baseline.newFindings[0].type, 'motion-duration');
+});
+
+test('audit CLI can enable motion scanning from config', () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-audit-motion-config-'));
+  fs.mkdirSync(path.join(fixtureDir, 'src'));
+  fs.writeFileSync(path.join(fixtureDir, 'src', 'motion.css'), '.button { transition-duration: 175ms; }\n');
+  fs.writeFileSync(
+    path.join(fixtureDir, '.rhythmguardrc.json'),
+    JSON.stringify({
+      audit: {
+        includeMotion: true,
+      },
+    }),
+  );
+
+  const result = runAuditCommand(fixtureDir, 'src', '--format', 'json');
+  assert.equal(result.status, 0, result.stderr);
+
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.motion.enabled, true);
+  assert.equal(report.summary.motionFindings, 1);
 });
 
 test('audit CLI can scan only staged files', () => {

--- a/test/eslint-tailwind.test.js
+++ b/test/eslint-tailwind.test.js
@@ -57,3 +57,52 @@ test('eslint tailwind class rule autofixes nearest value', () => {
   assert.equal(fixResult.fixed, true);
   assert.equal(fixResult.output, "const classes = 'p-[12px]';");
 });
+
+test('eslint tailwind motion rule reports arbitrary duration and easing values', () => {
+  const linter = new Linter({ configType: 'eslintrc' });
+  linter.defineRule(
+    'rhythmguard-tailwind/tailwind-class-use-motion-scale',
+    eslintPlugin.rules['tailwind-class-use-motion-scale'],
+  );
+
+  const messages = linter.verify(
+    "const classes = 'duration-[175ms] ease-[cubic-bezier(.2,0,0,1)] delay-[75ms]';",
+    {
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+      rules: {
+        'rhythmguard-tailwind/tailwind-class-use-motion-scale': 'error',
+      },
+    },
+  );
+
+  assert.equal(messages.length, 2);
+  assert.match(messages[0].message, /duration-\[175ms\]/);
+  assert.match(messages[1].message, /ease-\[cubic-bezier/);
+});
+
+test('eslint tailwind motion rule autofixes nearest duration value', () => {
+  const linter = new Linter({ configType: 'eslintrc' });
+  linter.defineRule(
+    'rhythmguard-tailwind/tailwind-class-use-motion-scale',
+    eslintPlugin.rules['tailwind-class-use-motion-scale'],
+  );
+
+  const fixResult = linter.verifyAndFix(
+    "const classes = 'duration-[175ms] delay-[0.175s]';",
+    {
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+      rules: {
+        'rhythmguard-tailwind/tailwind-class-use-motion-scale': 'error',
+      },
+    },
+  );
+
+  assert.equal(fixResult.fixed, true);
+  assert.equal(fixResult.output, "const classes = 'duration-[150ms] delay-[0.15s]';");
+});

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -13,6 +13,7 @@ test('plugin exports rules, shared configs, presets, and eslint companion', () =
   assert.ok(plugin.rules['rhythmguard/use-scale']);
   assert.ok(plugin.rules['rhythmguard/prefer-token']);
   assert.ok(plugin.rules['rhythmguard/no-offscale-transform']);
+  assert.ok(plugin.rules['rhythmguard/use-motion-scale']);
 
   assert.ok(plugin.configs.recommended);
   assert.ok(plugin.configs.strict);
@@ -20,6 +21,7 @@ test('plugin exports rules, shared configs, presets, and eslint companion', () =
   assert.ok(plugin.configs.expanded);
   assert.ok(plugin.configs.logical);
   assert.ok(plugin.configs.migration);
+  assert.ok(plugin.configs.motion);
 
   assert.deepEqual(plugin.configs.tailwind.extends, [
     'stylelint-config-tailwindcss',
@@ -35,6 +37,7 @@ test('plugin exports rules, shared configs, presets, and eslint companion', () =
 
   assert.ok(plugin.eslint);
   assert.ok(plugin.eslint.rules['tailwind-class-use-scale']);
+  assert.ok(plugin.eslint.rules['tailwind-class-use-motion-scale']);
 });
 
 test('strict config avoids transform overlap in use-scale', () => {
@@ -62,5 +65,7 @@ test('esm entrypoint exposes default plugin object', async () => {
   assert.ok(esm.default);
   assert.ok(esm.default.rules['rhythmguard/use-scale']);
   assert.ok(esm.configs.logical);
+  assert.ok(esm.configs.motion);
   assert.ok(esm.eslint.rules['tailwind-class-use-scale']);
+  assert.ok(esm.eslint.rules['tailwind-class-use-motion-scale']);
 });

--- a/test/floor-compat.test.js
+++ b/test/floor-compat.test.js
@@ -10,6 +10,7 @@ test('floor-compat: plugin exports shared configs', () => {
   assert.ok(plugin.configs.recommended);
   assert.ok(plugin.configs.strict);
   assert.ok(plugin.configs.tailwind);
+  assert.ok(plugin.configs.motion);
 });
 
 test('floor-compat: use-scale reports off-scale spacing', async () => {
@@ -46,4 +47,16 @@ test('floor-compat: no-offscale-transform reports off-scale translation', async 
 
   assert.equal(result.errored, true);
   assert.equal(result.warnings[0].rule, 'rhythmguard/no-offscale-transform');
+});
+
+test('floor-compat: use-motion-scale reports off-scale duration', async () => {
+  const result = await lintCss({
+    code: '.chip { transition-duration: 175ms; }',
+    rules: {
+      'rhythmguard/use-motion-scale': [true],
+    },
+  });
+
+  assert.equal(result.errored, true);
+  assert.equal(result.warnings[0].rule, 'rhythmguard/use-motion-scale');
 });

--- a/test/use-motion-scale.test.js
+++ b/test/use-motion-scale.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { lintCss } = require('./helpers/lint');
+
+test('use-motion-scale reports off-scale transition duration longhands', async () => {
+  const result = await lintCss({
+    code: '.button { transition-duration: 175ms; }',
+    rules: {
+      'rhythmguard/use-motion-scale': true,
+    },
+  });
+
+  assert.equal(result.warnings.length, 1);
+  assert.equal(result.warnings[0].rule, 'rhythmguard/use-motion-scale');
+  assert.match(result.warnings[0].text, /motion duration/);
+});
+
+test('use-motion-scale autofixes off-scale duration values', async () => {
+  const result = await lintCss({
+    code: '.button { transition-duration: 175ms; animation-delay: 0.175s; }',
+    fix: true,
+    rules: {
+      'rhythmguard/use-motion-scale': true,
+    },
+  });
+
+  assert.equal(result.code, '.button { transition-duration: 150ms; animation-delay: 0.15s; }');
+});
+
+test('use-motion-scale reports shorthand duration drift', async () => {
+  const result = await lintCss({
+    code: '.button { transition: opacity 175ms cubic-bezier(.2, 0, 0, 1) 75ms; }',
+    rules: {
+      'rhythmguard/use-motion-scale': true,
+    },
+  });
+
+  assert.equal(result.warnings.length, 2);
+  assert.ok(result.warnings.some((warning) => /175ms/.test(warning.text)));
+  assert.ok(result.warnings.some((warning) => /cubic-bezier/.test(warning.text)));
+});
+
+test('use-motion-scale reports negative durations without autofix', async () => {
+  const result = await lintCss({
+    code: '.button { animation-duration: -75ms; }',
+    fix: true,
+    rules: {
+      'rhythmguard/use-motion-scale': true,
+    },
+  });
+
+  assert.equal(result.warnings.length, 1);
+  assert.equal(result.code, '.button { animation-duration: -75ms; }');
+});
+
+test('use-motion-scale ignores invalid non-time values', async () => {
+  const result = await lintCss({
+    code: '.button { transition-duration: fast; animation-delay: var(--duration-fast); }',
+    rules: {
+      'rhythmguard/use-motion-scale': true,
+    },
+  });
+
+  assert.equal(result.warnings.length, 0);
+});
+
+test('use-motion-scale supports custom duration scale', async () => {
+  const result = await lintCss({
+    code: '.button { transition-duration: 175ms; }',
+    rules: {
+      'rhythmguard/use-motion-scale': [
+        true,
+        {
+          durationScale: [0, 175, 350],
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.warnings.length, 0);
+});


### PR DESCRIPTION
## Summary
- add rhythmguard/use-motion-scale and a motion shared config
- add Tailwind ESLint companion for duration/delay/easing arbitrary classes
- add audit --include-motion and config-driven motion reporting/baselines

## Verification
- node --test test/use-motion-scale.test.js test/eslint-tailwind.test.js test/audit-cli.test.js test/exports.test.js test/floor-compat.test.js
- npm run lint
- npm test
- npm run scales:validate
- npm run test:pack-smoke
- npm publish --dry-run --provenance