### PR TITLE
ci(release): publish through npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,27 +60,13 @@ jobs:
         if: matrix.node-version == '20.x' && matrix.stylelint-version == '16'
         run: npm run test:pack-smoke
 
-  publish-gate:
-    needs: verify
-    runs-on: [self-hosted, stylelint-plugin-rhythmguard]
-    outputs:
-      has_npm_token: ${{ steps.token.outputs.has_npm_token }}
-    steps:
-      - name: Detect npm token availability
-        id: token
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -n "$NPM_TOKEN" ]; then
-            echo "has_npm_token=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_npm_token=false" >> "$GITHUB_OUTPUT"
-          fi
-
   publish:
-    needs: [verify, publish-gate]
-    if: ${{ needs.publish-gate.outputs.has_npm_token == 'true' }}
-    runs-on: [self-hosted, stylelint-plugin-rhythmguard]
+    needs: verify
+    # npm trusted publishing (OIDC) is only supported from GitHub-hosted runners, so this
+    # one small job runs on ubuntu-latest while the verify matrix stays on the farm.
+    # No npm token: the trusted publisher on npmjs.com is bound to this repo and this
+    # workflow file. Provenance is generated automatically; --provenance is not needed.
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
@@ -91,26 +77,17 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           registry-url: https://registry.npmjs.org
+
+      - name: Ensure npm supports trusted publishing (>= 11.5.1)
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Publish to npm
-        # The farm runners carry an npm registry override (local proxy). Publishing must
-        # target the public registry explicitly; the CLI flag beats env and user config.
-        run: npm publish --provenance --registry https://registry.npmjs.org
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  publish-skipped:
-    needs: [verify, publish-gate]
-    if: ${{ needs.publish-gate.outputs.has_npm_token != 'true' }}
-    runs-on: [self-hosted, stylelint-plugin-rhythmguard]
-    steps:
-      - name: Skip publish because NPM_TOKEN is not configured
-        run: |
-          echo "NPM_TOKEN is not configured in repository secrets."
-          echo "Release verification completed; npm publish step was skipped."
+      - name: Publish to npm via OIDC
+        run: npm publish --access public --registry https://registry.npmjs.org

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -19,10 +19,9 @@
 
 ## npm Publish
 
-1. Confirm `NPM_TOKEN` exists in repo secrets.
-2. Publish via GitHub Release workflow (`release.yml`) or run local publish:
-   - `npm publish --provenance`
-3. Verify package metadata and README on npm.
+1. Publishing is done by `release.yml` through npm trusted publishing (OIDC). The trusted publisher on npmjs.com is bound to `PetriLahdelma/stylelint-plugin-rhythmguard` and the workflow file `release.yml`; no npm token is stored anywhere.
+2. The publish job must run on a GitHub-hosted runner (npm does not support trusted publishing from self-hosted runners). Provenance is attached automatically.
+3. Verify package metadata, provenance badge and README on npm.
 
 ## Post-release
 


### PR DESCRIPTION
Replaces the expired `NPM_TOKEN` path with npm trusted publishing.

- Trusted publisher is configured on npmjs.com: `PetriLahdelma/stylelint-plugin-rhythmguard`, workflow `release.yml`, `npm publish` allowed.
- npm supports trusted publishing only from GitHub-hosted runners, so the publish job runs on `ubuntu-latest`. The verify matrix stays on the farm.
- Node 24 + `npm@latest` for the npm >= 11.5.1 requirement. `--provenance` dropped (automatic). `publish-gate` and `publish-skipped` removed.
- CONTRIBUTING and RELEASE_CHECKLIST updated.

YAML validated; no npm token reference remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm publishing to use trusted publishing through GitHub-hosted runners.
  * Standardized the release process on Node.js 24 and the latest npm version.

* **Documentation**
  * Updated the release checklist with trusted publishing requirements and provenance verification steps.
  * Removed instructions for token-based and local publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->