### PR TITLE
[codex] reduce Audit 2 adoption friction

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ Framework-specific setup for Vue, Lit, Astro, and SvelteKit: [`docs/FRAMEWORKS.m
 
 - Side-by-side tool fit guide with migration snippets: [`docs/COMPARISON.md`](https://github.com/petrilahdelma/stylelint-plugin-rhythmguard/blob/main/docs/COMPARISON.md)
 - Audit 2.0 validation and roadmap: [`docs/AUDIT_2_VALIDATION.md`](https://github.com/petrilahdelma/stylelint-plugin-rhythmguard/blob/main/docs/AUDIT_2_VALIDATION.md)
+- CI baseline rollout recipe: [`docs/CI_ADOPTION.md`](https://github.com/petrilahdelma/stylelint-plugin-rhythmguard/blob/main/docs/CI_ADOPTION.md)
+- Programmatic dashboard and Figma-friendly export examples: [`docs/AUDIT_API_EXAMPLES.md`](https://github.com/petrilahdelma/stylelint-plugin-rhythmguard/blob/main/docs/AUDIT_API_EXAMPLES.md)
 - Real-world before/after excerpts from public repos: [`docs/ADOPTION_DIFFS.md`](https://github.com/petrilahdelma/stylelint-plugin-rhythmguard/blob/main/docs/ADOPTION_DIFFS.md)
 - Distribution submissions to Stylelint discovery surfaces: [`docs/DISTRIBUTION.md`](https://github.com/petrilahdelma/stylelint-plugin-rhythmguard/blob/main/docs/DISTRIBUTION.md)
 

--- a/docs/AUDIT_2_VALIDATION.md
+++ b/docs/AUDIT_2_VALIDATION.md
@@ -68,6 +68,6 @@ The report includes:
 
 ## Follow-Up Roadmap
 
-1. Add Figma-friendly export after the code-side contract stabilizes.
-2. Add richer dashboard examples around the programmatic audit API.
-3. Evaluate whether motion should move from opt-in to a recommended profile in a future major.
+1. Add Figma-friendly export after the code-side contract stabilizes. Delivered as a bridge payload example in [`AUDIT_API_EXAMPLES.md`](./AUDIT_API_EXAMPLES.md).
+2. Add richer dashboard examples around the programmatic audit API. Delivered as a dependency-free static dashboard example in [`AUDIT_API_EXAMPLES.md`](./AUDIT_API_EXAMPLES.md).
+3. Evaluate whether motion should move from opt-in to a recommended profile in a future major. Evidence captured in [`MOTION_DEFAULTS_EVIDENCE.md`](./MOTION_DEFAULTS_EVIDENCE.md).

--- a/docs/AUDIT_API_EXAMPLES.md
+++ b/docs/AUDIT_API_EXAMPLES.md
@@ -1,0 +1,43 @@
+# Audit API Examples
+
+Rhythmguard 2.0 exposes the audit contract through `stylelint-plugin-rhythmguard/audit` so teams can build dashboards, reports, and design-tool handoffs without scraping CLI text.
+
+## Static dashboard
+
+Generate a dependency-free HTML dashboard:
+
+```bash
+node examples/audit-dashboard.mjs --dir ./src --output rhythmguard-dashboard.html
+```
+
+Include motion findings when you are evaluating motion rhythm:
+
+```bash
+node examples/audit-dashboard.mjs --dir ./src --include-motion --output rhythmguard-dashboard.html
+```
+
+The script calls:
+
+```js
+import { createAuditReport, toAuditContractReport } from 'stylelint-plugin-rhythmguard/audit';
+
+const report = await createAuditReport({ dir: './src', includeMotion: true });
+const contract = toAuditContractReport(report);
+```
+
+## Figma-friendly export
+
+Generate a compact JSON payload for Figma/FigJam plugin experiments or manual design-system review:
+
+```bash
+node examples/audit-figma-export.mjs --dir ./src --include-motion --output rhythmguard-figma-export.json
+```
+
+The export intentionally stays small:
+
+- `summaryCards`: values that can become dashboard tiles.
+- `charts.findingsByType`: grouped issue counts.
+- `charts.findingsByFile`: top affected files.
+- `findings`: capped finding details for annotation layers or FigJam tables.
+
+This is a bridge format, not a full Figma plugin API. Keep the stable source of truth as the Audit 2.0 JSON contract and derive design-tool payloads from it.

--- a/docs/CI_ADOPTION.md
+++ b/docs/CI_ADOPTION.md
@@ -1,0 +1,86 @@
+# CI Adoption Recipe
+
+Use this rollout when a codebase already has spacing drift and you want Rhythmguard to block only new regressions.
+
+## 1. Create the baseline
+
+Run this once on the current codebase and commit the generated file:
+
+```bash
+npx rhythmguard audit ./src --write-baseline
+git add .rhythmguard-baseline.json
+```
+
+The baseline records known findings. Future checks can compare against it without forcing a full cleanup first.
+
+## 2. Add the GitHub Actions job
+
+```yaml
+name: Rhythmguard
+
+on:
+  pull_request:
+
+jobs:
+  rhythmguard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Audit design-system drift
+        run: |
+          npx rhythmguard audit ./src \
+            --since origin/${{ github.base_ref }} \
+            --since-baseline \
+            --fail-on-new-drift \
+            --format markdown \
+            --output rhythmguard-report.md
+
+      - name: Upload Rhythmguard report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rhythmguard-report
+          path: rhythmguard-report.md
+```
+
+For repos without a committed baseline, remove `--since-baseline` and `--fail-on-new-drift`, then gate with `--max-findings 0` only after the first cleanup pass.
+
+## 3. Post a PR comment
+
+The markdown output is designed for review comments:
+
+```bash
+npx rhythmguard audit ./src --format markdown --output rhythmguard-report.md
+gh pr comment "$PR_NUMBER" --body-file rhythmguard-report.md
+```
+
+If you prefer generated artifacts, use HTML:
+
+```bash
+npx rhythmguard audit ./src --format html --output rhythmguard-report.html
+```
+
+## 4. Tighten gradually
+
+Recommended rollout order:
+
+1. `--format markdown` only: visibility without blocking.
+2. `--write-baseline`: freeze existing drift.
+3. `--since-baseline --fail-on-new-drift`: block new drift only.
+4. `--min-cleanliness 95` or `--max-findings 0`: move from regression blocking to active cleanup.
+
+Keep motion checks opt-in until the team has reviewed local false positives:
+
+```bash
+npx rhythmguard audit ./src --include-motion --format markdown
+```

--- a/docs/MOTION_DEFAULTS_EVIDENCE.md
+++ b/docs/MOTION_DEFAULTS_EVIDENCE.md
@@ -1,0 +1,54 @@
+# Motion Defaults Evidence
+
+Date: 2026-06-16
+
+Question: should `rhythmguard/use-motion-scale` move from opt-in to a recommended profile?
+
+Decision: keep motion checks opt-in for now.
+
+## Local Evidence
+
+Commands were run from this repository with the current source:
+
+```bash
+node src/cli/index.js audit <target> --include-motion --format json --output <tmp-file>
+```
+
+| Target | Files scanned | CSS findings | Tailwind findings | Motion findings | Notes |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `digitaltableteur-nextjs/app` | 138 | 225 | 0 | 5 | Useful signal, but includes two `0.01ms` reduced-motion declarations that are likely intentional accessibility overrides. |
+| `aegis-design-os` | 267 | 328 | 0 | 0 | No observed motion drift in the current tree. |
+| `DSharp.DesignSystem/packages` | 1,424 | 214 | 13 | 10 | Half the sampled findings came from generated `storybook-static` output, which should be ignored before gating. |
+| `DSharp.DesignSystem/packages/react/src` | 403 | 0 | 5 | 5 | Source-only scan reports real motion design-system decisions: `2.1s`, `-1.05s`, and Material-style cubic-bezier curves. |
+
+## Interpretation
+
+The motion rule is finding real design-system questions, especially long-running durations and raw easing curves. That is useful for audit review and cleanup planning.
+
+It is not ready for the default `recommended` profile because:
+
+- Generated assets can add noise unless teams configure ignores.
+- Reduced-motion accessibility overrides such as `0.01ms` need a documented allowance before default gating.
+- Raw cubic-bezier values can be intentional brand motion primitives until a token map exists.
+
+## Recommended Next Gate
+
+Keep motion available through:
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/motion"]
+}
+```
+
+and through audit:
+
+```bash
+npx rhythmguard audit ./src --include-motion
+```
+
+Revisit default inclusion after:
+
+1. Reduced-motion override patterns are documented or configurable.
+2. Generated asset ignores are prominent in adoption recipes.
+3. At least three source-only audits show motion findings with low false-positive review cost.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Rhythmguard Playground — Token governance for CSS and Tailwind</title>
-<meta name="description" content="Paste CSS, see spacing scale violations and token opportunities in real time. No install, no config — just try it." />
-<meta property="og:title" content="Rhythmguard Playground" />
-<meta property="og:description" content="Paste CSS, see spacing scale violations in real time." />
+<title>Rhythmguard Playground + Audit 2.0 — Token governance for CSS and Tailwind</title>
+<meta name="description" content="Try CSS spacing and token checks in the browser, then run Rhythmguard Audit 2.0 locally for stable JSON, HTML reports, baselines, and CI gates." />
+<meta property="og:title" content="Rhythmguard Playground + Audit 2.0" />
+<meta property="og:description" content="Try CSS spacing and token checks in the browser, then run Audit 2.0 locally for reports and CI." />
 <meta property="og:image" content="https://raw.githubusercontent.com/petrilahdelma/stylelint-plugin-rhythmguard/main/assets/rhythmguard-banner.svg" />
 <meta name="twitter:card" content="summary_large_image" />
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230C1117'/%3E%3Ctext y='70' x='10' font-family='monospace' font-size='48' fill='white'%3E%7CR%7C%3C/text%3E%3C/svg%3E" />
@@ -49,6 +49,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 24px;
+    flex-wrap: wrap;
   }
 
   .brand {
@@ -72,6 +73,8 @@
     display: flex;
     gap: 16px;
     align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
   }
 
   nav.top-nav a {
@@ -81,6 +84,60 @@
   }
 
   nav.top-nav a:hover { color: var(--fg); }
+
+  .release-strip {
+    border-bottom: 1px solid var(--border);
+    padding: 12px 24px;
+    background: var(--bg-panel);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 18px;
+    flex-wrap: wrap;
+  }
+
+  .release-copy {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    flex-wrap: wrap;
+    color: var(--fg-muted);
+  }
+
+  .release-eyebrow {
+    color: var(--ok);
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  .release-copy strong {
+    color: var(--fg);
+    font-weight: 650;
+  }
+
+  .release-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .release-actions a {
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 5px 9px;
+    text-decoration: none;
+    font-size: 12px;
+    white-space: nowrap;
+  }
+
+  .release-actions a:hover {
+    border-color: var(--fg);
+    background: rgba(255, 255, 255, 0.04);
+  }
 
   main {
     display: grid;
@@ -339,8 +396,18 @@
     color: var(--fg);
   }
 
+  .cli-stack {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
   @media (max-width: 900px) {
     main { grid-template-columns: 1fr; }
+    header.top { align-items: flex-start; }
+    .brand { flex-wrap: wrap; }
+    .release-strip { align-items: flex-start; }
   }
 
   ::-webkit-scrollbar { width: 10px; height: 10px; }
@@ -359,9 +426,22 @@
     <nav class="top-nav">
       <a href="https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard" target="_blank" rel="noopener">GitHub</a>
       <a href="https://www.npmjs.com/package/stylelint-plugin-rhythmguard" target="_blank" rel="noopener">npm</a>
+      <a href="https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/MIGRATING_TO_2.md" target="_blank" rel="noopener">2.0 migration</a>
       <a href="https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/FRAMEWORKS.md" target="_blank" rel="noopener">Frameworks</a>
     </nav>
   </header>
+
+  <section class="release-strip" aria-label="Rhythmguard Audit 2.0 release">
+    <div class="release-copy">
+      <span class="release-eyebrow">Audit 2.0</span>
+      <strong>Stable repo audits are now the CLI path.</strong>
+      <span>This playground checks pasted CSS; local runs add JSON contracts, HTML reports, baselines, token sources, motion checks, and CI gates.</span>
+    </div>
+    <div class="release-actions">
+      <a href="https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/AUDIT_2_VALIDATION.md" target="_blank" rel="noopener">Audit guide</a>
+      <a href="https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/MIGRATING_TO_2.md" target="_blank" rel="noopener">Migration notes</a>
+    </div>
+  </section>
 
   <main>
     <section class="pane">
@@ -421,9 +501,11 @@
   </main>
 
   <footer class="bottom">
-    <div>
-      Using this locally? Install the plugin and run
+    <div class="cli-stack">
+      <span>Using this locally?</span>
       <span class="cli-hint">npx rhythmguard audit ./src</span>
+      <span class="cli-hint">npx rhythmguard audit ./src --format html --output rhythmguard-report.html</span>
+      <span class="cli-hint">npx rhythmguard audit --schema</span>
     </div>
     <div>
       <a href="https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/issues" target="_blank" rel="noopener">Report an issue</a>

--- a/examples/audit-dashboard.mjs
+++ b/examples/audit-dashboard.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { createAuditReport, toAuditContractReport } from 'stylelint-plugin-rhythmguard/audit';
+
+function readOption(argv, name, fallback) {
+  const index = argv.indexOf(name);
+  if (index === -1 || !argv[index + 1] || argv[index + 1].startsWith('--')) {
+    return fallback;
+  }
+
+  return argv[index + 1];
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function collectFindings(findings) {
+  return [
+    ...(findings.css || []),
+    ...(findings.tailwind || []),
+    ...(findings.motion || []),
+  ];
+}
+
+function renderMetric(label, value) {
+  return `<article class="metric"><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong></article>`;
+}
+
+function renderDashboard(contract) {
+  const findings = collectFindings(contract.findings);
+  const topFindings = findings.slice(0, 12);
+  const cleanliness = contract.contracts.scale.cleanliness;
+  const score = typeof cleanliness === 'number' ? cleanliness : contract.summary.cleanliness;
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rhythmguard Audit Dashboard</title>
+<style>
+body{font-family:Inter,ui-sans-serif,system-ui,sans-serif;margin:0;background:#f7f8fa;color:#111827;}
+main{max-width:1120px;margin:0 auto;padding:32px 20px;}
+h1{font-size:28px;margin:0 0 8px;}
+p{color:#4b5563;margin:0 0 24px;}
+.metrics{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;margin:24px 0;}
+.metric{border:1px solid #d8dde5;background:#fff;border-radius:8px;padding:16px;}
+.metric span{display:block;color:#6b7280;font-size:12px;text-transform:uppercase;}
+.metric strong{display:block;font-size:28px;margin-top:8px;}
+table{width:100%;border-collapse:collapse;background:#fff;border:1px solid #d8dde5;border-radius:8px;overflow:hidden;}
+th,td{text-align:left;border-bottom:1px solid #e5e7eb;padding:10px 12px;font-size:14px;}
+th{background:#f1f5f9;color:#374151;font-size:12px;text-transform:uppercase;}
+tr:last-child td{border-bottom:0;}
+code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;}
+</style>
+</head>
+<body>
+<main>
+<h1>Rhythmguard Audit Dashboard</h1>
+<p>${escapeHtml(contract.command.directory)} · ${escapeHtml(contract.command.scanScope)} · schema ${escapeHtml(contract.schemaVersion)}</p>
+<section class="metrics">
+${renderMetric('Scale cleanliness', `${score ?? 100}%`)}
+${renderMetric('CSS files', contract.scanned.cssFiles)}
+${renderMetric('Template files', contract.scanned.templateFiles)}
+${renderMetric('Findings', findings.length)}
+</section>
+<table>
+<thead><tr><th>Type</th><th>File</th><th>Value</th><th>Message</th></tr></thead>
+<tbody>
+${topFindings.map((finding) => `<tr><td>${escapeHtml(finding.type)}</td><td><code>${escapeHtml(finding.file)}</code></td><td><code>${escapeHtml(finding.value || finding.rawValue || '')}</code></td><td>${escapeHtml(finding.message || '')}</td></tr>`).join('\n')}
+</tbody>
+</table>
+</main>
+</body>
+</html>`;
+}
+
+const argv = process.argv.slice(2);
+const dir = readOption(argv, '--dir', argv.find((arg) => !arg.startsWith('--')) || 'src');
+const output = readOption(argv, '--output', 'rhythmguard-dashboard.html');
+const includeMotion = argv.includes('--include-motion');
+
+const report = await createAuditReport({ dir, includeMotion });
+const contract = toAuditContractReport(report);
+const outputPath = path.resolve(process.cwd(), output);
+
+fs.writeFileSync(outputPath, renderDashboard(contract));
+process.stdout.write(`Wrote ${outputPath}\n`);

--- a/examples/audit-figma-export.mjs
+++ b/examples/audit-figma-export.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { createAuditReport, toAuditContractReport } from 'stylelint-plugin-rhythmguard/audit';
+
+function readOption(argv, name, fallback) {
+  const index = argv.indexOf(name);
+  if (index === -1 || !argv[index + 1] || argv[index + 1].startsWith('--')) {
+    return fallback;
+  }
+
+  return argv[index + 1];
+}
+
+function collectFindings(findings) {
+  return [
+    ...(findings.css || []),
+    ...(findings.tailwind || []),
+    ...(findings.motion || []),
+  ];
+}
+
+function countBy(items, getKey) {
+  const counts = new Map();
+  for (const item of items) {
+    const key = getKey(item) || 'unknown';
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([label, value]) => ({ label, value }));
+}
+
+function buildFigmaPayload(contract) {
+  const findings = collectFindings(contract.findings);
+  const cleanliness = contract.contracts.scale.cleanliness;
+
+  return {
+    schema: 'rhythmguard.figma-export.v1',
+    generatedAt: new Date().toISOString(),
+    source: {
+      directory: contract.command.directory,
+      scanScope: contract.command.scanScope,
+      schemaVersion: contract.schemaVersion,
+    },
+    summaryCards: [
+      {
+        label: 'Scale cleanliness',
+        value: `${typeof cleanliness === 'number' ? cleanliness : contract.summary.cleanliness ?? 100}%`,
+      },
+      { label: 'CSS files', value: contract.scanned.cssFiles },
+      { label: 'Template files', value: contract.scanned.templateFiles },
+      { label: 'Findings', value: findings.length },
+    ],
+    charts: {
+      findingsByType: countBy(findings, (finding) => finding.type),
+      findingsByFile: countBy(findings, (finding) => finding.file).slice(0, 10),
+    },
+    findings: findings.slice(0, 25).map((finding) => ({
+      file: finding.file,
+      line: finding.line || null,
+      message: finding.message || '',
+      type: finding.type,
+      value: finding.value || finding.rawValue || null,
+    })),
+  };
+}
+
+const argv = process.argv.slice(2);
+const dir = readOption(argv, '--dir', argv.find((arg) => !arg.startsWith('--')) || 'src');
+const output = readOption(argv, '--output', 'rhythmguard-figma-export.json');
+const includeMotion = argv.includes('--include-motion');
+
+const report = await createAuditReport({ dir, includeMotion });
+const contract = toAuditContractReport(report);
+const outputPath = path.resolve(process.cwd(), output);
+
+fs.writeFileSync(outputPath, `${JSON.stringify(buildFigmaPayload(contract), null, 2)}\n`);
+process.stdout.write(`Wrote ${outputPath}\n`);

--- a/package.json
+++ b/package.json
@@ -20,76 +20,95 @@
   ],
   "type": "commonjs",
   "main": "src/index.js",
+  "types": "./types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "require": "./src/index.js",
       "import": "./src/index.mjs"
     },
     "./configs/recommended": {
+      "types": "./types/config.d.ts",
       "require": "./src/configs/recommended.js",
       "import": "./src/configs/recommended.mjs"
     },
     "./configs/strict": {
+      "types": "./types/config.d.ts",
       "require": "./src/configs/strict.js",
       "import": "./src/configs/strict.mjs"
     },
     "./configs/tailwind": {
+      "types": "./types/config.d.ts",
       "require": "./src/configs/tailwind.js",
       "import": "./src/configs/tailwind.mjs"
     },
     "./configs/expanded": {
+      "types": "./types/config.d.ts",
       "require": "./src/configs/expanded.js",
       "import": "./src/configs/expanded.mjs"
     },
     "./configs/logical": {
+      "types": "./types/config.d.ts",
       "require": "./src/configs/logical.js",
       "import": "./src/configs/logical.mjs"
     },
     "./configs/migration": {
+      "types": "./types/config.d.ts",
       "require": "./src/configs/migration.js",
       "import": "./src/configs/migration.mjs"
     },
     "./configs/motion": {
+      "types": "./types/config.d.ts",
       "require": "./src/configs/motion.js",
       "import": "./src/configs/motion.mjs"
     },
     "./configs/react-tailwind": {
+      "types": "./types/config.d.ts",
       "require": "./src/configs/react-tailwind.js",
       "import": "./src/configs/react-tailwind.mjs"
     },
     "./presets": {
+      "types": "./types/presets.d.ts",
       "require": "./src/presets/index.js",
       "import": "./src/presets/index.mjs"
     },
     "./audit": {
+      "types": "./types/audit.d.ts",
       "require": "./src/audit/index.js",
       "import": "./src/audit/index.mjs"
     },
     "./rules/use-scale": {
+      "types": "./types/rule.d.ts",
       "require": "./src/rules/use-scale/index.js",
       "import": "./src/rules/use-scale/index.mjs"
     },
     "./rules/prefer-token": {
+      "types": "./types/rule.d.ts",
       "require": "./src/rules/prefer-token/index.js",
       "import": "./src/rules/prefer-token/index.mjs"
     },
     "./rules/no-offscale-transform": {
+      "types": "./types/rule.d.ts",
       "require": "./src/rules/no-offscale-transform/index.js",
       "import": "./src/rules/no-offscale-transform/index.mjs"
     },
     "./rules/use-motion-scale": {
+      "types": "./types/rule.d.ts",
       "require": "./src/rules/use-motion-scale/index.js",
       "import": "./src/rules/use-motion-scale/index.mjs"
     },
     "./eslint": {
+      "types": "./types/eslint.d.ts",
       "require": "./src/eslint/index.js",
       "import": "./src/eslint/index.mjs"
     }
   },
   "files": [
+    "examples",
     "scales",
     "schemas",
     "src",
+    "types",
     "README.md",
     "CHANGELOG.md",
     "CONTRIBUTING.md",

--- a/src/cli/init.js
+++ b/src/cli/init.js
@@ -4,17 +4,39 @@ const fs = require('node:fs');
 const path = require('node:path');
 const readline = require('node:readline');
 
-function ask(question) {
+function createPrompter() {
+  if (!process.stdin.isTTY) {
+    const answers = fs.readFileSync(0, 'utf8').split(/\r?\n/);
+    let answerIndex = 0;
+
+    return {
+      ask(question) {
+        process.stdout.write(question);
+        const answer = answers[answerIndex] || '';
+        answerIndex += 1;
+        return Promise.resolve(answer.trim().toLowerCase());
+      },
+      close() {},
+    };
+  }
+
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
   });
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
+
+  return {
+    ask(question) {
+      return new Promise((resolve) => {
+        rl.question(question, (answer) => {
+          resolve(answer.trim().toLowerCase());
+        });
+      });
+    },
+    close() {
       rl.close();
-      resolve(answer.trim().toLowerCase());
-    });
-  });
+    },
+  };
 }
 
 function detect() {
@@ -80,49 +102,55 @@ function selectProfile(stack) {
 }
 
 async function run() {
-  process.stdout.write('\nRhythmguard Init\n\n');
+  const prompter = createPrompter();
 
-  const stack = detect();
+  try {
+    process.stdout.write('\nRhythmguard Init\n\n');
 
-  // Report detection
-  const detected = [];
-  if (stack.tailwind) detected.push('Tailwind CSS');
-  if (stack.nextjs) detected.push('Next.js');
-  if (detected.length > 0) {
-    process.stdout.write(`Detected: ${detected.join(', ')}\n`);
-  } else {
-    process.stdout.write('Detected: plain CSS project\n');
-  }
+    const stack = detect();
 
-  // Warn about existing config
-  if (stack.hasExistingConfig) {
-    process.stdout.write('\n⚠ Existing Stylelint config found.\n');
-    const answer = await ask('Overwrite? (y/n) ');
+    // Report detection
+    const detected = [];
+    if (stack.tailwind) detected.push('Tailwind CSS');
+    if (stack.nextjs) detected.push('Next.js');
+    if (detected.length > 0) {
+      process.stdout.write(`Detected: ${detected.join(', ')}\n`);
+    } else {
+      process.stdout.write('Detected: plain CSS project\n');
+    }
+
+    // Warn about existing config
+    if (stack.hasExistingConfig) {
+      process.stdout.write('\n⚠ Existing Stylelint config found.\n');
+      const answer = await prompter.ask('Overwrite? (y/n) ');
+      if (answer !== 'y' && answer !== 'yes') {
+        process.stdout.write('Aborted.\n');
+        process.exit(0);
+      }
+    }
+
+    const profile = selectProfile(stack);
+    process.stdout.write(`\nProfile: ${profile}\n`);
+
+    const answer = await prompter.ask('Write .stylelintrc.json? (y/n) ');
     if (answer !== 'y' && answer !== 'yes') {
       process.stdout.write('Aborted.\n');
       process.exit(0);
     }
+
+    const config = {
+      extends: [`stylelint-plugin-rhythmguard/configs/${profile}`],
+    };
+
+    const configPath = path.join(process.cwd(), '.stylelintrc.json');
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+
+    process.stdout.write(`\n✓ Wrote ${configPath}\n`);
+    process.stdout.write(`\nNext steps:\n`);
+    process.stdout.write(`  npx stylelint "src/**/*.css"\n\n`);
+  } finally {
+    prompter.close();
   }
-
-  const profile = selectProfile(stack);
-  process.stdout.write(`\nProfile: ${profile}\n`);
-
-  const answer = await ask('Write .stylelintrc.json? (y/n) ');
-  if (answer !== 'y' && answer !== 'yes') {
-    process.stdout.write('Aborted.\n');
-    process.exit(0);
-  }
-
-  const config = {
-    extends: [`stylelint-plugin-rhythmguard/configs/${profile}`],
-  };
-
-  const configPath = path.join(process.cwd(), '.stylelintrc.json');
-  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
-
-  process.stdout.write(`\n✓ Wrote ${configPath}\n`);
-  process.stdout.write(`\nNext steps:\n`);
-  process.stdout.write(`  npx stylelint "src/**/*.css"\n\n`);
 }
 
 run();

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -2,9 +2,11 @@
 
 const path = require('node:path');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
 const test = require('node:test');
 const { pathToFileURL } = require('node:url');
 
+const packageJson = require('../package.json');
 const plugin = require('../src/index');
 
 test('plugin exports rules, shared configs, presets, and eslint companion', () => {
@@ -70,4 +72,18 @@ test('esm entrypoint exposes default plugin object', async () => {
   assert.ok(esm.eslint.rules['tailwind-class-use-scale']);
   assert.ok(esm.eslint.rules['tailwind-class-use-motion-scale']);
   assert.ok(esm.audit.createAuditReport);
+});
+
+test('package exports expose TypeScript declaration paths', () => {
+  assert.equal(packageJson.types, './types/index.d.ts');
+  assert.ok(packageJson.files.includes('types'));
+
+  for (const [exportName, descriptor] of Object.entries(packageJson.exports)) {
+    assert.equal(typeof descriptor.types, 'string', `${exportName} is missing types`);
+    assert.equal(
+      fs.existsSync(path.join(__dirname, '..', descriptor.types)),
+      true,
+      `${exportName} types path does not exist`,
+    );
+  }
 });

--- a/test/init-cli.test.js
+++ b/test/init-cli.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const cliPath = path.join(__dirname, '..', 'src', 'cli', 'index.js');
+
+function makeFixture(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `rhythmguard-init-${prefix}-`));
+}
+
+function readGeneratedConfig(cwd) {
+  return JSON.parse(fs.readFileSync(path.join(cwd, '.stylelintrc.json'), 'utf8'));
+}
+
+function runInit(cwd, input = 'y\n') {
+  return spawnSync(process.execPath, [cliPath, 'init'], {
+    cwd,
+    encoding: 'utf8',
+    input,
+  });
+}
+
+test('init writes recommended config for plain CSS projects', () => {
+  const fixtureDir = makeFixture('plain');
+
+  const result = runInit(fixtureDir);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Detected: plain CSS project/);
+  assert.match(result.stdout, /Profile: recommended/);
+  assert.deepEqual(readGeneratedConfig(fixtureDir), {
+    extends: ['stylelint-plugin-rhythmguard/configs/recommended'],
+  });
+});
+
+test('init writes tailwind config when Tailwind is installed', () => {
+  const fixtureDir = makeFixture('tailwind');
+  fs.writeFileSync(
+    path.join(fixtureDir, 'package.json'),
+    JSON.stringify({ devDependencies: { tailwindcss: '^4.0.0' } }),
+  );
+
+  const result = runInit(fixtureDir);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Detected: Tailwind CSS/);
+  assert.match(result.stdout, /Profile: tailwind/);
+  assert.deepEqual(readGeneratedConfig(fixtureDir), {
+    extends: ['stylelint-plugin-rhythmguard/configs/tailwind'],
+  });
+});
+
+test('init writes react-tailwind config for Next.js Tailwind projects', () => {
+  const fixtureDir = makeFixture('next-tailwind');
+  fs.writeFileSync(path.join(fixtureDir, 'next.config.mjs'), 'export default {};\n');
+  fs.writeFileSync(path.join(fixtureDir, 'tailwind.config.mjs'), 'export default {};\n');
+
+  const result = runInit(fixtureDir);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Detected: Tailwind CSS, Next\.js/);
+  assert.match(result.stdout, /Profile: react-tailwind/);
+  assert.deepEqual(readGeneratedConfig(fixtureDir), {
+    extends: ['stylelint-plugin-rhythmguard/configs/react-tailwind'],
+  });
+});
+
+test('init aborts without overwriting an existing Stylelint config', () => {
+  const fixtureDir = makeFixture('decline-overwrite');
+  const configPath = path.join(fixtureDir, '.stylelintrc.json');
+  fs.writeFileSync(configPath, '{"extends":["existing"]}\n');
+
+  const result = runInit(fixtureDir, 'n\n');
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Existing Stylelint config found/);
+  assert.match(result.stdout, /Aborted/);
+  assert.equal(fs.readFileSync(configPath, 'utf8'), '{"extends":["existing"]}\n');
+});
+
+test('init overwrites an existing Stylelint config after confirmation', () => {
+  const fixtureDir = makeFixture('overwrite');
+  const configPath = path.join(fixtureDir, '.stylelintrc.json');
+  fs.writeFileSync(configPath, '{"extends":["existing"]}\n');
+
+  const result = runInit(fixtureDir, 'yes\nyes\n');
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Existing Stylelint config found/);
+  assert.match(result.stdout, /Profile: recommended/);
+  assert.deepEqual(readGeneratedConfig(fixtureDir), {
+    extends: ['stylelint-plugin-rhythmguard/configs/recommended'],
+  });
+});

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -1,0 +1,156 @@
+export type AuditTokenKind =
+  | "all"
+  | "motion"
+  | "radius"
+  | "size"
+  | "spacing"
+  | "typography";
+
+export type AuditTokenSourceFormat =
+  | "auto"
+  | "css"
+  | "dtcg"
+  | "flat-json"
+  | "style-dictionary";
+
+export interface AuditTokenSource {
+  baseDir?: string;
+  file?: string;
+  format?: AuditTokenSourceFormat;
+  path?: string;
+}
+
+export interface AuditOptions {
+  baseFontSize?: number;
+  baselinePath?: string;
+  config?: string;
+  dir?: string;
+  failOnNewDrift?: boolean;
+  format?: "json" | "json-v1" | "markdown" | "text" | "html";
+  ignorePath?: string;
+  ignorePatterns?: string[];
+  includeMotion?: boolean;
+  maxFindings?: number;
+  minCleanliness?: number;
+  output?: string;
+  scale?: Array<number | string>;
+  since?: string;
+  sinceBaseline?: boolean;
+  staged?: boolean;
+  tokenCandidateMinCount?: number;
+  tokenKind?: AuditTokenKind;
+  tokenSources?: AuditTokenSource[];
+  writeBaseline?: boolean;
+}
+
+export interface AuditSummary {
+  cleanliness: number;
+  filesWithFindings: number;
+  findingCount: number;
+  motionFindingCount?: number;
+  tokenOpportunityCount?: number;
+  [key: string]: unknown;
+}
+
+export interface AuditScanned {
+  cssFiles: number;
+  templateFiles: number;
+  totalFiles?: number;
+  [key: string]: unknown;
+}
+
+export interface AuditFinding {
+  column?: number;
+  file: string;
+  key?: string;
+  line?: number;
+  message: string;
+  property?: string;
+  rule?: string;
+  type: string;
+  value?: string;
+  [key: string]: unknown;
+}
+
+export interface AuditBaselineComparison {
+  baselineFindings: number;
+  newFindings: AuditFinding[];
+  newFindingsCount: number;
+  resolvedFindings: AuditFinding[];
+  resolvedFindingsCount: number;
+  [key: string]: unknown;
+}
+
+export interface AuditReport {
+  baseline?: AuditBaselineComparison | null;
+  config?: string | null;
+  directory: string;
+  findings: {
+    css: AuditFinding[];
+    motion: AuditFinding[];
+    tailwind: AuditFinding[];
+  };
+  scanned: AuditScanned;
+  summary: AuditSummary;
+  [key: string]: unknown;
+}
+
+export interface AuditContractReport {
+  baseline: AuditBaselineComparison | null;
+  command: {
+    config?: string | null;
+    directory: string;
+    scanScope: string;
+  };
+  contracts: {
+    motion?: unknown;
+    scale: {
+      cleanliness?: unknown;
+      offScaleValues?: unknown;
+      tokenOpportunities?: unknown;
+    };
+    tokens?: unknown;
+  };
+  findings: unknown;
+  scanned: AuditScanned;
+  schemaVersion: "2.0";
+  summary: AuditSummary;
+}
+
+export interface TokenSourceReport {
+  file: string;
+  format: AuditTokenSourceFormat;
+  requestedFormat: AuditTokenSourceFormat;
+  tokenCount: number;
+  warnings: string[];
+}
+
+export interface ParsedTokenSources {
+  definitions: Map<string, unknown>;
+  sources: TokenSourceReport[];
+  warnings: string[];
+}
+
+export const AUDIT_JSON_SCHEMA: Readonly<Record<string, unknown>>;
+
+export function createAuditReport(options?: AuditOptions): Promise<AuditReport>;
+
+export function loadAuditConfig(options?: AuditOptions): Record<string, unknown>;
+
+export function parseTokenSources(options?: {
+  baseFontSize?: number;
+  sources?: AuditTokenSource[];
+  tokenKind?: AuditTokenKind;
+}): ParsedTokenSources;
+
+export function toAuditContractReport(report: AuditReport): AuditContractReport;
+
+declare const audit: {
+  AUDIT_JSON_SCHEMA: typeof AUDIT_JSON_SCHEMA;
+  createAuditReport: typeof createAuditReport;
+  loadAuditConfig: typeof loadAuditConfig;
+  parseTokenSources: typeof parseTokenSources;
+  toAuditContractReport: typeof toAuditContractReport;
+};
+
+export default audit;

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -1,0 +1,5 @@
+import type { RhythmguardStylelintConfig } from "./shared";
+
+declare const config: RhythmguardStylelintConfig;
+
+export default config;

--- a/types/eslint.d.ts
+++ b/types/eslint.d.ts
@@ -1,0 +1,10 @@
+import type { RhythmguardEslintPlugin } from "./shared";
+
+export type { EslintRuleModule, RhythmguardEslintPlugin } from "./shared";
+
+export const configs: RhythmguardEslintPlugin["configs"];
+export const rules: RhythmguardEslintPlugin["rules"];
+
+declare const plugin: RhythmguardEslintPlugin;
+
+export default plugin;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,65 @@
+import type {
+  RhythmguardEslintPlugin,
+  RhythmguardPresets,
+  RhythmguardStylelintConfig,
+} from "./shared";
+import type * as auditApi from "./audit";
+import type { StylelintRuleModule } from "./rule";
+
+export type {
+  EslintRuleModule,
+  RhythmguardEslintPlugin,
+  RhythmguardPresets,
+  RhythmguardRuleConfig,
+  RhythmguardRuleOptions,
+  RhythmguardStylelintConfig,
+  ScalePresetMetadata,
+  ScaleValue,
+} from "./shared";
+export type {
+  AuditBaselineComparison,
+  AuditContractReport,
+  AuditFinding,
+  AuditOptions,
+  AuditReport,
+  AuditScanned,
+  AuditSummary,
+  AuditTokenKind,
+  AuditTokenSource,
+  AuditTokenSourceFormat,
+  ParsedTokenSources,
+  TokenSourceReport,
+} from "./audit";
+export type { StylelintRuleModule } from "./rule";
+
+export interface RhythmguardPlugin extends Array<StylelintRuleModule> {
+  audit: typeof auditApi;
+  configs: {
+    expanded: RhythmguardStylelintConfig;
+    logical: RhythmguardStylelintConfig;
+    migration: RhythmguardStylelintConfig;
+    motion: RhythmguardStylelintConfig;
+    recommended: RhythmguardStylelintConfig;
+    strict: RhythmguardStylelintConfig;
+    tailwind: RhythmguardStylelintConfig;
+    [configName: string]: RhythmguardStylelintConfig;
+  };
+  eslint: RhythmguardEslintPlugin;
+  presets: RhythmguardPresets;
+  rules: {
+    "rhythmguard/no-offscale-transform": StylelintRuleModule;
+    "rhythmguard/prefer-token": StylelintRuleModule;
+    "rhythmguard/use-motion-scale": StylelintRuleModule;
+    "rhythmguard/use-scale": StylelintRuleModule;
+    [ruleName: string]: StylelintRuleModule;
+  };
+}
+
+declare const plugin: RhythmguardPlugin;
+
+export const audit: typeof auditApi;
+export const configs: RhythmguardPlugin["configs"];
+export const eslint: RhythmguardEslintPlugin;
+export const presets: RhythmguardPresets;
+export const rules: RhythmguardPlugin["rules"];
+export default plugin;

--- a/types/presets.d.ts
+++ b/types/presets.d.ts
@@ -1,0 +1,14 @@
+import type { RhythmguardPresets } from "./shared";
+
+export type { RhythmguardPresets, ScalePresetMetadata } from "./shared";
+
+export const communityScaleMetadata: RhythmguardPresets["communityScaleMetadata"];
+export const getCommunityScaleMetadata: RhythmguardPresets["getCommunityScaleMetadata"];
+export const getScalePreset: RhythmguardPresets["getScalePreset"];
+export const listCommunityScalePresetNames: RhythmguardPresets["listCommunityScalePresetNames"];
+export const listScalePresetNames: RhythmguardPresets["listScalePresetNames"];
+export const scales: RhythmguardPresets["scales"];
+
+declare const presets: RhythmguardPresets;
+
+export default presets;

--- a/types/rule.d.ts
+++ b/types/rule.d.ts
@@ -1,0 +1,20 @@
+import type { RhythmguardRuleOptions } from "./shared";
+
+export interface StylelintRuleModule {
+  messages: Record<string, unknown>;
+  meta: {
+    fixable?: boolean;
+    url?: string;
+    [key: string]: unknown;
+  };
+  ruleName: string;
+  [key: string]: unknown;
+}
+
+declare const rule: StylelintRuleModule;
+
+export const messages: StylelintRuleModule["messages"];
+export const meta: StylelintRuleModule["meta"];
+export const ruleName: string;
+export type { RhythmguardRuleOptions };
+export default rule;

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -1,0 +1,66 @@
+export type ScaleValue = number | string;
+
+export type RuleSeverity = boolean | "always" | "never";
+
+export interface RhythmguardRuleOptions {
+  baseFontSize?: number;
+  customScale?: ScaleValue[];
+  includeMathFunctions?: boolean;
+  preset?: string;
+  properties?: Array<string | RegExp>;
+  scale?: ScaleValue[];
+  tokenMap?: Record<string, string>;
+  tokenMapFile?: string;
+  tokenMapFromCssCustomProperties?: boolean;
+  tokenMapFromTailwindSpacing?: boolean;
+  tokenPattern?: string;
+}
+
+export type RhythmguardRuleConfig =
+  | null
+  | RuleSeverity
+  | [RuleSeverity, RhythmguardRuleOptions];
+
+export interface RhythmguardStylelintConfig {
+  customSyntax?: string;
+  extends?: string | string[];
+  ignoreFiles?: string | string[];
+  plugins?: string[];
+  rules?: Record<string, RhythmguardRuleConfig>;
+}
+
+export interface ScalePresetMetadata {
+  aliases?: string[];
+  base?: number;
+  description?: string;
+  name?: string;
+  values?: number[];
+  [key: string]: unknown;
+}
+
+export interface RhythmguardPresets {
+  communityScaleMetadata: Record<string, ScalePresetMetadata>;
+  getCommunityScaleMetadata(name: string): ScalePresetMetadata | undefined;
+  getScalePreset(name: string): readonly number[] | undefined;
+  listCommunityScalePresetNames(): string[];
+  listScalePresetNames(): string[];
+  scales: Record<string, readonly number[]>;
+}
+
+export interface EslintRuleModule {
+  meta: Record<string, unknown>;
+  create(context: unknown): Record<string, unknown>;
+}
+
+export interface RhythmguardEslintPlugin {
+  configs: {
+    recommended: {
+      rules: Record<string, "off" | "warn" | "error" | number>;
+    };
+  };
+  rules: {
+    "tailwind-class-use-motion-scale": EslintRuleModule;
+    "tailwind-class-use-scale": EslintRuleModule;
+    [ruleName: string]: EslintRuleModule;
+  };
+}


### PR DESCRIPTION
## Summary
- adds direct `rhythmguard init` CLI coverage and fixes piped multi-prompt input
- publishes TypeScript declarations for root, config, rule, preset, ESLint, and audit exports
- adds CI rollout docs, Audit API dashboard/Figma export examples, and motion-default evidence
- updates the GitHub Pages playground copy to point users toward Audit 2.0 CLI workflows

## Verification
- `npm run lint`
- `npm test` (113/113)
- `npm run test:coverage`
- `npm run scales:validate`
- `npm run test:pack-smoke`
- `npm run test:npm-smoke`
- `npm pack --json --dry-run`
- `node examples/audit-dashboard.mjs --dir src --output /tmp/rhythmguard-dashboard.html`
- `node examples/audit-figma-export.mjs --dir src --include-motion --output /tmp/rhythmguard-figma-export.json`
- opened `docs/index.html` over localhost and verified the Audit 2.0 page title loads

## Notes
Motion remains opt-in. Local real-repo scans found useful source signal, but also generated-asset and reduced-motion noise that makes default-profile gating premature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit dashboard and Figma-friendly export functionality for design-system drift reports.
  * Published TypeScript type declarations for improved IDE support.

* **Documentation**
  * Added CI adoption recipe for integrating into existing codebases.
  * Added audit API examples and motion defaults evidence documentation.
  * Updated marketing site with Audit 2.0 release information and expanded CLI guidance.

* **Improvements**
  * Enhanced CLI init command with improved input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->