### PR TITLE
fix(ci): publish and smoke against the public npm registry explicitly

### DIFF
--- a/.github/workflows/post-publish-smoke.yml
+++ b/.github/workflows/post-publish-smoke.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           VERSION: ${{ steps.pkg.outputs.version }}
         run: |
-          if npm view "stylelint-plugin-rhythmguard@$VERSION" version >/dev/null 2>&1; then
+          if npm view "stylelint-plugin-rhythmguard@$VERSION" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,9 @@ jobs:
         run: npm ci
 
       - name: Publish to npm
-        run: npm publish --provenance
+        # The farm runners carry an npm registry override (local proxy). Publishing must
+        # target the public registry explicitly; the CLI flag beats env and user config.
+        run: npm publish --provenance --registry https://registry.npmjs.org
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard"
+    "url": "git+https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard.git"
   },
   "homepage": "https://github.com/petrilahdelma/stylelint-plugin-rhythmguard#readme",
   "bugs": {

--- a/scripts/ci/npm-registry-smoke.mjs
+++ b/scripts/ci/npm-registry-smoke.mjs
@@ -64,7 +64,7 @@ try {
 
   const installResult = run(
     'npm',
-    ['install', '--save-dev', 'stylelint@16', spec],
+    ['install', '--save-dev', 'stylelint@16', spec, '--registry', 'https://registry.npmjs.org'],
     { cwd: tempDir },
   );
   if (installResult.status !== 0) {


### PR DESCRIPTION
The v2.1.0 release run passed all eight verify jobs but the publish job failed with `ENEEDAUTH ... http://100.77.151.86:4873/`: the self-hosted runners carry an npm registry override pointing at a local proxy, and it beat the `registry-url` written by setup-node.

- `npm publish --provenance --registry https://registry.npmjs.org`
- post-publish smoke `npm view` and the smoke install use the public registry explicitly too
- `repository.url` normalized to the `git+https://...git` form npm rewrites it to (silences the publish warning)

Local gate: lint, 126/126 tests, pack smoke. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
