### PR TITLE
feat(audit): report off-scale drift by CSS property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ## [Unreleased]
 
+### Added
+
+- Audit findings for CSS declarations carry the declaration's `property`, recovered from the source at the warning position (`null` inside at-rules). Off-scale findings are counted by property in `offScaleProperties`, exposed as `contracts.scale.offScaleProperties`, rendered as a histogram in text, Markdown and HTML output and as a `Top properties` line in the quickstart. Baseline keys and benchmark snapshots are unchanged. ([#64](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/issues/64))
+
 ## [3.0.0] - 2026-09-06
 
 Upgrade notes: [`docs/MIGRATING_TO_3.md`](./docs/MIGRATING_TO_3.md).

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -60,7 +60,23 @@ Literal lengths in SCSS are checked. Declarations whose value is a Sass variable
 | New findings | 3 |
 ```
 
-Followed by histograms of off-scale values, token opportunities and Tailwind drift, the token contract, top affected files, and the baseline comparison when one is active.
+Followed by histograms of off-scale values, off-scale properties, token opportunities and Tailwind drift, the token contract, top affected files, and the baseline comparison when one is active.
+
+## Drift by property
+
+Every CSS finding carries the `property` of its declaration (`padding`, `margin-bottom`, `gap`, `transform`). Stylelint reports a position, not a node, so the audit reads the declaration back from the source at that position; a finding inside an at-rule such as `@include` gets `property: null`. The report counts off-scale findings by property in `offScaleProperties`, exposed in the JSON contract as `contracts.scale.offScaleProperties`, and prints the table after the value histogram:
+
+```md
+## CSS Off-Scale Properties
+
+| Property | Count |
+| --- | ---: |
+| `margin-bottom` | 112 |
+| `padding` | 41 |
+| `gap` | 3 |
+```
+
+The value histogram tells you which numbers drifted; the property table tells you where the layout decision lives. A table dominated by margins on siblings usually means the parent should own the spacing with `gap`, which removes the drift in one place instead of one declaration at a time. A table dominated by `padding` is component-internal and is fixed per component. Baselines and the quiet benchmark key findings by file, line and value, so the property does not affect either.
 
 ## Config file
 

--- a/docs/FOR_AGENTS.md
+++ b/docs/FOR_AGENTS.md
@@ -14,6 +14,7 @@ This project enforces its spacing scale with stylelint-plugin-rhythmguard.
 - Do not use `--fix` on spacing findings unless the task says so. Snapping a value can change layout; choose the value deliberately.
 - Values of one pixel or less (hairlines) and percentages are allowed and are not findings.
 - Tailwind arbitrary spacing values such as `p-[13px]` are findings too; use the scale utility (`p-3`) or an on-scale arbitrary value.
+- When the audit's `contracts.scale.offScaleProperties` table is dominated by margins on sibling elements, put a `gap` on the parent instead of fixing each margin. The parent owns the spacing between its children.
 - If the audit reports the scale source as `fallback`, the project has no discoverable spacing tokens. Ask before adding any; do not guess a scale.
 ```
 
@@ -24,7 +25,7 @@ Trim it to the lines that apply. The whole value of an agent instruction is that
 | Command | Use it when | Output |
 | --- | --- | --- |
 | `npx rhythmguard` | First contact with a repository | Detected stack, inferred scale with its source, findings summary, a config to paste. Human-readable, exit 0 |
-| `npx rhythmguard audit . --format json` | You need to act on findings | Stable JSON 2.0 contract: `contracts.scale.values` and `.source`, `findings.css[]` and `findings.tailwind[]` with `file`, `line`, `column`, `value`, `type`, `text`. Exit 0 unless a gate flag is set |
+| `npx rhythmguard audit . --format json` | You need to act on findings | Stable JSON 2.0 contract: `contracts.scale.values`, `.source` and `.offScaleProperties`, `findings.css[]` and `findings.tailwind[]` with `file`, `line`, `column`, `value`, `type`, `text`, and `property` on CSS findings. Exit 0 unless a gate flag is set |
 | `npx rhythmguard audit . --scale auto --format github` | Running inside GitHub Actions | One `::warning file=…,line=…::…` per finding |
 | `npx rhythmguard audit . --since-baseline --fail-on-new-drift` | Gating a change in CI | Exit 1 only when the change introduced drift not in `.rhythmguard-baseline.json` |
 | `npx stylelint "**/*.css"` | A Stylelint config with Rhythmguard exists | Standard Stylelint output; messages end with `(rhythmguard/use-scale)` |

--- a/src/audit/contract.js
+++ b/src/audit/contract.js
@@ -268,6 +268,9 @@ function buildReport({
   const offScaleValues = countByValue(cssFindings
     .filter((finding) => finding.type === 'off-scale' && finding.value)
     .map((finding) => finding.value));
+  const offScaleProperties = countByValue(cssFindings
+    .filter((finding) => finding.type === 'off-scale' && finding.property)
+    .map((finding) => finding.property));
   const tokenOpportunities = countByValue(cssFindings
     .filter((finding) => finding.type === 'token-opportunity' && finding.value)
     .map((finding) => finding.value));
@@ -319,6 +322,7 @@ function buildReport({
       findings: motionFindings.length,
       values: Object.fromEntries(sortCountMap(motionValues).slice(0, 10)),
     },
+    offScaleProperties: Object.fromEntries(sortCountMap(offScaleProperties).slice(0, 10)),
     offScaleValues: Object.fromEntries(sortCountMap(offScaleValues).slice(0, 10)),
     scale: scale || null,
     scaleCleanliness,
@@ -388,6 +392,7 @@ function toAuditContractReport(report) {
       scale: {
         cleanliness: report.scaleCleanliness,
         files: report.scale ? report.scale.files : [],
+        offScaleProperties: report.offScaleProperties || {},
         offScaleValues: report.offScaleValues,
         source: report.scale ? report.scale.source : 'default',
         tokenOpportunities: report.tokenOpportunities,

--- a/src/audit/render-html.js
+++ b/src/audit/render-html.js
@@ -34,6 +34,7 @@ function renderHtml(report) {
     metricHtml('CSS files', report.cssFilesScanned),
     metricHtml('Template files', report.templateFilesScanned),
     '</section>',
+    renderHtmlTable('CSS Off-Scale Properties', ['Property', 'Count'], Object.entries(report.offScaleProperties || {})),
     renderHtmlTable('Top Affected Files', ['File', 'Findings'], report.topAffectedFiles.map(({ file, count }) => [file, count])),
     renderHtmlTable('Token Contract Sources', ['File', 'Format', 'Tokens'], report.tokenContract.sources.map((source) => [
       source.file,

--- a/src/audit/render-markdown.js
+++ b/src/audit/render-markdown.js
@@ -40,6 +40,7 @@ function renderMarkdown(report) {
   lines.push('');
 
   appendMarkdownCounts(lines, 'CSS Off-Scale Values', report.offScaleValues);
+  appendMarkdownCounts(lines, 'CSS Off-Scale Properties', report.offScaleProperties, 'Property');
   appendMarkdownCounts(lines, 'CSS Token Opportunities', report.tokenOpportunities);
   appendMarkdownCounts(lines, 'Tailwind Class-String Drift', report.tailwindArbitraryValues);
   appendMarkdownCounts(lines, 'Motion Rhythm Drift', report.motion.values);
@@ -204,8 +205,8 @@ function appendBaselineMarkdown(lines, report) {
   }
 }
 
-function appendMarkdownCounts(lines, title, counts) {
-  const entries = sortCountMap(counts);
+function appendMarkdownCounts(lines, title, counts, label = 'Value') {
+  const entries = sortCountMap(counts || {});
 
   if (entries.length === 0) {
     return;
@@ -213,7 +214,7 @@ function appendMarkdownCounts(lines, title, counts) {
 
   lines.push(`## ${title}`);
   lines.push('');
-  lines.push('| Value | Count |');
+  lines.push(`| ${label} | Count |`);
   lines.push('| --- | ---: |');
   for (const [value, count] of entries) {
     lines.push(`| \`${escapeMarkdown(value)}\` | ${count} |`);

--- a/src/audit/render-text.js
+++ b/src/audit/render-text.js
@@ -33,6 +33,7 @@ function renderText(report) {
   lines.push('');
 
   appendHistogram(lines, 'CSS OFF-SCALE VALUES', report.offScaleValues);
+  appendHistogram(lines, 'CSS OFF-SCALE PROPERTIES', report.offScaleProperties);
   appendHistogram(lines, 'CSS TOKEN OPPORTUNITIES', report.tokenOpportunities);
   appendHistogram(lines, 'TAILWIND CLASS-STRING DRIFT', report.tailwindArbitraryValues);
   appendHistogram(lines, 'MOTION RHYTHM DRIFT', report.motion.values);
@@ -145,9 +146,9 @@ function appendBaselineText(lines, report) {
   }
 }
 
-function appendHistogram(lines, title, counts) {
-  const entries = sortCountMap(counts);
-  const total = sumCounts(counts);
+function appendHistogram(lines, title, counts = {}) {
+  const entries = sortCountMap(counts || {});
+  const total = sumCounts(counts || {});
 
   if (entries.length === 0) {
     return;

--- a/src/audit/scan.js
+++ b/src/audit/scan.js
@@ -342,10 +342,12 @@ async function runStylelintAudit(cssFiles, options) {
 
 function collectCssFindings(fileResults) {
   const findings = [];
+  const sources = new Map();
 
   for (const fileResult of fileResults) {
     for (const warning of fileResult.warnings || []) {
       const text = warning.text || '';
+      const source = readSourceOnce(sources, fileResult.source);
       const offScaleMatch = text.match(
         /Unexpected (?:off-scale value|transform translation value) "([^"]+)"/,
       );
@@ -363,6 +365,9 @@ function collectCssFindings(fileResults) {
         column: warning.column || 1,
         file: formatPath(fileResult.source),
         line: warning.line || 1,
+        property: source === null
+          ? null
+          : findDeclarationProperty(source, warning.line || 1, warning.column || 1),
         rule: warning.rule || 'rhythmguard',
         text,
         type: getCssFindingType({ motionDurationMatch, motionEasingMatch, tokenMatch }),
@@ -377,6 +382,73 @@ function collectCssFindings(fileResults) {
   }
 
   return findings;
+}
+
+function readSourceOnce(cache, filePath) {
+  if (!filePath) {
+    return null;
+  }
+  if (!cache.has(filePath)) {
+    try {
+      cache.set(filePath, fs.readFileSync(filePath, 'utf8'));
+    } catch {
+      cache.set(filePath, null);
+    }
+  }
+  return cache.get(filePath);
+}
+
+const DECLARATION_BOUNDARY = new Set([';', '{', '}']);
+const DECLARATION_HEAD_PATTERN = /^\s*(?:(?:\/\*[\s\S]*?\*\/|\/\/[^\n]*)\s*)*(--[\w-]+|[a-zA-Z][\w-]*)\s*:/;
+
+/**
+ * Stylelint warnings carry a position but not the declaration node. Recover the
+ * property by walking from the warning position back to the previous declaration
+ * boundary and reading the `property:` head, skipping block and Sass line comments.
+ * Sass interpolation is blanked first so `#{...}` braces do not act as boundaries. Returns null when the position is not
+ * inside a declaration, for example inside an at-rule.
+ */
+function findDeclarationProperty(source, line, column) {
+  const offset = positionToOffset(source, line, column);
+  if (offset === null) {
+    return null;
+  }
+
+  const text = source.replace(/#\{[^}]*\}/g, (match) => ' '.repeat(match.length));
+  let start = offset;
+  while (start > 0 && !DECLARATION_BOUNDARY.has(text[start - 1])) {
+    start -= 1;
+  }
+  const backward = text.slice(start, offset).match(DECLARATION_HEAD_PATTERN);
+  if (backward) {
+    return backward[1];
+  }
+
+  let end = offset;
+  while (end < text.length && !DECLARATION_BOUNDARY.has(text[end])) {
+    end += 1;
+  }
+  const forward = text.slice(offset, end).match(DECLARATION_HEAD_PATTERN);
+  return forward ? forward[1] : null;
+}
+
+function positionToOffset(source, line, column) {
+  if (!Number.isInteger(line) || line < 1) {
+    return null;
+  }
+  let offset = 0;
+  let currentLine = 1;
+  while (currentLine < line) {
+    const newline = source.indexOf('\n', offset);
+    if (newline === -1) {
+      return null;
+    }
+    offset = newline + 1;
+    currentLine += 1;
+  }
+  const lineEnd = source.indexOf('\n', offset);
+  const lineLength = (lineEnd === -1 ? source.length : lineEnd) - offset;
+  return offset + Math.min(Math.max((column || 1) - 1, 0), lineLength);
 }
 
 function getCssFindingValue({
@@ -581,6 +653,7 @@ module.exports = {
   collectTailwindMotionFindings,
   createIgnoreMatchers,
   escapeRegExp,
+  findDeclarationProperty,
   findStringLiterals,
   getCssFindingType,
   getCssFindingValue,

--- a/src/cli/quickstart.js
+++ b/src/cli/quickstart.js
@@ -177,6 +177,10 @@ async function run() {
   if (topValues.length > 0) {
     out.push(`    Top values      ${topValues.map(([value, count]) => `${value} ×${count}`).join(', ')}`);
   }
+  const topProperties = topEntries(report.offScaleProperties);
+  if (topProperties.length > 0) {
+    out.push(`    Top properties  ${topProperties.map(([property, count]) => `${property} ×${count}`).join(', ')}`);
+  }
   const topFiles = (report.topAffectedFiles || []).slice(0, 3);
   if (topFiles.length > 0) {
     out.push(`    Top files       ${topFiles.map((entry) => `${entry.file} (${entry.count})`).join(', ')}`);

--- a/test/audit-cli.test.js
+++ b/test/audit-cli.test.js
@@ -72,6 +72,9 @@ test('audit CLI JSON reports CSS and Tailwind design-system drift', () => {
   assert.equal(report.cssFilesScanned, 1);
   assert.equal(report.templateFilesScanned, 1);
   assert.equal(report.offScaleValues['13px'], 1);
+  assert.equal(report.offScaleProperties.padding, 1);
+  assert.equal(report.findings.css.find((finding) => finding.value === '13px').property, 'padding');
+  assert.equal(report.findings.css.find((finding) => finding.value === '16px').property, 'gap');
   assert.equal(report.tokenOpportunities['16px'], 1);
   assert.equal(report.tailwindArbitraryValues['13px'], 1);
   assert.equal(report.tailwindArbitraryValues['-0.3rem'], 1);
@@ -97,6 +100,7 @@ test('audit CLI JSON emits the 2.0 contract shape by default', () => {
   assert.equal(report.command.directory.endsWith('/src') || report.command.directory === path.join(fixtureDir, 'src'), true);
   assert.equal(report.scanned.cssFiles, 1);
   assert.equal(report.contracts.tokens.missingTokens[0].token, '--spacing-missing');
+  assert.deepEqual(report.contracts.scale.offScaleProperties, { padding: 1 });
   assert.equal(report.findings.tailwind.length, 2);
 });
 
@@ -128,6 +132,7 @@ test('audit CLI markdown emits a PR-ready design-system report', () => {
   assert.match(result.stdout, /^# Rhythmguard Design-System Audit/m);
   assert.match(result.stdout, /\| CSS files scanned \| 1 \|/);
   assert.match(result.stdout, /## Tailwind Class-String Drift/);
+  assert.match(result.stdout, /## CSS Off-Scale Properties\n\n\| Property \| Count \|\n\| --- \| ---: \|\n\| `padding` \| 1 \|/);
   assert.match(result.stdout, /`md:p-\[13px\]`/);
   assert.match(result.stdout, /`md:p-\[12px\]`/);
 });

--- a/test/audit-property.test.js
+++ b/test/audit-property.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { findDeclarationProperty } = require('../src/audit/scan');
+
+test('findDeclarationProperty returns the property of the declaration at a warning position', () => {
+  const source = [
+    '.card {',
+    '  padding: 13px;',
+    '  margin-bottom: 7px;',
+    '}',
+  ].join('\n');
+
+  assert.equal(findDeclarationProperty(source, 2, 12), 'padding');
+  assert.equal(findDeclarationProperty(source, 3, 18), 'margin-bottom');
+});
+
+test('findDeclarationProperty follows a value that spans several lines', () => {
+  const source = [
+    '.grid {',
+    '  margin:',
+    '    4px',
+    '    13px;',
+    '}',
+  ].join('\n');
+
+  assert.equal(findDeclarationProperty(source, 4, 5), 'margin');
+});
+
+test('findDeclarationProperty is not fooled by a pseudo-class colon in the selector', () => {
+  const source = 'a:hover { gap: 13px; }';
+
+  assert.equal(findDeclarationProperty(source, 1, 16), 'gap');
+});
+
+test('findDeclarationProperty reads the first declaration after an opening brace on the same line', () => {
+  const source = '.row { column-gap: 13px }';
+
+  assert.equal(findDeclarationProperty(source, 1, 20), 'column-gap');
+});
+
+test('findDeclarationProperty skips Sass line comments and block comments before the declaration', () => {
+  const source = [
+    '.button {',
+    '  margin-top: 8px;',
+    '',
+    '  // Padding prevents focus outlines from being cut off',
+    '  margin-inline-start: -2px;',
+    '  /* hairline */ padding: 13px;',
+    '}',
+  ].join('\n');
+
+  assert.equal(findDeclarationProperty(source, 5, 24), 'margin-inline-start');
+  assert.equal(findDeclarationProperty(source, 6, 27), 'padding');
+});
+
+test('findDeclarationProperty returns null when the position is not inside a declaration', () => {
+  const source = [
+    '.x {',
+    '  @include spacing(13px);',
+    '}',
+  ].join('\n');
+
+  assert.equal(findDeclarationProperty(source, 2, 20), null);
+  assert.equal(findDeclarationProperty(source, 9, 1), null);
+});

--- a/test/quickstart-cli.test.js
+++ b/test/quickstart-cli.test.js
@@ -46,6 +46,7 @@ test('bare `rhythmguard` runs the zero-config quickstart: detection, inferred sc
   assert.match(out, /Scale\s+0, 4, 8, 12, 16/, 'inferred scale is printed');
   assert.match(out, /scanned-css/, 'scale provenance is printed');
   assert.match(out, /13px/, 'the off-scale value shows up');
+  assert.match(out, /Top properties\s+padding ×1/, 'off-scale findings are broken down by property');
   assert.match(out, /\.stylelintrc\.json/, 'a config file name is suggested');
   assert.match(out, /"scale": "auto"/, 'the suggested config uses auto inference');
   assert.match(out, /stylelint-plugin-rhythmguard\/configs\/recommended/, 'plain CSS projects get the recommended config');

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -77,7 +77,8 @@ export interface AuditFinding {
   key?: string;
   line?: number;
   message: string;
-  property?: string;
+  /** CSS property of the declaration, recovered from the source. Null when the position is not inside a declaration. CSS findings only. */
+  property?: string | null;
   rule?: string;
   type: string;
   value?: string;
@@ -113,6 +114,10 @@ export interface AuditReport {
     motion: AuditFinding[];
     tailwind: AuditFinding[];
   };
+  /** Off-scale CSS findings counted by property, top ten. */
+  offScaleProperties?: Record<string, number>;
+  /** Off-scale CSS findings counted by value, top ten. */
+  offScaleValues?: Record<string, number>;
   scanned: AuditScanned;
   summary: AuditSummary;
   [key: string]: unknown;
@@ -130,6 +135,7 @@ export interface AuditContractReport {
     scale: {
       cleanliness?: unknown;
       files: string[];
+      offScaleProperties?: Record<string, number>;
       offScaleValues?: unknown;
       source: AuditScaleSource;
       tokenOpportunities?: unknown;


### PR DESCRIPTION
Closes #64.

## What

- Every `findings.css[]` entry now carries `property`, recovered from the file source at the warning position because Stylelint exposes no node. Declarations inside at-rules get `null`.
- New `offScaleProperties` on the report and `contracts.scale.offScaleProperties` in the JSON 2.0 contract: off-scale findings counted by property, top ten.
- Rendered in text, Markdown and HTML output, and as a `Top properties` line in the quickstart.
- `docs/AUDIT.md` documents the field and how to read the table next to the value histogram. `docs/FOR_AGENTS.md` adds one line: when sibling margins dominate, put `gap` on the parent.

## Why

The value histogram says which numbers drifted. The property table says where the layout decision lives. On Mastodon it reads `padding 206, margin-bottom 99, gap 41, margin 40, margin-top 40`, which is a different conversation from the one the value table starts.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` (168 tests) all exit 0 locally.
- `npm run test:pack-smoke` passes.
- `npm run bench:quiet -- --check --only mastodon` still matches the snapshot; snapshots key on file, line and value.
- On the Mastodon checkout, 1819 of 1819 CSS findings resolve a property after the line-comment fix (the first pass missed 3 behind `//` comments; a test pins that case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit findings now identify the associated CSS property when available.
  * Reports include off-scale CSS properties with frequency counts in JSON, text, Markdown, and HTML formats.
  * Quickstart output highlights the most frequent off-scale properties.
* **Documentation**
  * Audit documentation now explains property-level drift reporting, JSON fields, and handling for findings outside declarations.
* **Type Improvements**
  * Audit report types now include property-level findings and off-scale property summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->