### PR TITLE
chore(release): v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ## [Unreleased]
 
-The next release is 3.0.0. See [`docs/MIGRATING_TO_3.md`](./docs/MIGRATING_TO_3.md).
+## [3.0.0] - 2026-09-06
+
+Upgrade notes: [`docs/MIGRATING_TO_3.md`](./docs/MIGRATING_TO_3.md).
 
 ### Breaking
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stylelint-plugin-rhythmguard",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint-plugin-rhythmguard",
-      "version": "2.2.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "known-css-properties": "^0.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-rhythmguard",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Nobody chose 13px. Catches off-scale spacing in CSS and Tailwind class strings and snaps it to your scale or tokens. Stylelint rules, an ESLint companion, and an audit CLI.",
   "bin": {
     "rhythmguard": "src/cli/index.js"


### PR DESCRIPTION
Version bump to 3.0.0 and CHANGELOG cut.

3.0.0 is the honest-footprint release: Node 20.19 floor, one runtime dependency, five configs, plus everything since 2.2.0 (Sass token sources in the audit and in the rules, token-package discovery, SCSS auditing, the twenty-repo benchmark, contributor onboarding). Upgrade notes in `docs/MIGRATING_TO_3.md`.

Local gate: lint, typecheck, pack smoke pass; 162/162 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Published the 3.0.0 release entry dated September 6, 2026.
  - Added a link to upgrade and migration guidance.

- **Release**
  - Updated the package version to 3.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->