### PR TITLE
feat(configs): embed entry point and guide for shared-config authors (Track B3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format follows Keep a Changelog principles and semantic versioning.
 - Added the quiet benchmark (`npm run bench:quiet`): audits public design systems with `--scale auto`, classifies findings as drift, noise or allowance, and writes `docs/QUIET_BENCHMARK.md` with a per-repo false-positive rate. Manifest and classification rules live in `benchmarks/quiet/`.
 - Scale inference now reads token values written as `calc(<length> * var(--factor))` (Radix Themes), expands a bare Tailwind v4 `--spacing` base into the default multiplier scale, and matches prefixed spacing tokens such as `--lb-spacing-md` while excluding `letter-spacing` and `word-spacing`.
 
+- Added `stylelint-plugin-rhythmguard/configs/embed`: `use-scale` at warning level with `scale: "auto"`, no `extends`, shape frozen for 2.x. The entry point for shared-config authors who want to enable spacing governance for their consumers without knowing each consumer's scale. Guide in `docs/FOR_CONFIG_AUTHORS.md`.
 - Added `allowHairlines` (default `true`) to `use-scale`, `no-offscale-transform` and `prefer-token`. Non-zero lengths that resolve to one CSS pixel or less (`1px`, `-1px`, `0.5px`, `0.0625rem`) are exempt: they compensate for borders and rendering, not spacing. The quiet benchmark showed them to be the only systematic false positive left across Radix Themes, Mantine, Primer React and Liveblocks. Set `allowHairlines: false` to restore the previous reports.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Every rule validates its options up front. Unknown option names and wrong shapes
 
 ## Configs
 
-`recommended`, `strict`, `tailwind`, `react-tailwind`, `expanded`, `logical`, `migration`, `motion`. All are `stylelint-plugin-rhythmguard/configs/<name>`. What each enables, the full custom setup, and the scale-selection precedence are in [docs/CONFIGS.md](docs/CONFIGS.md). Built-in and community scale presets are in [docs/SCALE_PRESETS.md](docs/SCALE_PRESETS.md).
+`recommended`, `strict`, `tailwind`, `react-tailwind`, `expanded`, `logical`, `migration`, `motion`, and `embed` for authors of shared configs (see [docs/FOR_CONFIG_AUTHORS.md](docs/FOR_CONFIG_AUTHORS.md)). All are `stylelint-plugin-rhythmguard/configs/<name>`. What each enables, the full custom setup, and the scale-selection precedence are in [docs/CONFIGS.md](docs/CONFIGS.md). Built-in and community scale presets are in [docs/SCALE_PRESETS.md](docs/SCALE_PRESETS.md).
 
 ## Audit before you enforce
 

--- a/docs/CONFIGS.md
+++ b/docs/CONFIGS.md
@@ -4,6 +4,7 @@ Every config is a one-line `extends`. Pick the first one that fits and move down
 
 | Config | Enables | Use when |
 | --- | --- | --- |
+| `embed` | `use-scale` at warning level with `scale: "auto"` | You maintain a shared config that other teams install. Shape frozen for 2.x. See [`FOR_CONFIG_AUTHORS.md`](./FOR_CONFIG_AUTHORS.md) |
 | `recommended` | `use-scale` on the spacing group | You want spacing on a scale and nothing else decided for you |
 | `strict` | `use-scale` + `prefer-token` + `no-offscale-transform` | Tokens exist and raw literals should be errors |
 | `tailwind` | `strict` + `stylelint-config-tailwindcss` + `@theme` token extraction | Tailwind v3 or v4 project |

--- a/docs/FOR_CONFIG_AUTHORS.md
+++ b/docs/FOR_CONFIG_AUTHORS.md
@@ -1,0 +1,107 @@
+# Rhythmguard for shared-config authors
+
+You maintain a Stylelint config that other teams install: a design-system org config, a platform team's `@company/stylelint-config`, a framework starter. This page is the contract for embedding Rhythmguard in it.
+
+## The one-liner
+
+```json
+{
+  "extends": ["stylelint-plugin-rhythmguard/configs/embed"]
+}
+```
+
+Or, if your config lists rules directly:
+
+```json
+{
+  "plugins": ["stylelint-plugin-rhythmguard"],
+  "rules": {
+    "rhythmguard/use-scale": [true, { "scale": "auto", "severity": "warning" }]
+  }
+}
+```
+
+That is the whole `embed` config. One rule, warning level, scale inferred from the consumer's own tokens. It has no `extends`, so it pulls nothing but this plugin into your dependency tree, and its shape is frozen for the 2.x line: a minor bump will not change what your consumers see.
+
+## What your consumers get
+
+`rhythmguard/use-scale` reports spacing values (`margin`, `padding`, `gap`, `inset`, translations) that are not on the spacing scale, with the two nearest on-scale values in the message. It never guesses tokens and never rewrites anything unless the consumer runs `--fix`.
+
+What it does not do, so nobody expects it: it does not check colors or hex values, it does not lint Tailwind class strings (that is the separate ESLint companion, see below), and it does not enforce token usage over raw values (that is `prefer-token`, which you should leave to consumers who have a token system).
+
+## Why warning level
+
+A shared config reaches codebases you have never seen. Some will have hundreds of off-scale values on day one. At warning level the rule shows up in editors and in CI output without failing anyone's build, so consumers can fix at their own pace or ratchet with [`rhythmguard audit --since-baseline --fail-on-new-drift`](./AUDIT.md). Teams that want it to fail set the severity in their own config:
+
+```json
+{
+  "extends": ["@company/stylelint-config"],
+  "rules": {
+    "rhythmguard/use-scale": [true, { "scale": "auto", "severity": "error" }]
+  }
+}
+```
+
+## Why `scale: "auto"`
+
+You do not know each consumer's scale, and you should not have to. With `"auto"` the rule resolves the scale per project, first match wins:
+
+1. `scaleSources` files, if the consumer or your config lists any
+2. `audit.tokenSources` from the consumer's `.rhythmguardrc.json`
+3. spacing custom properties in the linted stylesheet (`--space-*`, `--spacing-*`, prefixed variants like `--acme-spacing-md`, Tailwind v4's `--spacing` base, values written as `calc(4px * var(--scaling))`)
+4. `theme.spacing` from `tailwindConfigPath`
+5. the `rhythmic-4` preset, announced once in the first report of the file
+
+Inference needs at least three distinct token values before it trusts a source; a one-token scale is worse than the default. The [quiet benchmark](./QUIET_BENCHMARK.md) shows how this behaves on Radix Themes, Mantine, shadcn/ui, Primer React and Liveblocks.
+
+### When tokens live in a package, not in CSS
+
+Design systems often ship tokens from a Style Dictionary build or an npm package (`@primer/primitives`, Mantine's JS theme). The linted stylesheets then contain no token definitions and inference falls back. Point `scaleSources` at the built token file so every consumer of your config gets the same scale:
+
+```json
+{
+  "plugins": ["stylelint-plugin-rhythmguard"],
+  "rules": {
+    "rhythmguard/use-scale": [
+      true,
+      {
+        "scale": "auto",
+        "scaleSources": ["node_modules/@company/tokens/dist/tokens.json"],
+        "severity": "warning"
+      }
+    ]
+  }
+}
+```
+
+Flat JSON, Style Dictionary JSON, DTCG JSON and CSS custom properties are all accepted. This is the pattern the first external adopter arrived at independently: derive the effective pixel scale from the token *values* rather than the token names, because under Tailwind v4 the per-step `--spacing-N` names are inert and only the values matter.
+
+## How consumers opt out
+
+Per file or block, the standard Stylelint way:
+
+```css
+/* stylelint-disable rhythmguard/use-scale */
+.legacy-grid { margin: 13px; }
+/* stylelint-enable rhythmguard/use-scale */
+```
+
+Per project, in their own config: `"rhythmguard/use-scale": null`. Per path, with Stylelint `overrides`. Generated CSS and third-party CSS should be ignored at the config level (`ignoreFiles`) or never linted in the first place; the rule cannot tell authored from generated.
+
+## What is exempt by default
+
+Zero, percentages, and hairlines (non-zero lengths of one CSS pixel or less such as `margin: -1px` or a `1px` focus-ring inset). The reasoning is in the [`use-scale` docs](./rules/use-scale.md#hairlines). Consumers who want hairlines reported set `allowHairlines: false`.
+
+## Footprint and support
+
+- Stylelint 16 and 17. Node 18.18 or newer for 16, Node 20.19 or newer for 17.
+- Runtime dependency: `known-css-properties`. Two further dependencies (`stylelint-config-tailwindcss`, `stylelint-plugin-logical-css`) are currently installed for the optional `tailwind` and `logical` configs and become optional peers in 3.0. `embed` does not use them.
+- CommonJS and ESM entry points, TypeScript declarations for every export.
+- The `embed` config's shape and defaults will not change within 2.x. Changes to inference sources are additive.
+- Bugs and false positives: [open an issue](https://github.com/petrilahdelma/stylelint-plugin-rhythmguard/issues). A finding your consumers consider wrong is exactly what the quiet benchmark exists to catch; a reproduction in an issue is enough.
+
+## Going further
+
+- `rhythmguard/prefer-token` for consumers with a token system: raw literals become token suggestions with an autofix from a token map. Leave it out of a shared config unless every consumer has tokens.
+- The ESLint companion `stylelint-plugin-rhythmguard/eslint` for Tailwind class strings (`p-[13px]`), which the Stylelint side cannot see.
+- [`rhythmguard audit`](./AUDIT.md) for a repo-level report, baselines and CI gates.

--- a/docs/STRATEGY_2026-09.md
+++ b/docs/STRATEGY_2026-09.md
@@ -164,6 +164,8 @@ Define "quiet" as findings a maintainer of the scanned repo would accept as real
 
 #### B3. Embed kit for shared-config authors
 
+Status 2026-09-05: shipped. `configs/embed` and [`FOR_CONFIG_AUTHORS.md`](./FOR_CONFIG_AUTHORS.md). The guide also covers the case the first external adopter (doctor-school/ds-platform) solved on their own: tokens that live in a package or a Style Dictionary build, fed through `scaleSources`.
+
 A short `docs/FOR_CONFIG_AUTHORS.md`: the exact `rules` block to add, why warning level, how consumers opt out per file, how consumers override the scale, the dependency footprint (zero hard deps, Stylelint 16 and 17), and the support commitment. Ship a `stylelint-plugin-rhythmguard/embed` config entry point that is `recommended` with `scale: "auto"` and warning severity and nothing else, so config authors have a stable one-liner that will not change shape between minors.
 
 #### B4. Target list and outreach method

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
       "require": "./src/configs/recommended.js",
       "import": "./src/configs/recommended.mjs"
     },
+    "./configs/embed": {
+      "types": "./types/config.d.ts",
+      "require": "./src/configs/embed.js",
+      "import": "./src/configs/embed.mjs"
+    },
     "./configs/strict": {
       "types": "./types/config.d.ts",
       "require": "./src/configs/strict.js",

--- a/src/configs/embed.js
+++ b/src/configs/embed.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/**
+ * The one-liner for shared-config authors.
+ *
+ * One rule, warning level, scale inferred from the consuming project's own
+ * spacing tokens (scaleSources, .rhythmguardrc.json token sources, the
+ * stylesheet's custom properties, a Tailwind config, then rhythmic-4).
+ * No `extends`, no dependency beyond this plugin, and the shape is frozen for
+ * the life of the 2.x line so a config that embeds it never changes behaviour
+ * on a minor bump.
+ */
+module.exports = {
+  plugins: ['stylelint-plugin-rhythmguard'],
+  rules: {
+    'rhythmguard/use-scale': [
+      true,
+      {
+        scale: 'auto',
+        severity: 'warning',
+      },
+    ],
+  },
+};

--- a/src/configs/embed.mjs
+++ b/src/configs/embed.mjs
@@ -1,0 +1,4 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const config = require('./embed.js');
+export default config;

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ module.exports.rules = {
   [useMotionScale.ruleName]: useMotionScale,
 };
 module.exports.configs = {
+  embed: require('./configs/embed'),
   recommended: require('./configs/recommended'),
   strict: require('./configs/strict'),
   tailwind: require('./configs/tailwind'),

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -111,3 +111,17 @@ test('every ./configs/* package export is exposed on plugin.configs (cjs and esm
 
   assert.deepEqual(Object.keys(plugin.configs).sort(), exportedConfigNames);
 });
+
+test('embed config is the one-liner for shared-config authors: use-scale on auto scale at warning level, nothing else', () => {
+  const embed = plugin.configs.embed;
+  assert.ok(embed, 'configs.embed is missing');
+  assert.deepEqual(embed.plugins, ['stylelint-plugin-rhythmguard']);
+  assert.equal(embed.extends, undefined, 'embed must not pull other configs or dependencies');
+  assert.deepEqual(Object.keys(embed.rules), ['rhythmguard/use-scale']);
+  assert.deepEqual(embed.rules['rhythmguard/use-scale'], [
+    true,
+    { scale: 'auto', severity: 'warning' },
+  ]);
+  assert.equal(packageJson.exports['./configs/embed'].require, './src/configs/embed.js');
+  assert.equal(packageJson.exports['./configs/embed'].import, './src/configs/embed.mjs');
+});

--- a/types/__checks__/consumer.ts
+++ b/types/__checks__/consumer.ts
@@ -14,6 +14,7 @@ import { createAuditReport, toAuditContractReport } from 'stylelint-plugin-rhyth
 import eslintPlugin from 'stylelint-plugin-rhythmguard/eslint';
 import { getScalePreset, listScalePresetNames } from 'stylelint-plugin-rhythmguard/presets';
 import recommended from 'stylelint-plugin-rhythmguard/configs/recommended';
+import embed from 'stylelint-plugin-rhythmguard/configs/embed';
 import reactTailwind from 'stylelint-plugin-rhythmguard/configs/react-tailwind';
 import useScale, { ruleName as useScaleName } from 'stylelint-plugin-rhythmguard/rules/use-scale';
 
@@ -27,6 +28,8 @@ const pluginConfigs: readonly RhythmguardStylelintConfig[] = [
   plugin.configs.motion,
   plugin.configs['react-tailwind'],
   configs.recommended,
+  plugin.configs.embed,
+  embed,
   recommended,
   reactTailwind,
 ];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -38,6 +38,7 @@ export type { StylelintRuleModule } from "./rule";
 export interface RhythmguardPlugin extends Array<StylelintRuleModule> {
   audit: typeof auditApi;
   configs: {
+    embed: RhythmguardStylelintConfig;
     expanded: RhythmguardStylelintConfig;
     logical: RhythmguardStylelintConfig;
     migration: RhythmguardStylelintConfig;


### PR DESCRIPTION
Track B3 from `docs/STRATEGY_2026-09.md`: the embed kit for shared-config authors.

- **`stylelint-plugin-rhythmguard/configs/embed`**: `use-scale` at warning level with `scale: "auto"`, no `extends`, no dependency beyond the plugin, shape frozen for the 2.x line. A test pins the exact shape.
- **`docs/FOR_CONFIG_AUTHORS.md`**: the one-liner, why warning level, how `auto` resolves per consumer, `scaleSources` for tokens that live in a package or a Style Dictionary build, consumer opt-outs, default exemptions, footprint and support commitment. It is honest that two dependencies only become optional peers in 3.0.
- README configs line, CONFIGS table, CHANGELOG, strategy status.

The package-vs-CSS token case in the guide is drawn from `doctor-school/ds-platform`, the first external adopter found in a public-mentions sweep: they derived an effective pixel scale from Style Dictionary `space.*` values because Tailwind v4's per-step `--spacing-N` names are inert, and reported zero false positives with `use-scale` plus the ESLint companion.

Local gate: lint, typecheck, pack smoke pass; 145/145 tests; relative links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `embed` shared Stylelint configuration.
  - The configuration automatically detects spacing scales and reports issues as warnings without extending other presets.
  - Added CommonJS, ESM, and TypeScript support for importing the configuration.
- **Documentation**
  - Added guidance for shared-config authors, including token sources, opt-outs, defaults, and supported integrations.
  - Documented the new preset in the README and configuration reference.
- **Tests**
  - Added export, configuration, and type-check coverage for the new preset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->