### PR TITLE
feat(rules): scale auto reads Sass variables and maps from the linted SCSS file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format follows Keep a Changelog principles and semantic versioning.
 - Quiet benchmark widened from 7 to 20 public repositories, adding SCSS-first systems: Bootstrap, Primer CSS, Penpot, Mastodon, Gutenberg components, GitLab UI, Pico, Bulma, Spectrum CSS, USWDS, Carbon, Salesforce Lightning, wp-calypso components.
 
 - `scale: "auto"` now reads spacing tokens shipped by installed design-token packages when the project's own stylesheets define none: `tailwindcss` (v4 `theme.css`), `@radix-ui/themes`, `@mantine/core`, `@primer/primitives`, `@shopify/polaris-tokens`, `@spectrum-css/tokens`. Provenance is `token-package`. Token-source entries accept a per-file `tokenPattern` for packages that name spacing differently. The allowlist is `src/utils/token-packages.json`.
-- Sass variables and maps are token sources for `--scale auto` and for `scaleSources` files: `$spacer: 1rem`, `$spacing-01: 0.125rem`, and maps such as `$spacers: (1: $spacer * .25, ...)` with nested maps, variable references, `* / + -` arithmetic and `math.div()`. Unevaluable function calls, strings, keywords and interpolated keys are skipped. Bootstrap, Bulma, Carbon and USWDS now infer their own scales in the quiet benchmark.
+- Sass variables and maps are token sources for `--scale auto`, for `scaleSources` files, and for `scale: "auto"` inside the rules when the linted `.scss` file declares them (with `postcss-scss`): `$spacer: 1rem`, `$spacing-01: 0.125rem`, and maps such as `$spacers: (1: $spacer * .25, ...)` with nested maps, variable references, `* / + -` arithmetic and `math.div()`. Unevaluable function calls, strings, keywords and interpolated keys are skipped. Bootstrap, Bulma, Carbon and USWDS now infer their own scales in the quiet benchmark.
 
 ### Changed
 

--- a/docs/rules/use-scale.md
+++ b/docs/rules/use-scale.md
@@ -88,7 +88,7 @@ Deterministic: the value is replaced with the nearest scale step, preserving sig
 }
 ```
 
-Token values in `rem` and `em` are converted through `baseFontSize`; values in units that cannot convert to `px` are ignored. Sass variables and maps (`$spacer`, `$spacers: (...)`) are read as token sources by `rhythmguard audit --scale auto` and by `scaleSources` files; reading them from the linted stylesheet itself inside the rule is tracked in [issue #52](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/issues/52). Values written as `calc(<length> * var(--factor))`, the Radix Themes scaling idiom, contribute the length. A bare Tailwind v4 base (`--spacing: 0.25rem`) expands into Tailwind's default multiplier scale. Prefixed names such as `--lb-spacing-md` or `--mantine-spacing-xs` match; `letter-spacing` and `word-spacing` tokens never do. `customScale` still overrides everything.
+Token values in `rem` and `em` are converted through `baseFontSize`; values in units that cannot convert to `px` are ignored. Sass variables and maps (`$spacer`, `$spacers: (1: $spacer * .25, ...)`) count too, both in `scaleSources` files and in the linted `.scss` file itself when Stylelint runs with `postcss-scss`; names must start with the scale word, so `$dropdown-spacer` is not a token. Values written as `calc(<length> * var(--factor))`, the Radix Themes scaling idiom, contribute the length. A bare Tailwind v4 base (`--spacing: 0.25rem`) expands into Tailwind's default multiplier scale. Prefixed names such as `--lb-spacing-md` or `--mantine-spacing-xs` match; `letter-spacing` and `word-spacing` tokens never do. `customScale` still overrides everything.
 
 ## Options
 

--- a/src/utils/scale-inference.js
+++ b/src/utils/scale-inference.js
@@ -5,7 +5,7 @@ const path = require('node:path');
 
 const { parseLengthToken, toPx } = require('./length');
 const { buildEffectiveTokenMap } = require('./token-map');
-const { parseTokenSources } = require('./token-sources');
+const { collectScssTokens, createTokenKindMatcher, parseTokenSources } = require('./token-sources');
 const { getScalePreset } = require('../presets/scales');
 
 // Matches the audit default so lint and audit agree on what a spacing token is.
@@ -228,8 +228,27 @@ function rcTokenSources(cwd) {
     .filter(Boolean);
 }
 
-function scaleFromTokenMap(map, baseFontSize) {
-  const keys = [];
+/**
+ * Sass variables and maps declared in the linted stylesheet itself (postcss-scss
+ * exposes them as declarations whose prop starts with `$`). Evaluated with the
+ * same collector the audit uses; component variables such as $dropdown-spacer
+ * are excluded by the anchored name rule.
+ */
+function sassValuesFromRoot(root) {
+  const lines = [];
+  root.walkDecls((decl) => {
+    if (typeof decl.prop === 'string' && decl.prop.startsWith('$')) {
+      lines.push(`${decl.prop}: ${decl.value};`);
+    }
+  });
+  if (lines.length === 0) {
+    return [];
+  }
+  return collectScssTokens(lines.join('\n'), createTokenKindMatcher('spacing')).map((token) => token.value);
+}
+
+function scaleFromTokenMap(map, baseFontSize, extraKeys = []) {
+  const keys = [...extraKeys];
   const baseKeys = [];
   for (const [key, reference] of Object.entries(map)) {
     const name = String(reference).match(/^var\((--[\w-]+)\)$/);
@@ -277,7 +296,7 @@ function resolveAutoScale({
       root,
       tokenRegex,
     });
-    const scale = scaleFromTokenMap(stylesheetMap, baseFontSize);
+    const scale = scaleFromTokenMap(stylesheetMap, baseFontSize, sassValuesFromRoot(root));
     if (scale) {
       return { files: [], scale, source: 'stylesheet', tokenCount: scale.length - 1, warnings: [] };
     }

--- a/test/helpers/lint.js
+++ b/test/helpers/lint.js
@@ -4,11 +4,12 @@ const path = require('node:path');
 
 const pluginPath = path.join(__dirname, '..', '..', 'src', 'index.js');
 
-async function lintCss({ code, fix = false, rules }) {
+async function lintCss({ code, customSyntax, fix = false, rules }) {
   const { default: stylelint } = await import('stylelint');
   const lintResult = await stylelint.lint({
     code,
     config: {
+      ...(customSyntax ? { customSyntax } : {}),
       plugins: [pluginPath],
       rules,
     },

--- a/test/scale-auto.test.js
+++ b/test/scale-auto.test.js
@@ -271,3 +271,28 @@ test('token packages that are only transitive dependencies are ignored', async (
   assert.equal(result.warnings.length, 1);
   assert.match(result.warnings[0].text, /using preset "rhythmic-4"/, 'a transitive tailwindcss must not supply the scale');
 });
+
+test('scale "auto" reads Sass variables and maps from the linted SCSS file itself (issue #52)', async () => {
+  const result = await lintCss({
+    customSyntax: require.resolve('postcss-scss'),
+    code: [
+      '$spacer: 1rem !default;',
+      '$spacers: (',
+      '  0: 0,',
+      '  1: $spacer * .25,',
+      '  2: $spacer * .5,',
+      '  3: $spacer,',
+      ') !default;',
+      '$dropdown-spacer: .125rem;',
+      '.a { padding: 13px; margin: 8px; gap: 2px; }',
+    ].join('\n'),
+    rules: useScaleAuto(),
+  });
+
+  assert.deepEqual(result.invalidOptionWarnings, []);
+  const texts = result.warnings.map((w) => w.text);
+  assert.equal(texts.length, 2, texts.join('\n'));
+  assert.match(texts[0], /"13px".*nearest: 8px or 16px/);
+  assert.match(texts[1], /"2px"/, 'the component variable $dropdown-spacer must not have put 2px on the scale');
+  assert.doesNotMatch(texts[0], /No spacing tokens/);
+});


### PR DESCRIPTION
Closes #52. Rule-level counterpart of the audit Sass support: with postcss-scss, `$`-prefixed declarations from the linted file go through the same evaluator, anchored names only. Test covers a Bootstrap-style `$spacer` plus `$spacers` map and confirms `$dropdown-spacer` stays out.

Gate: lint, typecheck, 162/162 tests, benchmark check unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)