### PR TITLE
Stabilize audit contract for 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-05-23
+
+### Changed
+
+- `rhythmguard audit --format json` now emits the stable audit contract with `schemaVersion: "2.0"`.
+- Moved the pre-2.0 audit JSON shape to `--format json-v1` for migration compatibility.
+- Updated audit defaults to use the explicit spacing token pattern `^--(space|spacing)-`.
+
+### Added
+
+- Added `stylelint-plugin-rhythmguard/audit` with `createAuditReport`, `loadAuditConfig`, `parseTokenSources`, and `toAuditContractReport`.
+- Added `rhythmguard audit --format html`, `--output <file>`, and `--schema`.
+- Added `rhythmguard doctor` checks for `.rhythmguardrc.json`, configured token sources, motion audit config, and baseline files.
+- Added `docs/MIGRATING_TO_2.md`.
+
 ## [1.9.0] - 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ npx rhythmguard audit ./src --staged --max-findings 0
 npx rhythmguard audit ./src --token-source ./tokens.json
 npx rhythmguard audit ./src --token-source ./theme.css --token-source-format css
 npx rhythmguard audit ./src --include-motion
+npx rhythmguard audit ./src --format html --output rhythmguard-report.html
+npx rhythmguard audit --schema
 ```
 
-The report covers authored CSS declarations, Tailwind arbitrary spacing values in common template/source files, and token-contract drift such as missing spacing tokens, unused spacing tokens, repeated raw values that deserve token review, raw values that match known tokens, and conflicting token values. Scan paths are scoped to the directory argument. Use `--ignore`, `.rhythmguardignore`, or `--ignore-path` for generated or legacy subtrees, then add baselines and CI thresholds when you are ready to gate new drift. Markdown output is PR-ready for UX developers, UX designers, and design-system owners:
+The report covers authored CSS declarations, Tailwind arbitrary spacing values in common template/source files, and token-contract drift such as missing spacing tokens, unused spacing tokens, repeated raw values that deserve token review, raw values that match known tokens, conflicting token values, and opt-in motion rhythm drift. Scan paths are scoped to the directory argument. Use `--ignore`, `.rhythmguardignore`, or `--ignore-path` for generated or legacy subtrees, then add baselines and CI thresholds when you are ready to gate new drift. Markdown output is PR-ready for UX developers, UX designers, and design-system owners:
 
 ```md
 # Rhythmguard Design-System Audit
@@ -135,6 +137,44 @@ For large codebases, put shared audit settings in `.rhythmguardrc.json`:
 ```
 
 `rhythmguard audit` loads `.rhythmguardrc.json` automatically when present. Use `--config <file>` for another config, `--no-config` to skip config discovery, and `--token-source <file>` for extra canonical token files. Token source paths in config files resolve from the config file directory; CLI token source paths resolve from the current working directory. Supported source formats are CSS custom properties and Tailwind v4 `@theme`, flat JSON maps, Style Dictionary JSON, and DTCG JSON.
+
+### Audit JSON 2.0 and API
+
+In Rhythmguard 2.0, `--format json` emits the stable audit contract:
+
+```json
+{
+  "schemaVersion": "2.0",
+  "command": { "directory": "./src", "scanScope": "full" },
+  "summary": { "totalFindings": 12, "scaleCleanliness": 94 },
+  "scanned": { "cssFiles": 10, "templateFiles": 20 },
+  "contracts": {
+    "scale": {},
+    "tokens": {},
+    "motion": {}
+  },
+  "findings": {
+    "css": [],
+    "tailwind": [],
+    "motion": []
+  },
+  "baseline": null
+}
+```
+
+Use `--format json-v1` for the pre-2.0 JSON shape during migration.
+
+Programmatic usage:
+
+```js
+const {
+  createAuditReport,
+  toAuditContractReport,
+} = require('stylelint-plugin-rhythmguard/audit');
+
+const report = await createAuditReport({ dir: './src', noConfig: true });
+const contract = toAuditContractReport(report);
+```
 
 ## Installation
 

--- a/docs/AUDIT_2_VALIDATION.md
+++ b/docs/AUDIT_2_VALIDATION.md
@@ -38,6 +38,8 @@ npx rhythmguard audit ./src --since origin/main --max-findings 0
 npx rhythmguard audit ./src --token-source ./tokens.json
 npx rhythmguard audit ./src --config ./configs/rhythmguard.json
 npx rhythmguard audit ./src --include-motion
+npx rhythmguard audit ./src --format html --output rhythmguard-report.html
+npx rhythmguard audit --schema
 ```
 
 The report includes:
@@ -59,10 +61,13 @@ The report includes:
 - External token-source contract checks for canonical tokens that live outside the scanned source tree.
 - `.rhythmguardrc.json` audit config for reusable ignores, thresholds, token sources, and token-kind selection.
 - Opt-in motion rhythm reporting for CSS duration/delay drift, raw easing curves, and Tailwind arbitrary motion utilities.
+- Stable JSON 2.0 contract with `--format json-v1` migration compatibility.
+- Static HTML report output and `--output <file>` for generated artifacts.
+- Programmatic audit API at `stylelint-plugin-rhythmguard/audit`.
 - CI gates with `--max-findings`, `--min-cleanliness`, and `--fail-on-new-drift`.
 
 ## Follow-Up Roadmap
 
-1. Add HTML report output for design reviews.
-2. Add Figma-friendly export after the code-side contract stabilizes.
-3. Stabilize the audit JSON contract and add HTML output for design reviews.
+1. Add Figma-friendly export after the code-side contract stabilizes.
+2. Add richer dashboard examples around the programmatic audit API.
+3. Evaluate whether motion should move from opt-in to a recommended profile in a future major.

--- a/docs/MIGRATING_TO_2.md
+++ b/docs/MIGRATING_TO_2.md
@@ -1,0 +1,64 @@
+# Migrating to Rhythmguard 2.0
+
+Rhythmguard 2.0 stabilizes the audit contract for CI, dashboards, and generated reports.
+
+## Audit JSON
+
+`rhythmguard audit --format json` now emits the 2.0 contract:
+
+```json
+{
+  "schemaVersion": "2.0",
+  "command": {},
+  "summary": {},
+  "scanned": {},
+  "contracts": {
+    "scale": {},
+    "tokens": {},
+    "motion": {}
+  },
+  "findings": {
+    "css": [],
+    "tailwind": [],
+    "motion": []
+  },
+  "baseline": null
+}
+```
+
+Use `--format json-v1` while migrating scripts that still consume the pre-2.0 JSON shape.
+
+## HTML and Output Files
+
+Use `--format html --output rhythmguard-report.html` for a static design review report.
+
+`--output <file>` works with `json`, `json-v1`, `markdown`, and `html`.
+
+## Programmatic API
+
+```js
+const {
+  createAuditReport,
+  toAuditContractReport,
+} = require('stylelint-plugin-rhythmguard/audit');
+
+const report = await createAuditReport({ dir: './src', noConfig: true });
+const contract = toAuditContractReport(report);
+```
+
+## Config
+
+`.rhythmguardrc.json` is the recommended audit config surface:
+
+```json
+{
+  "audit": {
+    "ignore": ["legacy/**"],
+    "tokenSources": ["./tokens.json"],
+    "includeMotion": false,
+    "minCleanliness": 90
+  }
+}
+```
+
+Run `npx rhythmguard doctor` to validate token sources, motion settings, and baseline files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stylelint-plugin-rhythmguard",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint-plugin-rhythmguard",
-      "version": "1.9.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "known-css-properties": "^0.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-rhythmguard",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "description": "Token governance for CSS and Tailwind — enforce spacing scales, require design tokens, catch arbitrary values",
   "bin": {
     "rhythmguard": "src/cli/index.js"
@@ -60,6 +60,10 @@
     "./presets": {
       "require": "./src/presets/index.js",
       "import": "./src/presets/index.mjs"
+    },
+    "./audit": {
+      "require": "./src/audit/index.js",
+      "import": "./src/audit/index.mjs"
     },
     "./rules/use-scale": {
       "require": "./src/rules/use-scale/index.js",

--- a/src/audit/index.js
+++ b/src/audit/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const {
+  AUDIT_JSON_SCHEMA,
+  createAuditReport,
+  loadAuditConfig,
+  toAuditContractReport,
+} = require('../cli/audit');
+const { parseTokenSources } = require('../utils/token-sources');
+
+module.exports = {
+  AUDIT_JSON_SCHEMA,
+  createAuditReport,
+  loadAuditConfig,
+  parseTokenSources,
+  toAuditContractReport,
+};

--- a/src/audit/index.mjs
+++ b/src/audit/index.mjs
@@ -1,0 +1,11 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const audit = require('./index.js');
+
+export default audit;
+export const AUDIT_JSON_SCHEMA = audit.AUDIT_JSON_SCHEMA;
+export const createAuditReport = audit.createAuditReport;
+export const loadAuditConfig = audit.loadAuditConfig;
+export const parseTokenSources = audit.parseTokenSources;
+export const toAuditContractReport = audit.toAuditContractReport;

--- a/src/cli/audit.js
+++ b/src/cli/audit.js
@@ -25,8 +25,9 @@ const DEFAULT_BASE_FONT_SIZE = 16;
 const DEFAULT_BASELINE_PATH = '.rhythmguard-baseline.json';
 const DEFAULT_CONFIG_PATH = '.rhythmguardrc.json';
 const DEFAULT_IGNORE_PATH = '.rhythmguardignore';
+const DEFAULT_AUDIT_TOKEN_PATTERN = '^--(space|spacing)-';
 const DEFAULT_TOKEN_CANDIDATE_MIN_COUNT = 2;
-const VALID_FORMATS = new Set(['text', 'json', 'markdown']);
+const VALID_FORMATS = new Set(['text', 'json', 'json-v1', 'markdown', 'html']);
 const SKIP_DIRS = new Set([
   '.git',
   '.next',
@@ -56,9 +57,11 @@ const TEMPLATE_EXTENSIONS = new Set([
 const HELP = `Usage: rhythmguard audit <dir> [options]
 
 Options:
-  --format <text|json|markdown>  Output format (default: text)
+  --format <text|json|json-v1|markdown|html> Output format (default: text)
   --json                         Alias for --format json
   --markdown                     Alias for --format markdown
+  --schema                       Print the audit JSON schema and exit
+  --output <file>                Write json, markdown, or html output to a file
   --config <file>                Load audit config (default: .rhythmguardrc.json when present)
   --no-config                    Ignore .rhythmguardrc.json discovery
   --ignore <pattern>             Exclude root-relative path/glob (repeatable, comma-separated)
@@ -81,37 +84,19 @@ Options:
 `;
 
 function parseArgs(argv) {
-  const parsed = {
-    baselinePath: DEFAULT_BASELINE_PATH,
-    baseFontSize: DEFAULT_BASE_FONT_SIZE,
-    cliOptions: new Set(),
-    configExplicit: false,
-    configPath: DEFAULT_CONFIG_PATH,
-    dir: null,
-    failOnNewDrift: false,
-    format: 'text',
-    ignorePath: DEFAULT_IGNORE_PATH,
-    ignorePatterns: [],
-    includeMotion: false,
-    maxFindings: null,
-    minCleanliness: null,
-    noConfig: false,
-    scale: DEFAULT_SCALE,
-    since: null,
-    sinceBaseline: false,
-    staged: false,
-    tokenCandidateMinCount: DEFAULT_TOKEN_CANDIDATE_MIN_COUNT,
-    tokenKind: 'spacing',
-    tokenSourceFormat: 'auto',
-    tokenSources: [],
-    writeBaseline: false,
-  };
+  const parsed = createDefaultAuditOptions();
 
   for (let index = 0; index < argv.length; index++) {
     const arg = argv[index];
 
     if (arg === '--help' || arg === '-h') {
       parsed.help = true;
+      continue;
+    }
+
+    if (arg === '--schema') {
+      parsed.schema = true;
+      parsed.format = 'json';
       continue;
     }
 
@@ -122,6 +107,18 @@ function parseArgs(argv) {
 
     if (arg === '--markdown') {
       parsed.format = 'markdown';
+      continue;
+    }
+
+    if (arg === '--output') {
+      parsed.outputPath = parsePathOption(argv[++index], '--output');
+      parsed.cliOptions.add('outputPath');
+      continue;
+    }
+
+    if (arg.startsWith('--output=')) {
+      parsed.outputPath = parsePathOption(arg.slice('--output='.length), '--output');
+      parsed.cliOptions.add('outputPath');
       continue;
     }
 
@@ -365,7 +362,7 @@ function parseArgs(argv) {
   }
 
   if (!VALID_FORMATS.has(parsed.format)) {
-    throw new Error(`Invalid format "${parsed.format}". Expected text, json, or markdown.`);
+    throw new Error(`Invalid format "${parsed.format}". Expected text, json, json-v1, markdown, or html.`);
   }
 
   if (parsed.since && parsed.staged) {
@@ -377,6 +374,36 @@ function parseArgs(argv) {
   }
 
   return parsed;
+}
+
+function createDefaultAuditOptions() {
+  return {
+    baselinePath: DEFAULT_BASELINE_PATH,
+    baseFontSize: DEFAULT_BASE_FONT_SIZE,
+    cliOptions: new Set(),
+    configExplicit: false,
+    configPath: DEFAULT_CONFIG_PATH,
+    dir: null,
+    failOnNewDrift: false,
+    format: 'text',
+    ignorePath: DEFAULT_IGNORE_PATH,
+    ignorePatterns: [],
+    includeMotion: false,
+    maxFindings: null,
+    minCleanliness: null,
+    noConfig: false,
+    outputPath: null,
+    scale: DEFAULT_SCALE,
+    schema: false,
+    since: null,
+    sinceBaseline: false,
+    staged: false,
+    tokenCandidateMinCount: DEFAULT_TOKEN_CANDIDATE_MIN_COUNT,
+    tokenKind: 'spacing',
+    tokenSourceFormat: 'auto',
+    tokenSources: [],
+    writeBaseline: false,
+  };
 }
 
 function parsePathOption(raw, optionName) {
@@ -486,25 +513,27 @@ function parseBaseFontSize(raw) {
 
 function assertDirectory(dir) {
   if (!dir) {
-    process.stderr.write(HELP);
-    process.exit(1);
+    throw new Error('Missing audit directory.');
   }
 
   const resolvedDir = path.resolve(dir);
   if (!fs.existsSync(resolvedDir)) {
-    process.stderr.write(`Directory not found: ${dir}\n`);
-    process.exit(1);
+    throw new Error(`Directory not found: ${dir}`);
   }
 
   if (!fs.statSync(resolvedDir).isDirectory()) {
-    process.stderr.write(`Not a directory: ${dir}\n`);
-    process.exit(1);
+    throw new Error(`Not a directory: ${dir}`);
   }
 
   return resolvedDir;
 }
 
 function loadAuditConfig(parsed) {
+  parsed = {
+    ...createDefaultAuditOptions(),
+    ...parsed,
+  };
+
   if (parsed.noConfig) {
     return null;
   }
@@ -901,7 +930,7 @@ async function runStylelintAudit(cssFiles, options) {
         scale: options.scale,
         severity: 'warning',
         tokenMapFromCssCustomProperties: true,
-        tokenPattern: '^--spac(e|ing)-',
+        tokenPattern: DEFAULT_AUDIT_TOKEN_PATTERN,
       },
     ],
   };
@@ -1985,6 +2014,209 @@ function formatPath(filePath) {
   return path.relative(process.cwd(), filePath).replace(/\\/g, '/');
 }
 
+async function createAuditReport(options) {
+  const parsed = normalizeCreateAuditOptions(options);
+  const resolvedDir = assertDirectory(parsed.dir);
+  let ignorePatterns;
+  ignorePatterns = [
+    ...loadIgnorePatterns(parsed.ignorePath),
+    ...parsed.ignorePatterns,
+  ];
+
+  const scanFiles = getScanFiles(resolvedDir, ignorePatterns, parsed);
+
+  const { cssFiles, scanScope, templateFiles } = scanFiles;
+  const lintOptions = {
+    baseFontSize: parsed.baseFontSize,
+    includeMotion: parsed.includeMotion,
+    scale: parsed.scale,
+  };
+
+  const cssResults = await runStylelintAudit(cssFiles, lintOptions);
+
+  const tokenSourceResult = parseTokenSources({
+    baseFontSize: parsed.baseFontSize,
+    sources: parsed.tokenSources,
+    tokenKind: parsed.tokenKind,
+  });
+  const stylelintFindings = collectCssFindings(cssResults);
+  const cssFindings = stylelintFindings.filter((finding) => !finding.type.startsWith('motion-'));
+  const motionFindings = [
+    ...stylelintFindings.filter((finding) => finding.type.startsWith('motion-')),
+    ...collectTailwindMotionFindings(templateFiles, lintOptions),
+  ];
+
+  const report = buildReport({
+    baseFontSize: parsed.baseFontSize,
+    config: parsed.config,
+    cssFiles,
+    cssFindings,
+    dir: parsed.dir,
+    externalTokenDefinitions: tokenSourceResult.definitions,
+    includeMotion: parsed.includeMotion,
+    motionFindings,
+    scanScope,
+    tailwindFindings: collectTailwindFindings(templateFiles, lintOptions),
+    templateFiles,
+    tokenCandidateMinCount: parsed.tokenCandidateMinCount,
+    tokenKind: parsed.tokenKind,
+    tokenSourceReports: tokenSourceResult.sources,
+    tokenSourceWarnings: tokenSourceResult.warnings,
+  });
+
+  if (parsed.sinceBaseline) {
+    applyBaselineComparison(report, parsed.baselinePath);
+  }
+
+  if (parsed.writeBaseline) {
+    writeBaseline(report, parsed.baselinePath);
+  }
+
+  return report;
+}
+
+function normalizeCreateAuditOptions(options = {}) {
+  const parsed = {
+    ...createDefaultAuditOptions(),
+    ...options,
+    cliOptions: options.cliOptions instanceof Set
+      ? options.cliOptions
+      : new Set(Object.keys(options)),
+  };
+
+  if (!Array.isArray(parsed.ignorePatterns)) {
+    parsed.ignorePatterns = [];
+  }
+
+  if (!Array.isArray(parsed.tokenSources)) {
+    parsed.tokenSources = [];
+  }
+
+  if (parsed.configApplied) {
+    delete parsed.cliOptions;
+    return parsed;
+  }
+
+  return applyAuditConfig(parsed, loadAuditConfig(parsed));
+}
+
+function toAuditContractReport(report) {
+  return {
+    baseline: report.baseline || null,
+    command: {
+      config: report.config,
+      directory: report.directory,
+      scanScope: report.scanScope.mode,
+    },
+    contracts: {
+      motion: report.motion,
+      scale: {
+        cleanliness: report.scaleCleanliness,
+        offScaleValues: report.offScaleValues,
+        tokenOpportunities: report.tokenOpportunities,
+      },
+      tokens: report.tokenContract,
+    },
+    findings: report.findings,
+    scanned: report.scanned,
+    schemaVersion: '2.0',
+    summary: report.summary,
+  };
+}
+
+const AUDIT_JSON_SCHEMA = Object.freeze({
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  additionalProperties: true,
+  properties: {
+    baseline: { type: ['object', 'null'] },
+    command: { type: 'object' },
+    contracts: { type: 'object' },
+    findings: { type: 'object' },
+    scanned: { type: 'object' },
+    schemaVersion: { const: '2.0' },
+    summary: { type: 'object' },
+  },
+  required: ['schemaVersion', 'command', 'summary', 'scanned', 'contracts', 'findings'],
+  title: 'Rhythmguard Audit Report',
+  type: 'object',
+});
+
+function renderHtml(report) {
+  const contractReport = toAuditContractReport(report);
+  const lines = [
+    '<!doctype html>',
+    '<html lang="en">',
+    '<head>',
+    '<meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width, initial-scale=1">',
+    '<title>Rhythmguard Design-System Audit</title>',
+    '<style>',
+    'body{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;margin:0;color:#171717;background:#fafafa;}',
+    'main{max-width:1040px;margin:0 auto;padding:32px 20px;}',
+    'h1,h2{line-height:1.2;}',
+    '.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;}',
+    '.metric{border:1px solid #ddd;background:#fff;padding:14px;border-radius:6px;}',
+    '.metric strong{display:block;font-size:28px;}',
+    'table{width:100%;border-collapse:collapse;background:#fff;border:1px solid #ddd;}',
+    'th,td{padding:10px;border-bottom:1px solid #eee;text-align:left;}',
+    'code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;}',
+    '</style>',
+    '</head>',
+    '<body>',
+    '<main>',
+    '<h1>Rhythmguard Design-System Audit</h1>',
+    `<p>Directory: <code>${escapeHtml(contractReport.command.directory)}</code></p>`,
+    '<section class="grid">',
+    metricHtml('Total findings', report.totalWarnings),
+    metricHtml('Scale cleanliness', `${report.scaleCleanliness}%`),
+    metricHtml('CSS files', report.cssFilesScanned),
+    metricHtml('Template files', report.templateFilesScanned),
+    '</section>',
+    renderHtmlTable('Top Affected Files', ['File', 'Findings'], report.topAffectedFiles.map(({ file, count }) => [file, count])),
+    renderHtmlTable('Token Contract Sources', ['File', 'Format', 'Tokens'], report.tokenContract.sources.map((source) => [
+      source.file,
+      source.format,
+      source.tokenCount,
+    ])),
+    renderHtmlTable('Motion Rhythm Drift', ['Value', 'Count'], Object.entries(report.motion.values)),
+    '<h2>Machine JSON</h2>',
+    `<pre><code>${escapeHtml(JSON.stringify(contractReport, null, 2))}</code></pre>`,
+    '</main>',
+    '</body>',
+    '</html>',
+  ];
+
+  return `${lines.join('\n')}\n`;
+}
+
+function metricHtml(label, value) {
+  return `<div class="metric"><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong></div>`;
+}
+
+function renderHtmlTable(title, headers, rows) {
+  if (rows.length === 0) {
+    return '';
+  }
+
+  return [
+    `<h2>${escapeHtml(title)}</h2>`,
+    '<table>',
+    `<thead><tr>${headers.map((header) => `<th>${escapeHtml(header)}</th>`).join('')}</tr></thead>`,
+    '<tbody>',
+    ...rows.map((row) => `<tr>${row.map((cell) => `<td><code>${escapeHtml(cell)}</code></td>`).join('')}</tr>`),
+    '</tbody>',
+    '</table>',
+  ].join('\n');
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 async function run() {
   let parsed;
   try {
@@ -1999,86 +2231,14 @@ async function run() {
     return;
   }
 
-  try {
-    parsed = applyAuditConfig(parsed, loadAuditConfig(parsed));
-  } catch (err) {
-    process.stderr.write(`${err.message}\n`);
-    process.exit(1);
+  if (parsed.schema) {
+    writeOutput(`${JSON.stringify(AUDIT_JSON_SCHEMA, null, 2)}\n`, parsed.outputPath);
+    return;
   }
 
-  const resolvedDir = assertDirectory(parsed.dir);
-  let ignorePatterns;
+  let report;
   try {
-    ignorePatterns = [
-      ...loadIgnorePatterns(parsed.ignorePath),
-      ...parsed.ignorePatterns,
-    ];
-  } catch (err) {
-    process.stderr.write(`${err.message}\n`);
-    process.exit(1);
-  }
-
-  let scanFiles;
-  try {
-    scanFiles = getScanFiles(resolvedDir, ignorePatterns, parsed);
-  } catch (err) {
-    process.stderr.write(`${err.message}\n`);
-    process.exit(1);
-  }
-
-  const { cssFiles, scanScope, templateFiles } = scanFiles;
-  const options = {
-    baseFontSize: parsed.baseFontSize,
-    includeMotion: parsed.includeMotion,
-    scale: parsed.scale,
-  };
-
-  let cssResults;
-  try {
-    cssResults = await runStylelintAudit(cssFiles, options);
-  } catch (err) {
-    process.stderr.write(`Lint error: ${err.message}\n`);
-    process.exit(1);
-  }
-
-  const tokenSourceResult = parseTokenSources({
-    baseFontSize: parsed.baseFontSize,
-    sources: parsed.tokenSources,
-    tokenKind: parsed.tokenKind,
-  });
-  const stylelintFindings = collectCssFindings(cssResults);
-  const cssFindings = stylelintFindings.filter((finding) => !finding.type.startsWith('motion-'));
-  const motionFindings = [
-    ...stylelintFindings.filter((finding) => finding.type.startsWith('motion-')),
-    ...collectTailwindMotionFindings(templateFiles, options),
-  ];
-
-  const report = buildReport({
-    baseFontSize: parsed.baseFontSize,
-    config: parsed.config,
-    cssFiles,
-    cssFindings,
-    dir: parsed.dir,
-    externalTokenDefinitions: tokenSourceResult.definitions,
-    includeMotion: parsed.includeMotion,
-    motionFindings,
-    scanScope,
-    tailwindFindings: collectTailwindFindings(templateFiles, options),
-    templateFiles,
-    tokenCandidateMinCount: parsed.tokenCandidateMinCount,
-    tokenKind: parsed.tokenKind,
-    tokenSourceReports: tokenSourceResult.sources,
-    tokenSourceWarnings: tokenSourceResult.warnings,
-  });
-
-  try {
-    if (parsed.sinceBaseline) {
-      applyBaselineComparison(report, parsed.baselinePath);
-    }
-
-    if (parsed.writeBaseline) {
-      writeBaseline(report, parsed.baselinePath);
-    }
+    report = await createAuditReport(parsed);
   } catch (err) {
     process.stderr.write(`${err.message}\n`);
     process.exit(1);
@@ -2087,19 +2247,42 @@ async function run() {
   const auditFailures = getAuditFailures(report, parsed);
 
   if (parsed.format === 'json') {
-    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    writeOutput(`${JSON.stringify(toAuditContractReport(report), null, 2)}\n`, parsed.outputPath);
+    finish(auditFailures);
+    return;
+  }
+
+  if (parsed.format === 'json-v1') {
+    writeOutput(`${JSON.stringify(report, null, 2)}\n`, parsed.outputPath);
     finish(auditFailures);
     return;
   }
 
   if (parsed.format === 'markdown') {
-    process.stdout.write(renderMarkdown(report));
+    writeOutput(renderMarkdown(report), parsed.outputPath);
     finish(auditFailures);
     return;
   }
 
-  process.stdout.write(renderText(report));
+  if (parsed.format === 'html') {
+    writeOutput(renderHtml(report), parsed.outputPath);
+    finish(auditFailures);
+    return;
+  }
+
+  writeOutput(renderText(report), parsed.outputPath);
   finish(auditFailures);
+}
+
+function writeOutput(output, outputPath) {
+  if (!outputPath) {
+    process.stdout.write(output);
+    return;
+  }
+
+  const resolvedPath = path.resolve(process.cwd(), outputPath);
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  fs.writeFileSync(resolvedPath, output);
 }
 
 function finish(auditFailures) {
@@ -2111,4 +2294,16 @@ function finish(auditFailures) {
   process.exitCode = 1;
 }
 
-run();
+module.exports = {
+  AUDIT_JSON_SCHEMA,
+  createAuditReport,
+  loadAuditConfig,
+  parseArgs,
+  renderHtml,
+  run,
+  toAuditContractReport,
+};
+
+if (require.main === module) {
+  run();
+}

--- a/src/cli/doctor.js
+++ b/src/cli/doctor.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { normalizeTokenSourceFormat } = require('../utils/token-sources');
 
 const cwd = process.cwd();
 let issues = 0;
@@ -205,6 +206,99 @@ function checkCustomSyntax(configContent) {
   }
 }
 
+function checkRhythmguardConfig() {
+  const configPath = path.join(cwd, '.rhythmguardrc.json');
+  if (!fs.existsSync(configPath)) {
+    skip('rhythmguard config check skipped (.rhythmguardrc.json not found)');
+    return;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  } catch {
+    fail('.rhythmguardrc.json is not valid JSON', 'Fix or remove .rhythmguardrc.json');
+    return;
+  }
+
+  const audit = parsed.audit;
+  if (!audit || typeof audit !== 'object' || Array.isArray(audit)) {
+    fail('.rhythmguardrc.json audit config missing', 'Add an "audit" object or remove the config file');
+    return;
+  }
+
+  pass('.rhythmguardrc.json audit config valid');
+  checkRhythmguardTokenSources(audit, path.dirname(configPath));
+  checkRhythmguardMotionConfig(audit);
+  checkRhythmguardBaseline(audit);
+}
+
+function checkRhythmguardTokenSources(audit, baseDir) {
+  if (audit.tokenSources === undefined) {
+    skip('token source config check skipped (not configured)');
+    return;
+  }
+
+  if (!Array.isArray(audit.tokenSources)) {
+    fail('audit.tokenSources must be an array', 'Use strings or { "path": "...", "format": "..." } entries');
+    return;
+  }
+
+  for (const source of audit.tokenSources) {
+    const sourcePath = typeof source === 'string' ? source : source && source.path;
+    const format = typeof source === 'string' ? 'auto' : source && source.format;
+
+    if (typeof sourcePath !== 'string' || sourcePath.trim().length === 0) {
+      fail('token source entry missing path', 'Use strings or objects with a non-empty path');
+      continue;
+    }
+
+    try {
+      normalizeTokenSourceFormat(format || 'auto');
+    } catch {
+      fail(`token source format invalid for ${sourcePath}`, 'Use auto, css, flat-json, style-dictionary, or dtcg');
+    }
+
+    if (fs.existsSync(path.resolve(baseDir, sourcePath))) {
+      pass(`token source found (${sourcePath})`);
+    } else {
+      fail(`token source not found (${sourcePath})`, 'Update audit.tokenSources or create the token file');
+    }
+  }
+}
+
+function checkRhythmguardMotionConfig(audit) {
+  if (audit.includeMotion === undefined) {
+    skip('motion audit check skipped (not configured)');
+    return;
+  }
+
+  if (typeof audit.includeMotion === 'boolean') {
+    pass(`motion audit config valid (${audit.includeMotion})`);
+  } else {
+    fail('audit.includeMotion must be a boolean', 'Use true or false');
+  }
+}
+
+function checkRhythmguardBaseline(audit) {
+  const baselinePath = path.resolve(cwd, audit.baseline || '.rhythmguard-baseline.json');
+  if (!fs.existsSync(baselinePath)) {
+    skip('baseline freshness check skipped (baseline not found)');
+    return;
+  }
+
+  try {
+    const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+    if (!Array.isArray(baseline.findings)) {
+      fail('baseline file does not include findings array', 'Regenerate it with rhythmguard audit --write-baseline');
+      return;
+    }
+    pass(`baseline file readable (${path.relative(cwd, baselinePath)})`);
+  } catch {
+    fail('baseline file is not valid JSON', 'Regenerate it with rhythmguard audit --write-baseline');
+  }
+}
+
 function run() {
   process.stdout.write('\nRhythmguard Doctor\n\n');
 
@@ -214,6 +308,7 @@ function run() {
   checkTokenPattern(configContent);
   checkTailwindConfig(configContent);
   checkCustomSyntax(configContent);
+  checkRhythmguardConfig();
 
   process.stdout.write('\n');
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -27,7 +27,7 @@ if (!command || command === '--help' || command === '-h') {
 }
 
 if (command === 'audit') {
-  require('./audit');
+  require('./audit').run();
 } else if (command === 'init') {
   require('./init');
 } else if (command === 'doctor') {

--- a/src/index.js
+++ b/src/index.js
@@ -25,3 +25,4 @@ module.exports.configs = {
 };
 module.exports.eslint = require('./eslint');
 module.exports.presets = require('./presets');
+module.exports.audit = require('./audit');

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -8,3 +8,4 @@ export const rules = plugin.rules;
 export const configs = plugin.configs;
 export const presets = plugin.presets;
 export const eslint = plugin.eslint;
+export const audit = plugin.audit;

--- a/test/audit-api.test.js
+++ b/test/audit-api.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  AUDIT_JSON_SCHEMA,
+  createAuditReport,
+  loadAuditConfig,
+  parseTokenSources,
+  toAuditContractReport,
+} = require('../src/audit');
+
+test('audit API creates reports and v2 contract output', async () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-audit-api-'));
+  fs.mkdirSync(path.join(fixtureDir, 'src'));
+  fs.writeFileSync(path.join(fixtureDir, 'src', 'card.css'), '.card { padding: 13px; }\n');
+
+  const report = await createAuditReport({
+    dir: path.join(fixtureDir, 'src'),
+    noConfig: true,
+  });
+  const contract = toAuditContractReport(report);
+
+  assert.equal(report.formatVersion, 5);
+  assert.equal(contract.schemaVersion, '2.0');
+  assert.equal(contract.summary.totalFindings, 2);
+});
+
+test('audit API exposes config and token-source parsing helpers', () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-audit-api-config-'));
+  const previousCwd = process.cwd();
+  fs.writeFileSync(
+    path.join(fixtureDir, '.rhythmguardrc.json'),
+    JSON.stringify({
+      audit: {
+        tokenSources: ['tokens.json'],
+      },
+    }),
+  );
+  fs.writeFileSync(path.join(fixtureDir, 'tokens.json'), JSON.stringify({ '--spacing-4': '16px' }));
+
+  try {
+    process.chdir(fixtureDir);
+    const config = loadAuditConfig({});
+    assert.equal(config.file, '.rhythmguardrc.json');
+
+    const tokenResult = parseTokenSources({
+      sources: [{ path: 'tokens.json', baseDir: fixtureDir }],
+    });
+    assert.equal(tokenResult.definitions.get('--spacing-4').values.has('16px'), true);
+    assert.equal(AUDIT_JSON_SCHEMA.properties.schemaVersion.const, '2.0');
+  } finally {
+    process.chdir(previousCwd);
+  }
+});

--- a/test/audit-cli.test.js
+++ b/test/audit-cli.test.js
@@ -63,7 +63,7 @@ function runGit(cwd, ...args) {
 
 test('audit CLI JSON reports CSS and Tailwind design-system drift', () => {
   const fixtureDir = createAuditFixture();
-  const result = runAudit(fixtureDir, '--format', 'json');
+  const result = runAudit(fixtureDir, '--format', 'json-v1');
 
   assert.equal(result.status, 0, result.stderr);
 
@@ -84,6 +84,40 @@ test('audit CLI JSON reports CSS and Tailwind design-system drift', () => {
   ));
   assert.ok(report.tokenContract.rawValueCandidates.some(({ value, count }) => value === '13px' && count === 2));
   assert.ok(report.topAffectedFiles.some(({ file }) => file.endsWith('Button.tsx')));
+});
+
+test('audit CLI JSON emits the 2.0 contract shape by default', () => {
+  const fixtureDir = createAuditFixture();
+  const result = runAudit(fixtureDir, '--format', 'json');
+
+  assert.equal(result.status, 0, result.stderr);
+
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.schemaVersion, '2.0');
+  assert.equal(report.command.directory.endsWith('/src') || report.command.directory === path.join(fixtureDir, 'src'), true);
+  assert.equal(report.scanned.cssFiles, 1);
+  assert.equal(report.contracts.tokens.missingTokens[0].token, '--spacing-missing');
+  assert.equal(report.findings.tailwind.length, 2);
+});
+
+test('audit CLI prints schema and can write HTML output', () => {
+  const fixtureDir = createAuditFixture();
+  const schemaResult = runAuditCommand(fixtureDir, 'src', '--schema');
+  assert.equal(schemaResult.status, 0, schemaResult.stderr);
+  assert.equal(JSON.parse(schemaResult.stdout).properties.schemaVersion.const, '2.0');
+
+  const outputPath = path.join(fixtureDir, 'report.html');
+  const htmlResult = runAuditCommand(
+    fixtureDir,
+    'src',
+    '--format',
+    'html',
+    '--output',
+    outputPath,
+  );
+  assert.equal(htmlResult.status, 0, htmlResult.stderr);
+  assert.equal(htmlResult.stdout, '');
+  assert.match(fs.readFileSync(outputPath, 'utf8'), /Rhythmguard Design-System Audit/);
 });
 
 test('audit CLI markdown emits a PR-ready design-system report', () => {
@@ -117,7 +151,7 @@ test('audit CLI ignores root-relative paths before scanning', () => {
     '.vendor { padding: 13px; }\n',
   );
 
-  const result = runAudit(fixtureDir, '--format', 'json', '--ignore', 'legacy/**,vendor');
+  const result = runAudit(fixtureDir, '--format', 'json-v1', '--ignore', 'legacy/**,vendor');
 
   assert.equal(result.status, 0, result.stderr);
 
@@ -136,7 +170,7 @@ test('audit CLI scopes traversal to the requested directory', () => {
     '.outside { padding: 13px; gap: 16px; }\n',
   );
 
-  const result = runAudit(fixtureDir, '--format', 'json');
+  const result = runAudit(fixtureDir, '--format', 'json-v1');
 
   assert.equal(result.status, 0, result.stderr);
 
@@ -156,7 +190,7 @@ test('audit CLI loads ignore patterns from an ignore file', () => {
   );
   fs.writeFileSync(ignorePath, '# generated code\nlegacy\n');
 
-  const result = runAudit(fixtureDir, '--format', 'json', '--ignore-path', ignorePath);
+  const result = runAudit(fixtureDir, '--format', 'json-v1', '--ignore-path', ignorePath);
 
   assert.equal(result.status, 0, result.stderr);
 
@@ -180,8 +214,7 @@ test('audit CLI loads external CSS token sources outside the scan directory', ()
   const result = runAuditCommand(
     fixtureDir,
     'src',
-    '--format',
-    'json',
+    '--format', 'json-v1',
     '--token-source',
     'tokens.css',
   );
@@ -220,8 +253,7 @@ test('audit CLI loads DTCG token sources', () => {
   const result = runAuditCommand(
     fixtureDir,
     'src',
-    '--format',
-    'json',
+    '--format', 'json-v1',
     '--token-source',
     'tokens.json',
     '--token-source-format',
@@ -255,8 +287,7 @@ test('audit CLI loads Style Dictionary token sources', () => {
   const result = runAuditCommand(
     fixtureDir,
     'src',
-    '--format',
-    'json',
+    '--format', 'json-v1',
     '--token-source',
     'tokens.json',
     '--token-source-format',
@@ -287,8 +318,7 @@ test('audit CLI loads flat JSON token sources', () => {
   const result = runAuditCommand(
     fixtureDir,
     'src',
-    '--format',
-    'json',
+    '--format', 'json-v1',
     '--token-source',
     'tokens.json',
     '--token-source-format',
@@ -335,8 +365,7 @@ test('audit CLI loads config and lets CLI scalar options override config', () =>
   const result = runAuditCommand(
     fixtureDir,
     'src',
-    '--format',
-    'json',
+    '--format', 'json-v1',
     '--token-kind',
     'spacing',
     '--token-candidate-min-count',
@@ -363,8 +392,7 @@ test('audit CLI handles repeated token sources without duplicating token definit
   const result = runAuditCommand(
     fixtureDir,
     'src',
-    '--format',
-    'json',
+    '--format', 'json-v1',
     '--token-source',
     'tokens.json,tokens.json',
   );
@@ -384,8 +412,7 @@ test('audit CLI reports missing token source warnings without failing', () => {
   const result = runAuditCommand(
     fixtureDir,
     'src',
-    '--format',
-    'json',
+    '--format', 'json-v1',
     '--token-source',
     'missing.json',
   );
@@ -403,7 +430,7 @@ test('audit CLI fails on invalid rhythmguard config', () => {
   fs.writeFileSync(path.join(fixtureDir, 'src', 'card.css'), '.card { padding: 16px; }\n');
   fs.writeFileSync(path.join(fixtureDir, '.rhythmguardrc.json'), '{ invalid json');
 
-  const result = runAuditCommand(fixtureDir, 'src', '--format', 'json');
+  const result = runAuditCommand(fixtureDir, 'src', '--format', 'json-v1');
 
   assert.equal(result.status, 1);
   assert.match(result.stderr, /Invalid Rhythmguard config/);
@@ -412,7 +439,7 @@ test('audit CLI fails on invalid rhythmguard config', () => {
 test('audit CLI writes and compares baselines for new drift gating', () => {
   const fixtureDir = createAuditFixture();
   const baselinePath = path.join(fixtureDir, 'baseline.json');
-  const writeResult = runAudit(fixtureDir, '--format', 'json', '--write-baseline', baselinePath);
+  const writeResult = runAudit(fixtureDir, '--format', 'json-v1', '--write-baseline', baselinePath);
 
   assert.equal(writeResult.status, 0, writeResult.stderr);
   assert.equal(fs.existsSync(baselinePath), true);
@@ -424,8 +451,7 @@ test('audit CLI writes and compares baselines for new drift gating', () => {
 
   const result = runAudit(
     fixtureDir,
-    '--format',
-    'json',
+    '--format', 'json-v1',
     '--since-baseline',
     baselinePath,
     '--fail-on-new-drift',
@@ -443,8 +469,7 @@ test('audit CLI supports threshold exit gates', () => {
   const fixtureDir = createAuditFixture();
   const result = runAudit(
     fixtureDir,
-    '--format',
-    'json',
+    '--format', 'json-v1',
     '--max-findings',
     '0',
     '--min-cleanliness',
@@ -469,11 +494,11 @@ test('audit CLI includes motion drift only when requested', () => {
     'export const Button = <button className="duration-[175ms] ease-[cubic-bezier(.2,0,0,1)]" />;\n',
   );
 
-  const defaultResult = runAuditCommand(fixtureDir, 'src', '--format', 'json');
+  const defaultResult = runAuditCommand(fixtureDir, 'src', '--format', 'json-v1');
   assert.equal(defaultResult.status, 0, defaultResult.stderr);
   assert.equal(JSON.parse(defaultResult.stdout).summary.motionFindings, 0);
 
-  const result = runAuditCommand(fixtureDir, 'src', '--format', 'json', '--include-motion');
+  const result = runAuditCommand(fixtureDir, 'src', '--format', 'json-v1', '--include-motion');
   assert.equal(result.status, 0, result.stderr);
 
   const report = JSON.parse(result.stdout);
@@ -493,8 +518,7 @@ test('audit CLI compares motion findings in baselines', () => {
   const writeResult = runAuditCommand(
     fixtureDir,
     'src',
-    '--format',
-    'json',
+    '--format', 'json-v1',
     '--include-motion',
     '--write-baseline',
     baselinePath,
@@ -505,8 +529,7 @@ test('audit CLI compares motion findings in baselines', () => {
   const result = runAuditCommand(
     fixtureDir,
     'src',
-    '--format',
-    'json',
+    '--format', 'json-v1',
     '--include-motion',
     '--since-baseline',
     baselinePath,
@@ -534,7 +557,7 @@ test('audit CLI can enable motion scanning from config', () => {
     }),
   );
 
-  const result = runAuditCommand(fixtureDir, 'src', '--format', 'json');
+  const result = runAuditCommand(fixtureDir, 'src', '--format', 'json-v1');
   assert.equal(result.status, 0, result.stderr);
 
   const report = JSON.parse(result.stdout);
@@ -555,7 +578,7 @@ test('audit CLI can scan only staged files', () => {
   fs.writeFileSync(path.join(fixtureDir, 'src', 'unstaged.css'), '.unstaged { padding: 13px; }\n');
   runGit(fixtureDir, 'add', 'src/staged.css');
 
-  const result = runAuditCommand(fixtureDir, 'src', '--format', 'json', '--staged');
+  const result = runAuditCommand(fixtureDir, 'src', '--format', 'json-v1', '--staged');
 
   assert.equal(result.status, 0, result.stderr);
 
@@ -577,7 +600,7 @@ test('audit CLI can scan files changed since a git ref', () => {
   runGit(fixtureDir, 'commit', '-m', 'init');
   fs.writeFileSync(path.join(fixtureDir, 'src', 'changed.css'), '.changed { padding: 13px; }\n');
 
-  const result = runAuditCommand(fixtureDir, 'src', '--format', 'json', '--since', 'HEAD');
+  const result = runAuditCommand(fixtureDir, 'src', '--format', 'json-v1', '--since', 'HEAD');
 
   assert.equal(result.status, 0, result.stderr);
 

--- a/test/doctor-cli.test.js
+++ b/test/doctor-cli.test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const cliPath = path.join(__dirname, '..', 'src', 'cli', 'index.js');
+
+test('doctor validates rhythmguard config token sources and motion settings', () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-doctor-'));
+  fs.writeFileSync(
+    path.join(fixtureDir, '.rhythmguardrc.json'),
+    JSON.stringify({
+      audit: {
+        includeMotion: true,
+        tokenSources: [
+          { path: 'tokens.json', format: 'dtcg' },
+        ],
+      },
+    }),
+  );
+  fs.writeFileSync(path.join(fixtureDir, 'tokens.json'), JSON.stringify({ spacing: { 4: { $value: '16px' } } }));
+
+  const result = spawnSync(process.execPath, [cliPath, 'doctor'], {
+    cwd: fixtureDir,
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /\.rhythmguardrc\.json audit config valid/);
+  assert.match(result.stdout, /token source found/);
+  assert.match(result.stdout, /motion audit config valid/);
+});

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -38,6 +38,7 @@ test('plugin exports rules, shared configs, presets, and eslint companion', () =
   assert.ok(plugin.eslint);
   assert.ok(plugin.eslint.rules['tailwind-class-use-scale']);
   assert.ok(plugin.eslint.rules['tailwind-class-use-motion-scale']);
+  assert.ok(plugin.audit.createAuditReport);
 });
 
 test('strict config avoids transform overlap in use-scale', () => {
@@ -68,4 +69,5 @@ test('esm entrypoint exposes default plugin object', async () => {
   assert.ok(esm.configs.motion);
   assert.ok(esm.eslint.rules['tailwind-class-use-scale']);
   assert.ok(esm.eslint.rules['tailwind-class-use-motion-scale']);
+  assert.ok(esm.audit.createAuditReport);
 });


### PR DESCRIPTION
## Summary
- add stylelint-plugin-rhythmguard/audit programmatic API
- make audit --format json emit schemaVersion 2.0 and keep json-v1 compatibility
- add HTML output, --output, --schema, and stronger doctor checks
- add migration guide for 2.0 audit consumers

## Verification
- node --test test/audit-cli.test.js test/audit-api.test.js test/doctor-cli.test.js test/exports.test.js
- npm run lint
- npm test
- npm run scales:validate
- npm run test:pack-smoke
- npm publish --dry-run --provenance
- node src/cli/index.js audit test --format json --max-findings 999