### PR TITLE
feat(inference): read spacing tokens from installed design-token packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format follows Keep a Changelog principles and semantic versioning.
 - The audit now scans `.scss` files through `postcss-scss` (new optional peer dependency). Without it, SCSS files are reported as skipped instead of ignored. `scanned.scssFiles` and `scanned.scssSkipped` join the JSON contract; text and Markdown output show the counts.
 - Quiet benchmark widened from 7 to 20 public repositories, adding SCSS-first systems: Bootstrap, Primer CSS, Penpot, Mastodon, Gutenberg components, GitLab UI, Pico, Bulma, Spectrum CSS, USWDS, Carbon, Salesforce Lightning, wp-calypso components.
 
+- `scale: "auto"` now reads spacing tokens shipped by installed design-token packages when the project's own stylesheets define none: `tailwindcss` (v4 `theme.css`), `@radix-ui/themes`, `@mantine/core`, `@primer/primitives`, `@shopify/polaris-tokens`, `@spectrum-css/tokens`. Provenance is `token-package`. Token-source entries accept a per-file `tokenPattern` for packages that name spacing differently. The allowlist is `src/utils/token-packages.json`.
 - Sass variables and maps are token sources for `--scale auto` and for `scaleSources` files: `$spacer: 1rem`, `$spacing-01: 0.125rem`, and maps such as `$spacers: (1: $spacer * .25, ...)` with nested maps, variable references, `* / + -` arithmetic and `math.div()`. Unevaluable function calls, strings, keywords and interpolated keys are skipped. Bootstrap, Bulma, Carbon and USWDS now infer their own scales in the quiet benchmark.
 
 ### Changed

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -31,7 +31,7 @@ Scan paths are scoped to the directory argument. Common generated directories ar
 
 ## Scale
 
-`--scale 0,4,8,12,16` sets the scale explicitly. `--scale auto` infers one project-level scale and reports where it came from: external `--token-source` files first, then spacing custom properties (`--space-*`, `--spacing-*`) found across the scanned CSS, then the default `rhythmic-4` values. The JSON contract carries it under `contracts.scale.values`, `contracts.scale.source` and `contracts.scale.files`; text and Markdown output print the scale and its source. A shared config that enables `scale: "auto"` on the rules and an audit run with `--scale auto` therefore agree on the scale.
+`--scale 0,4,8,12,16` sets the scale explicitly. `--scale auto` infers one project-level scale and reports where it came from: external `--token-source` files first, then spacing custom properties (`--space-*`, `--spacing-*`) and Sass variables found across the scanned CSS and SCSS, then spacing tokens shipped by installed design-token packages (`source: "token-package"`), then the default `rhythmic-4` values. The JSON contract carries it under `contracts.scale.values`, `contracts.scale.source` and `contracts.scale.files`; text and Markdown output print the scale and its source. A shared config that enables `scale: "auto"` on the rules and an audit run with `--scale auto` therefore agree on the scale.
 
 ## SCSS
 

--- a/docs/FOR_CONFIG_AUTHORS.md
+++ b/docs/FOR_CONFIG_AUTHORS.md
@@ -49,14 +49,15 @@ You do not know each consumer's scale, and you should not have to. With `"auto"`
 1. `scaleSources` files, if the consumer or your config lists any
 2. `audit.tokenSources` from the consumer's `.rhythmguardrc.json`
 3. spacing custom properties in the linted stylesheet (`--space-*`, `--spacing-*`, prefixed variants like `--acme-spacing-md`, Tailwind v4's `--spacing` base, values written as `calc(4px * var(--scaling))`)
-4. `theme.spacing` from `tailwindConfigPath`
-5. the `rhythmic-4` preset, announced once in the first report of the file
+4. spacing tokens shipped by installed design-token packages (`tailwindcss`, `@radix-ui/themes`, `@mantine/core`, `@primer/primitives`, `@shopify/polaris-tokens`, `@spectrum-css/tokens`)
+5. `theme.spacing` from `tailwindConfigPath`
+6. the `rhythmic-4` preset, announced once in the first report of the file
 
 Inference needs at least three distinct token values before it trusts a source; a one-token scale is worse than the default. The [quiet benchmark](./QUIET_BENCHMARK.md) shows how this behaves on Radix Themes, Mantine, shadcn/ui, Primer React and Liveblocks.
 
 ### When tokens live in a package, not in CSS
 
-Design systems often ship tokens from a Style Dictionary build or an npm package (`@primer/primitives`, Mantine's JS theme). The linted stylesheets then contain no token definitions and inference falls back. Point `scaleSources` at the built token file so every consumer of your config gets the same scale:
+Design systems often ship tokens from a Style Dictionary build or an npm package. For the packages on the allowlist (Tailwind v4, Radix Themes, Mantine, Primer primitives, Polaris, Spectrum) inference reads the installed files on its own. For any other package, or your own token build, point `scaleSources` at the built token file so every consumer of your config gets the same scale:
 
 ```json
 {

--- a/docs/rules/use-scale.md
+++ b/docs/rules/use-scale.md
@@ -76,8 +76,9 @@ Deterministic: the value is replaced with the nearest scale step, preserving sig
 1. `scaleSources`: token files listed in the rule options. CSS custom properties (including Tailwind v4 `@theme`), flat JSON, Style Dictionary JSON, or DTCG JSON.
 2. `audit.tokenSources` in a `.rhythmguardrc.json` in the working directory, so lint and `rhythmguard audit` read the same token contract.
 3. Custom properties in the linted stylesheet whose names match `tokenPattern` (default for auto: `^--(space|spacing)-`).
-4. `theme.spacing` from `tailwindConfigPath` (Tailwind v3 JS config).
-5. Fallback to the `rhythmic-4` preset. The first report in the file says so: `No spacing tokens were found for scale "auto"; using preset "rhythmic-4".`
+4. Spacing tokens shipped by design-token packages the project has installed: `tailwindcss` (the v4 `--spacing` base in `theme.css`), `@radix-ui/themes`, `@mantine/core`, `@primer/primitives`, `@shopify/polaris-tokens`, `@spectrum-css/tokens`. The allowlist lives in `src/utils/token-packages.json` and additions are welcome.
+5. `theme.spacing` from `tailwindConfigPath` (Tailwind v3 JS config).
+6. Fallback to the `rhythmic-4` preset. The first report in the file says so: `No spacing tokens were found for scale "auto"; using preset "rhythmic-4".`
 
 ```json
 {

--- a/src/audit/report.js
+++ b/src/audit/report.js
@@ -18,7 +18,7 @@ const {
 } = require('./config');
 const { buildReport, collectTokenDefinitions } = require('./contract');
 const { DEFAULT_SCALE, formatPath } = require('./shared');
-const { scaleFromDefinitions } = require('../utils/scale-inference');
+const { discoverTokenPackages, scaleFromDefinitions } = require('../utils/scale-inference');
 const {
   assertDirectory,
   collectCssFindings,
@@ -159,6 +159,20 @@ function resolveAuditScale({ baseFontSize, cssFiles, requested, tokenSourceResul
         files: Array.from(files).sort(),
         source: 'scanned-css',
         tokenCount: definitions.size,
+        values,
+      };
+    }
+  }
+
+  const packageSources = discoverTokenPackages(process.cwd());
+  if (packageSources.length > 0) {
+    const parsedPackages = parseTokenSources({ baseFontSize, sources: packageSources, tokenKind: 'spacing' });
+    const values = scaleFromDefinitions(parsedPackages.definitions, baseFontSize);
+    if (values) {
+      return {
+        files: parsedPackages.sources.map((source) => source.file),
+        source: 'token-package',
+        tokenCount: parsedPackages.definitions.size,
         values,
       };
     }

--- a/src/cli/quickstart.js
+++ b/src/cli/quickstart.js
@@ -14,6 +14,7 @@ const path = require('node:path');
 
 const { createAuditReport } = require('../audit/report');
 const { detect } = require('./init');
+const { discoverTokenPackages } = require('../utils/scale-inference');
 
 const TOKEN_FILE_PATTERN = /(^|[.-])tokens?\.json$/i;
 const TOKEN_DIRS = ['tokens', 'design-tokens', path.join('src', 'tokens'), path.join('dist', 'tokens')];
@@ -127,6 +128,8 @@ async function run() {
   out.push(`    Next.js         ${stack.nextjs ? 'yes' : 'no'}`);
   out.push(`    Stylelint config ${stack.hasExistingConfig ? 'present' : 'none'}`);
   out.push(`    Token files     ${tokenFiles.length > 0 ? tokenFiles.join(', ') : 'none found'}`);
+  const tokenPackages = [...new Set(discoverTokenPackages(cwd).map((source) => source.package))];
+  out.push(`    Token packages  ${tokenPackages.length > 0 ? tokenPackages.join(', ') : 'none installed'}`);
   out.push(`    .rhythmguardrc  ${rcPresent ? 'present (its token sources are used)' : 'none'}`);
   out.push('');
 

--- a/src/utils/scale-inference.js
+++ b/src/utils/scale-inference.js
@@ -21,6 +21,80 @@ const MIN_INFERRED_SCALE_LENGTH = 4;
 const RC_FILE = '.rhythmguardrc.json';
 
 const sourceCache = new Map();
+const TOKEN_PACKAGES = require('./token-packages.json').packages;
+
+/**
+ * Installed design-token packages that ship a spacing scale (allowlist in
+ * token-packages.json). Resolved from the project, so only what the project
+ * actually depends on is read. Returns token-source entries.
+ */
+function readDirectDependencies(dir) {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
+    return new Set([
+      ...Object.keys(pkg.dependencies || {}),
+      ...Object.keys(pkg.devDependencies || {}),
+      ...Object.keys(pkg.peerDependencies || {}),
+    ]);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Project roots from cwd up to the repository boundary (first directory holding
+ * .git), each with the dependencies it declares directly. Hoisted monorepo
+ * installs are found by walking up; a stray global node_modules is never
+ * consulted because the walk stops at the repository.
+ */
+function projectRoots(cwd) {
+  const roots = [];
+  let current = path.resolve(cwd);
+  for (;;) {
+    const direct = readDirectDependencies(current);
+    if (direct) {
+      roots.push({ dir: current, direct });
+    }
+    const parent = path.dirname(current);
+    if (fs.existsSync(path.join(current, '.git')) || parent === current) {
+      break;
+    }
+    current = parent;
+  }
+  return roots;
+}
+
+function discoverTokenPackages(cwd = process.cwd()) {
+  const sources = [];
+  const roots = projectRoots(cwd);
+  for (const entry of TOKEN_PACKAGES) {
+    // Only packages the project depends on directly count. A transitive
+    // tailwindcss (for example via stylelint-config-tailwindcss) must not hand
+    // a non-Tailwind project the Tailwind scale.
+    const owner = roots.find((root) => root.direct.has(entry.name));
+    if (!owner) {
+      continue;
+    }
+    const root = roots
+      .map((candidate) => path.join(candidate.dir, 'node_modules', entry.name))
+      .find((dir) => fs.existsSync(path.join(dir, 'package.json')));
+    if (!root) {
+      continue;
+    }
+    for (const file of entry.files) {
+      const resolved = path.join(root, file);
+      if (fs.existsSync(resolved)) {
+        sources.push({
+          format: 'auto',
+          package: entry.name,
+          path: resolved,
+          ...(entry.tokenPattern ? { tokenPattern: entry.tokenPattern } : {}),
+        });
+      }
+    }
+  }
+  return sources;
+}
 
 function pxValuesFromKeys(keys, baseFontSize) {
   const values = new Set([0]);
@@ -54,6 +128,7 @@ function normalizeSource(source, baseDir) {
     return {
       format: typeof source.format === 'string' ? source.format : 'auto',
       path: path.resolve(source.baseDir || baseDir, rawPath),
+      ...(source.tokenPattern ? { tokenPattern: source.tokenPattern } : {}),
     };
   }
 
@@ -69,7 +144,7 @@ function cacheKey(sources) {
       } catch {
         // missing file: key still changes when it appears
       }
-      return `${source.path}|${source.format}|${mtime}`;
+      return `${source.path}|${source.format}|${source.tokenPattern || ''}|${mtime}`;
     })
     .join('\n');
 }
@@ -86,13 +161,9 @@ function scaleFromSources(sources, baseFontSize) {
   }
 
   const parsed = parseTokenSources({ baseFontSize, sources: normalized, tokenKind: 'spacing' });
-  const keys = [];
-  for (const definition of parsed.definitions.values()) {
-    keys.push(...definition.normalizedValues);
-  }
-
-  const scale = pxValuesFromKeys(keys, baseFontSize);
-  const outcome = scale.length >= MIN_INFERRED_SCALE_LENGTH
+  // scaleFromDefinitions also expands a bare Tailwind --spacing base into its multiples.
+  const scale = scaleFromDefinitions(parsed.definitions, baseFontSize);
+  const outcome = scale
     ? {
       files: parsed.sources.map((source) => source.file),
       scale,
@@ -229,6 +300,11 @@ function resolveAutoScale({
     }
   }
 
+  const fromPackages = scaleFromSources(discoverTokenPackages(process.cwd()), baseFontSize);
+  if (fromPackages) {
+    return { source: 'token-package', ...fromPackages };
+  }
+
   return {
     files: [],
     preset: FALLBACK_PRESET,
@@ -250,6 +326,7 @@ function autoScaleFallbackNote(inference) {
 module.exports = {
   DEFAULT_AUTO_TOKEN_PATTERN,
   autoScaleFallbackNote,
+  discoverTokenPackages,
   resolveAutoScale,
   scaleFromDefinitions,
 };

--- a/src/utils/token-packages.json
+++ b/src/utils/token-packages.json
@@ -1,0 +1,48 @@
+{
+  "$comment": "Design-token packages whose installed files declare a spacing scale. Used by scale: \"auto\" after the project's own stylesheets are checked. Each entry lists the files to read (relative to the package root) and, when the package does not use space/spacing names, the token pattern to match. Additions welcome; keep them to files that ship in the published package.",
+  "packages": [
+    {
+      "name": "tailwindcss",
+      "files": [
+        "theme.css"
+      ],
+      "note": "Tailwind v4 base multiplier --spacing"
+    },
+    {
+      "name": "@radix-ui/themes",
+      "files": [
+        "tokens.css"
+      ],
+      "note": "--space-1..9 as calc(<px> * var(--scaling))"
+    },
+    {
+      "name": "@mantine/core",
+      "files": [
+        "styles.css"
+      ],
+      "note": "--mantine-spacing-* as calc(<rem> * var(--mantine-scale))"
+    },
+    {
+      "name": "@primer/primitives",
+      "files": [
+        "dist/css/base/size/size.css"
+      ],
+      "tokenPattern": "^--base-size-\\d+$",
+      "note": "Primer names its spacing ladder size"
+    },
+    {
+      "name": "@shopify/polaris-tokens",
+      "files": [
+        "dist/css/styles.css"
+      ],
+      "note": "--p-space-* in rem"
+    },
+    {
+      "name": "@spectrum-css/tokens",
+      "files": [
+        "dist/css/global-vars.css"
+      ],
+      "note": "--spectrum-spacing-* in px"
+    }
+  ]
+}

--- a/src/utils/token-sources.js
+++ b/src/utils/token-sources.js
@@ -68,6 +68,15 @@ function normalizeTokenKind(kind) {
   return normalized;
 }
 
+function createPatternMatcher(pattern, fallback) {
+  try {
+    const regex = new RegExp(pattern);
+    return (token) => regex.test(token);
+  } catch {
+    return fallback;
+  }
+}
+
 function createTokenKindMatcher(kind) {
   const normalizedKind = normalizeTokenKind(kind);
   const pattern = TOKEN_KIND_PATTERNS[normalizedKind] || TOKEN_KIND_PATTERNS.spacing;
@@ -115,16 +124,19 @@ function parseTokenSources({
     }
 
     let tokens = [];
+    const matchesSource = normalizedSource.tokenPattern
+      ? createPatternMatcher(normalizedSource.tokenPattern, matchesKind)
+      : matchesKind;
     try {
       if (normalizedSource.format === 'css') {
-        tokens = collectCssTokens(text, matchesKind);
+        tokens = collectCssTokens(text, matchesSource);
       } else {
         const parsed = JSON.parse(text);
         const detectedFormat = normalizedSource.requestedFormat === 'auto'
           ? detectJsonTokenFormat(parsed)
           : normalizedSource.format;
         sourceReport.format = detectedFormat;
-        tokens = collectJsonTokens(parsed, matchesKind);
+        tokens = collectJsonTokens(parsed, matchesSource);
       }
     } catch (err) {
       const warning = `Unable to parse token source ${normalizedSource.displayPath}: ${err.message}`;
@@ -174,6 +186,9 @@ function normalizeTokenSource(source) {
     format: requestedFormat === 'auto' ? detectSourceFormat(resolvedPath) : requestedFormat,
     requestedFormat,
     resolvedPath,
+    // Optional per-source override for packages that name spacing tokens differently
+    // (Primer's --base-size-*). Falls back to the kind matcher when absent.
+    tokenPattern: typeof source.tokenPattern === 'string' && source.tokenPattern ? source.tokenPattern : null,
   };
 }
 

--- a/test/audit-cli.test.js
+++ b/test/audit-cli.test.js
@@ -781,3 +781,23 @@ test('audit CLI --scale auto ignores token declarations in test and fixture dire
   assert.deepEqual(report.contracts.scale.values, [0, 4, 8, 12], 'the 7px test token must not join the scale');
   assert.deepEqual(report.contracts.scale.files, ['src/theme.css']);
 });
+
+test('audit CLI --scale auto reports token-package provenance when the scale comes from node_modules', () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-audit-pkg-'));
+  fs.mkdirSync(path.join(fixtureDir, 'src'));
+  fs.mkdirSync(path.join(fixtureDir, 'node_modules', '@radix-ui', 'themes'), { recursive: true });
+  fs.writeFileSync(path.join(fixtureDir, 'package.json'), '{"name":"fixture","dependencies":{"@radix-ui/themes":"^3.0.0"}}');
+  fs.writeFileSync(path.join(fixtureDir, 'node_modules', '@radix-ui', 'themes', 'package.json'), '{"name":"@radix-ui/themes","version":"3.0.0"}');
+  fs.writeFileSync(
+    path.join(fixtureDir, 'node_modules', '@radix-ui', 'themes', 'tokens.css'),
+    ':root { --space-1: calc(4px * var(--scaling)); --space-2: calc(8px * var(--scaling)); --space-3: calc(12px * var(--scaling)); --space-4: calc(16px * var(--scaling)); }\n',
+  );
+  fs.writeFileSync(path.join(fixtureDir, 'src', 'card.css'), '.card { padding: 13px; margin: 8px; }\n');
+
+  const result = runAuditCommand(fixtureDir, 'src', '--scale', 'auto', '--format', 'json');
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.contracts.scale.source, 'token-package');
+  assert.deepEqual(report.contracts.scale.values, [0, 4, 8, 12, 16]);
+  assert.deepEqual(report.contracts.scale.files, ['node_modules/@radix-ui/themes/tokens.css']);
+});

--- a/test/scale-auto.test.js
+++ b/test/scale-auto.test.js
@@ -199,3 +199,75 @@ test('scale "auto" falls back when fewer than three token values are found, beca
   assert.match(texts[0], /"13px".*nearest: 12px or 16px/);
   assert.match(texts[0], /using preset "rhythmic-4"/);
 });
+
+test('scale "auto" discovers spacing tokens shipped by installed design-token packages', async () => {
+  const dir = tempDir('token-packages');
+  fs.mkdirSync(path.join(dir, 'node_modules', 'tailwindcss'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"fixture","devDependencies":{"tailwindcss":"^4.1.0"}}');
+  fs.writeFileSync(path.join(dir, 'node_modules', 'tailwindcss', 'package.json'), '{"name":"tailwindcss","version":"4.1.0"}');
+  fs.writeFileSync(path.join(dir, 'node_modules', 'tailwindcss', 'theme.css'), '@theme default { --spacing: 0.25rem; --color-red-500: red; }\n');
+
+  const previousCwd = process.cwd();
+  process.chdir(dir);
+  let result;
+  try {
+    result = await lintCss({
+      code: '@import "tailwindcss";\n.a { padding: 13px; margin: 20px; }',
+      rules: useScaleAuto(),
+    });
+  } finally {
+    process.chdir(previousCwd);
+  }
+
+  assert.deepEqual(result.invalidOptionWarnings, []);
+  assert.equal(result.warnings.length, 1, result.warnings.map((w) => w.text).join('\n'));
+  assert.match(result.warnings[0].text, /"13px".*nearest: 12px or 14px/);
+  assert.doesNotMatch(result.warnings[0].text, /No spacing tokens/);
+});
+
+test('token packages with their own naming (Primer --base-size-*) are read through a per-package pattern', async () => {
+  const dir = tempDir('token-packages-primer');
+  const primer = path.join(dir, 'node_modules', '@primer', 'primitives');
+  fs.mkdirSync(path.join(primer, 'dist', 'css', 'base', 'size'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"fixture","dependencies":{"@primer/primitives":"^10.0.0"}}');
+  fs.writeFileSync(path.join(primer, 'package.json'), '{"name":"@primer/primitives","version":"10.0.0"}');
+  fs.writeFileSync(
+    path.join(primer, 'dist', 'css', 'base', 'size', 'size.css'),
+    ':root { --base-size-4: 0.25rem; --base-size-8: 0.5rem; --base-size-12: 0.75rem; --base-size-16: 1rem; --base-size-24: 1.5rem; }\n',
+  );
+
+  const previousCwd = process.cwd();
+  process.chdir(dir);
+  let result;
+  try {
+    result = await lintCss({ code: '.a { padding: 13px; margin: 24px; gap: 32px; }', rules: useScaleAuto() });
+  } finally {
+    process.chdir(previousCwd);
+  }
+
+  const texts = result.warnings.map((w) => w.text);
+  assert.equal(texts.length, 2, texts.join('\n'));
+  assert.match(texts[0], /"13px".*nearest: 12px or 16px/);
+  assert.match(texts[1], /"32px"/, '32px is on rhythmic-4 but not on Primer\'s ladder, so it proves the package scale was used');
+  assert.doesNotMatch(texts[0], /No spacing tokens/);
+});
+
+test('token packages that are only transitive dependencies are ignored', async () => {
+  const dir = tempDir('token-packages-transitive');
+  fs.mkdirSync(path.join(dir, 'node_modules', 'tailwindcss'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"fixture","devDependencies":{"stylelint-config-tailwindcss":"^1.0.0"}}');
+  fs.writeFileSync(path.join(dir, 'node_modules', 'tailwindcss', 'package.json'), '{"name":"tailwindcss","version":"4.1.0"}');
+  fs.writeFileSync(path.join(dir, 'node_modules', 'tailwindcss', 'theme.css'), '@theme default { --spacing: 0.25rem; }\n');
+
+  const previousCwd = process.cwd();
+  process.chdir(dir);
+  let result;
+  try {
+    result = await lintCss({ code: '.a { padding: 13px; }', rules: useScaleAuto() });
+  } finally {
+    process.chdir(previousCwd);
+  }
+
+  assert.equal(result.warnings.length, 1);
+  assert.match(result.warnings[0].text, /using preset "rhythmic-4"/, 'a transitive tailwindcss must not supply the scale');
+});

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -93,7 +93,7 @@ export interface AuditBaselineComparison {
   [key: string]: unknown;
 }
 
-export type AuditScaleSource = "default" | "explicit" | "fallback" | "scanned-css" | "token-sources";
+export type AuditScaleSource = "default" | "explicit" | "fallback" | "scanned-css" | "token-package" | "token-sources";
 
 export interface AuditScale {
   /** Files the scale was derived from (token sources or scanned stylesheets). Empty for explicit, default and fallback. */

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -10,6 +10,8 @@ export interface ScaleSource {
   /** `auto` (default), `css`, `flat-json`, `style-dictionary`, or `dtcg`. */
   format?: string;
   path?: string;
+  /** Regex for token names in this file, overriding the spacing kind matcher (for packages that name spacing differently). */
+  tokenPattern?: string;
 }
 
 export interface RhythmguardRuleOptions {


### PR DESCRIPTION
Closes #53. The second inference gap from the benchmark: Primer React and Mantine consumers keep their tokens in an npm package, so `scale: "auto"` fell back.

## What

- Allowlist `src/utils/token-packages.json`: `tailwindcss` (v4 `theme.css` base multiplier), `@radix-ui/themes` (`tokens.css`, calc-wrapped), `@mantine/core` (`styles.css`), `@primer/primitives` (`dist/css/base/size/size.css`, with a per-package pattern for `--base-size-*`), `@shopify/polaris-tokens`, `@spectrum-css/tokens`. File paths verified against the published tarballs.
- Discovery in both the rule path (`resolveAutoScale`) and the audit path (`resolveAuditScale`), after the project's own stylesheets and an explicit `tailwindConfigPath`, before the fallback. Provenance `token-package`; the quickstart prints detected packages.
- **Direct dependencies only.** While testing, this repository's own `node_modules` contained `tailwindcss@4.1.18`, pulled in transitively by `stylelint-config-tailwindcss`, and discovery handed the Tailwind scale to a repo that does not use Tailwind. Discovery now reads `package.json` at each project root up to the repository boundary and only accepts packages declared there. A test pins the transitive case.
- Token-source entries accept `tokenPattern`, declared in the types.

Local gate: lint, typecheck, pack smoke pass; 161/161 tests; `bench:quiet --check` unchanged (sparse clones have no `node_modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
