### PR TITLE
[codex] release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-06-17
+
+### Added
+
+- Added TypeScript declaration files for the public plugin, config, rule, preset, ESLint companion, and Audit 2.0 API exports.
+- Added dependency-free Audit 2.0 dashboard and Figma-friendly export examples under `examples/`.
+- Added CI adoption and motion-default evidence docs for safer baseline-based rollout.
+
+### Fixed
+
+- Fixed `rhythmguard init` scripted input handling so multiple prompts work reliably in piped/CI contexts.
+
 ## [2.0.0] - 2026-05-23
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stylelint-plugin-rhythmguard",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint-plugin-rhythmguard",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "known-css-properties": "^0.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-rhythmguard",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Token governance for CSS and Tailwind — enforce spacing scales, require design tokens, catch arbitrary values",
   "bin": {
     "rhythmguard": "src/cli/index.js"


### PR DESCRIPTION
## Summary
- bumps package metadata from 2.0.0 to 2.0.1
- documents the patch release in CHANGELOG.md
- prepares the npm artifact containing the merged TypeScript declarations, examples, docs, and init CLI fix

## Verification
- npm run lint
- npm test
- npm run scales:validate
- npm pack --json --dry-run
- npm run test:pack-smoke

## Publish path
Local npm auth is not available in this environment (npm whoami returns E401), so publishing should be handled by the repository GitHub Release workflow using its NPM_TOKEN secret.