### PR TITLE
docs: align every place that describes Rhythmguard with the new positioning

### DIFF
--- a/.github/ISSUE_TEMPLATE/scale-request.yml
+++ b/.github/ISSUE_TEMPLATE/scale-request.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Design context
       description: What kind of product or design system is this for?
-      placeholder: enterprise dashboard / editorial layout / mobile-first app
+      placeholder: admin dashboard / editorial layout / mobile-first app
     validations:
       required: true
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -8,7 +8,7 @@ This guide helps teams choose the right Stylelint plugin for each problem, then 
 | --- | --- | --- |
 | `stylelint-plugin-defensive-css` | Resilience and accessibility guardrails | UI hardening, interaction safety, reduced-motion, focus behavior |
 | `stylelint-plugin-logical-css` | Direction-agnostic and writing-mode-safe CSS | Internationalization, RTL/LTR parity, logical properties and keywords |
-| `stylelint-plugin-rhythmguard` | Design-token + spacing-scale governance | Consistent spacing/radius/size/typography and deterministic scale autofix |
+| `stylelint-plugin-rhythmguard` | Off-scale spacing and missing tokens | Spacing (and optionally radius, size, typography) kept on one scale, with deterministic nearest-value autofix |
 | `stylelint-scales` | Property-specific numeric scale enforcement | Teams that want granular scale rules per property category |
 
 ## When to use each
@@ -32,7 +32,7 @@ This guide helps teams choose the right Stylelint plugin for each problem, then 
 ### Use `stylelint-scales` when:
 
 - You want a broad rule-pack where each property family has its own numeric rule.
-- Your team prefers direct per-rule tuning by property type over a single governance model.
+- Your team prefers direct per-rule tuning by property type over one shared scale.
 
 ## Recommended rollout order in real teams
 
@@ -61,7 +61,7 @@ This guide helps teams choose the right Stylelint plugin for each problem, then 
 }
 ```
 
-## 3) Add Rhythmguard scale governance
+## 3) Add Rhythmguard scale checks
 
 ```json
 {

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,11 +1,26 @@
-# Distribution Submissions (Feb 21, 2026)
+# Where Rhythmguard is listed
 
-Submitted PRs to improve discovery where Stylelint users already browse tools:
+Kept current so the descriptions people meet elsewhere match the product.
 
-1. Awesome Stylelint plugin list:
-   - Primary (open): https://github.com/stylelint/awesome-stylelint/pull/109
-   - Duplicate (closed): https://github.com/stylelint/awesome-stylelint/pull/110
-2. Related plugins cross-link (`stylelint-plugin-defensive-css`):
-   - https://github.com/yuschick/stylelint-plugin-defensive-css/pull/152
-3. Related plugins cross-link (`stylelint-plugin-logical-css`):
-   - https://github.com/yuschick/stylelint-plugin-logical-css/pull/123
+## Listings we maintain
+
+| Place | Text | Status |
+| --- | --- | --- |
+| GitHub about | "Nobody chose 13px. Catches off-scale spacing in CSS and Tailwind and snaps it to your scale." | current |
+| npm description | same first sentence, plus what ships (Stylelint rules, ESLint companion, audit CLI) | current from the next publish; the npm page shows the README of the last published version |
+| Browser playground | `docs/index.html` on GitHub Pages | updated alongside the README |
+
+## Listings maintained by others
+
+| Place | Entry | Assessment |
+| --- | --- | --- |
+| [stylelint/awesome-stylelint](https://github.com/stylelint/awesome-stylelint) (mirrored on stylelint.io) | "Enforce spacing scales and design token usage across CSS and Tailwind class strings (Pack)". Added by [#114](https://github.com/stylelint/awesome-stylelint/pull/114), merged 2026-05-03. | Accurate. The list keeps descriptions terse; a change would only be worth a PR if the scope changes (for example to mention SCSS), and the maintainers decide wording. |
+| Research notes and skill files in other repositories | Cite Rhythmguard as the spacing-scale gate in agent-guardrail setups | Not ours to edit. The README now states what the tool is not, which is the correction one of them had to write. |
+| Automated catalogues (for example `Arnon-hs/open-source`) | Scrape the GitHub about text | Refresh on their own schedule. |
+
+## History
+
+- 2026-02-17: [awesome-stylelint#109](https://github.com/stylelint/awesome-stylelint/pull/109) opened; closed 2026-05-03 in favour of #114. A duplicate, #110, was closed.
+- 2026-02-21: cross-link PRs to `stylelint-plugin-defensive-css` ([#152](https://github.com/yuschick/stylelint-plugin-defensive-css/pull/152)) and `stylelint-plugin-logical-css` ([#123](https://github.com/yuschick/stylelint-plugin-logical-css/pull/123)) were closed without merge. No further cross-link requests are planned.
+- 2026-04-28: Show HN, 1 point, no comments.
+- 2026-05-03: awesome-stylelint listing merged.

--- a/docs/FRAMEWORKS.md
+++ b/docs/FRAMEWORKS.md
@@ -21,7 +21,7 @@ This gives you:
 - Expanded enforcement (spacing + radius) on CSS Modules (`*.module.css`)
 - `.next/` and `out/` build directories ignored
 
-Pair with the ESLint companion for Tailwind class-string governance in JSX/TSX:
+Pair with the ESLint companion to check Tailwind class strings in JSX/TSX:
 
 ```js
 // eslint.config.js

--- a/docs/TAILWIND.md
+++ b/docs/TAILWIND.md
@@ -70,7 +70,7 @@ export default [
 
 Then layer on:
 
-- `eslint-plugin-tailwindcss` for broader class-string governance and conventions. Its `tailwindcss/no-arbitrary-value` rule is useful when a project wants to reject all arbitrary values; Rhythmguard's companion rule is narrower and checks arbitrary spacing values against your configured scale.
+- `eslint-plugin-tailwindcss` for broader class-string linting and conventions. Its `tailwindcss/no-arbitrary-value` rule is useful when a project wants to reject all arbitrary values; Rhythmguard's companion rule is narrower and checks arbitrary spacing values against your configured scale.
 
 Use Prettier for deterministic ordering:
 
@@ -88,4 +88,4 @@ Use Prettier for deterministic ordering:
 2. ESLint over JS/TS/JSX/TSX templates.
 3. Prettier check.
 
-This gives complete spacing governance without mixing parser responsibilities.
+This covers spacing in both CSS and class strings without mixing parser responsibilities.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Rhythmguard Playground + Audit 2.0 — Token governance for CSS and Tailwind</title>
-<meta name="description" content="Try CSS spacing and token checks in the browser, then run Rhythmguard Audit 2.0 locally for stable JSON, HTML reports, baselines, and CI gates." />
-<meta property="og:title" content="Rhythmguard Playground + Audit 2.0" />
-<meta property="og:description" content="Try CSS spacing and token checks in the browser, then run Audit 2.0 locally for reports and CI." />
+<title>Rhythmguard playground: nobody chose 13px</title>
+<meta name="description" content="Paste CSS and see off-scale spacing with the nearest steps on your scale. For a whole repository, run npx rhythmguard: no install, no config." />
+<meta property="og:title" content="Rhythmguard playground: nobody chose 13px" />
+<meta property="og:description" content="Paste CSS, see off-scale spacing and the nearest steps on your scale. Then run npx rhythmguard on a real repository." />
 <meta property="og:image" content="https://raw.githubusercontent.com/petrilahdelma/stylelint-plugin-rhythmguard/main/assets/rhythmguard-banner.svg" />
 <meta name="twitter:card" content="summary_large_image" />
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230C1117'/%3E%3Ctext y='70' x='10' font-family='monospace' font-size='48' fill='white'%3E%7CR%7C%3C/text%3E%3C/svg%3E" />
@@ -421,25 +421,25 @@
   <header class="top">
     <div class="brand">
       <span class="title">|Rhythmguard|</span>
-      <span class="sub">playground — try it before you install</span>
+      <span class="sub">playground: try it before you install</span>
     </div>
     <nav class="top-nav">
       <a href="https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard" target="_blank" rel="noopener">GitHub</a>
       <a href="https://www.npmjs.com/package/stylelint-plugin-rhythmguard" target="_blank" rel="noopener">npm</a>
-      <a href="https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/MIGRATING_TO_2.md" target="_blank" rel="noopener">2.0 migration</a>
+      <a href="https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/AUDIT.md" target="_blank" rel="noopener">Audit</a>
       <a href="https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/FRAMEWORKS.md" target="_blank" rel="noopener">Frameworks</a>
     </nav>
   </header>
 
-  <section class="release-strip" aria-label="Rhythmguard Audit 2.0 release">
+  <section class="release-strip" aria-label="Rhythmguard 2.2">
     <div class="release-copy">
-      <span class="release-eyebrow">Audit 2.0</span>
-      <strong>Stable repo audits are now the CLI path.</strong>
-      <span>This playground checks pasted CSS; local runs add JSON contracts, HTML reports, baselines, token sources, motion checks, and CI gates.</span>
+      <span class="release-eyebrow">2.2</span>
+      <strong>One command audits a whole repository.</strong>
+      <span>This playground checks pasted CSS. In a project, <code>npx rhythmguard</code> infers your scale from your own tokens, lists the drift, and prints the config to paste. The audit adds JSON, HTML, SCSS, baselines and CI gates.</span>
     </div>
     <div class="release-actions">
-      <a href="https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/AUDIT_2_VALIDATION.md" target="_blank" rel="noopener">Audit guide</a>
-      <a href="https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/MIGRATING_TO_2.md" target="_blank" rel="noopener">Migration notes</a>
+      <a href="https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/AUDIT.md" target="_blank" rel="noopener">Audit guide</a>
+      <a href="https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/blob/main/docs/QUIET_BENCHMARK.md" target="_blank" rel="noopener">Quiet benchmark</a>
     </div>
   </section>
 

--- a/scales/community/product-decimal-10.json
+++ b/scales/community/product-decimal-10.json
@@ -1,10 +1,33 @@
 {
   "name": "product-decimal-10",
-  "description": "Decimal-friendly product spacing scale for dashboard-heavy enterprise UIs.",
+  "description": "Decimal-friendly product spacing scale for dashboard-heavy UIs.",
   "base": 10,
-  "steps": [0, 2, 4, 6, 8, 10, 12, 16, 20, 24, 32, 40, 48, 64, 80],
-  "aliases": ["decimal-10", "enterprise-10"],
-  "tags": ["product", "dashboard", "community"],
+  "steps": [
+    0,
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    16,
+    20,
+    24,
+    32,
+    40,
+    48,
+    64,
+    80
+  ],
+  "aliases": [
+    "decimal-10",
+    "enterprise-10"
+  ],
+  "tags": [
+    "product",
+    "dashboard",
+    "community"
+  ],
   "contributor": "Petri Lahdelma",
   "contributorUrl": "https://github.com/PetriLahdelma"
 }


### PR DESCRIPTION
Sweep of every description of the tool we control: playground copy, comparison and framework docs, community scale text, issue template, and a rewritten DISTRIBUTION.md that inventories third-party listings and their state.

Gate: lint, 152/152 tests, links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)