### PR TITLE
feat(audit): --format badge writes a shields.io endpoint document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ## [Unreleased]
 
+### Added
+
+- `rhythmguard audit --format badge` writes a shields.io endpoint document for a README badge: `spacing drift` as a percentage by default, or the off-scale count with `--badge-metric findings`. Workflow in `docs/CI_ADOPTION.md`. ([#68](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/issues/68))
+
 ## [3.1.0] - 2026-09-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The audit scans CSS declarations, Tailwind class strings and your token contract
 
 `npx rhythmguard init` writes a starter config for your stack. `npx rhythmguard doctor` checks the setup.
 
+A README badge comes from the same audit: `--format badge` writes a shields.io endpoint document, see [`docs/CI_ADOPTION.md`](./docs/CI_ADOPTION.md#5-show-a-badge).
+
 ## Guides
 
 - [Tailwind integration](docs/TAILWIND.md), including v4 `@theme` tokens and what each layer covers

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -15,6 +15,7 @@ npx rhythmguard audit ./src --format markdown          # PR-ready report
 npx rhythmguard audit ./src --format json              # stable 2.0 contract
 npx rhythmguard audit ./src --format html --output rhythmguard-report.html
 npx rhythmguard audit ./src --format github            # GitHub Actions annotations
+npx rhythmguard audit ./src --format badge             # shields.io endpoint JSON for a README badge
 npx rhythmguard audit . --ignore "apps/legacy/**" --ignore "vendor/**"
 npx rhythmguard audit ./src --write-baseline
 npx rhythmguard audit ./src --since-baseline --fail-on-new-drift
@@ -77,6 +78,16 @@ Every CSS finding carries the `property` of its declaration (`padding`, `margin-
 ```
 
 The value histogram tells you which numbers drifted; the property table tells you where the layout decision lives. A table dominated by margins on siblings usually means the parent should own the spacing with `gap`, which removes the drift in one place instead of one declaration at a time. A table dominated by `padding` is component-internal and is fixed per component. Baselines and the quiet benchmark key findings by file, line and value, so the property does not affect either.
+
+## Badge
+
+`--format badge` writes a [shields.io endpoint](https://shields.io/badges/endpoint) document:
+
+```json
+{ "schemaVersion": 1, "label": "spacing drift", "message": "3%", "color": "green" }
+```
+
+`drift` (the default) is 100 minus scale cleanliness, the share of scanned files with at least one finding. `--badge-metric findings` reports the number of off-scale CSS values plus Tailwind class-string findings instead, labelled `off-scale values`. Colours: drift 0 to 2% brightgreen, to 5% green, to 15% yellow, above orange; findings 0 brightgreen, to 10 green, to 50 yellow, above orange. Publish the file somewhere public and embed `https://img.shields.io/endpoint?url=<file url>` in the README; the workflow is in [`CI_ADOPTION.md`](./CI_ADOPTION.md#5-show-a-badge).
 
 ## Config file
 

--- a/docs/CI_ADOPTION.md
+++ b/docs/CI_ADOPTION.md
@@ -95,3 +95,45 @@ Keep motion checks opt-in until the team has reviewed local false positives:
 ```bash
 npx rhythmguard audit ./src --include-motion --format markdown
 ```
+
+## 5. Show a badge
+
+`--format badge` writes a shields.io endpoint document. Commit it to a branch that GitHub Pages serves, or push it to a gist, and embed it:
+
+```yaml
+name: Spacing badge
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  badge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npx rhythmguard audit ./src --scale auto --format badge --output badges/spacing.json
+      - name: Publish to the badges branch
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git fetch origin badges || git checkout --orphan badges
+          git checkout badges 2>/dev/null || true
+          git add badges/spacing.json
+          git commit -m "badge: spacing drift" || exit 0
+          git push origin badges
+```
+
+Then in the README:
+
+```md
+![spacing drift](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/<owner>/<repo>/badges/badges/spacing.json)
+```
+
+`--badge-metric findings` shows the off-scale count instead of the drift percentage.

--- a/src/audit/args.js
+++ b/src/audit/args.js
@@ -4,6 +4,7 @@ const {
   normalizeTokenKind,
   normalizeTokenSourceFormat,
 } = require('../utils/token-sources');
+const { BADGE_METRICS } = require('./render-badge');
 const {
   VALID_FORMATS,
   createDefaultAuditOptions,
@@ -13,12 +14,14 @@ const {
 const HELP = `Usage: rhythmguard audit <dir> [options]
 
 Options:
-  --format <text|json|json-v1|markdown|html|github> Output format (default: text)
+  --format <text|json|json-v1|markdown|html|github|badge> Output format (default: text)
                                  github = GitHub Actions workflow-command annotations
+                                 badge = shields.io endpoint JSON for a README badge
+  --badge-metric <drift|findings> Badge value: drift percent or off-scale count (default: drift)
   --json                         Alias for --format json
   --markdown                     Alias for --format markdown
   --schema                       Print the audit JSON schema and exit
-  --output <file>                Write json, markdown, or html output to a file
+  --output <file>                Write json, markdown, html or badge output to a file
   --config <file>                Load audit config (default: .rhythmguardrc.json when present)
   --no-config                    Ignore .rhythmguardrc.json discovery
   --ignore <pattern>             Exclude root-relative path/glob (repeatable, comma-separated)
@@ -283,6 +286,16 @@ function parseArgs(argv) {
       continue;
     }
 
+    if (arg === '--badge-metric') {
+      parsed.badgeMetric = String(argv[++index] || '').toLowerCase();
+      continue;
+    }
+
+    if (arg.startsWith('--badge-metric=')) {
+      parsed.badgeMetric = arg.slice('--badge-metric='.length).toLowerCase();
+      continue;
+    }
+
     if (arg === '--format') {
       parsed.format = String(argv[++index] || '').toLowerCase();
       continue;
@@ -327,6 +340,10 @@ function parseArgs(argv) {
 
   if (!VALID_FORMATS.has(parsed.format)) {
     throw new Error(`Invalid format "${parsed.format}". Expected text, json, json-v1, markdown, html, or github.`);
+  }
+
+  if (!BADGE_METRICS.has(parsed.badgeMetric)) {
+    throw new Error(`Invalid badge metric "${parsed.badgeMetric}". Expected drift or findings.`);
   }
 
   if (parsed.since && parsed.staged) {

--- a/src/audit/render-badge.js
+++ b/src/audit/render-badge.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * shields.io endpoint badge: https://shields.io/badges/endpoint
+ *
+ * `drift` reports 100 minus scale cleanliness as a percentage (the share of
+ * scanned files with at least one finding). `findings` reports the number of
+ * off-scale CSS values plus Tailwind class-string findings.
+ */
+const BADGE_METRICS = new Set(['drift', 'findings']);
+
+const THRESHOLDS = {
+  drift: [[2, 'brightgreen'], [5, 'green'], [15, 'yellow']],
+  findings: [[0, 'brightgreen'], [10, 'green'], [50, 'yellow']],
+};
+
+function badgeColor(metric, value) {
+  for (const [limit, color] of THRESHOLDS[metric]) {
+    if (value <= limit) {
+      return color;
+    }
+  }
+  return 'orange';
+}
+
+function badgeValue(report, metric) {
+  if (metric === 'drift') {
+    const cleanliness = Number.isFinite(report.scaleCleanliness) ? report.scaleCleanliness : 100;
+    return Math.max(0, Math.min(100, 100 - cleanliness));
+  }
+  const css = (report.findings && report.findings.css) || [];
+  const tailwind = (report.findings && report.findings.tailwind) || [];
+  return css.filter((finding) => finding.type === 'off-scale').length + tailwind.length;
+}
+
+function renderBadge(report, { metric = 'drift' } = {}) {
+  if (!BADGE_METRICS.has(metric)) {
+    throw new Error(`Unknown badge metric "${metric}". Use one of: ${Array.from(BADGE_METRICS).join(', ')}.`);
+  }
+  const value = badgeValue(report, metric);
+  const badge = {
+    schemaVersion: 1,
+    label: metric === 'drift' ? 'spacing drift' : 'off-scale values',
+    message: metric === 'drift' ? `${value}%` : String(value),
+    color: badgeColor(metric, value),
+  };
+  return `${JSON.stringify(badge, null, 2)}\n`;
+}
+
+module.exports = {
+  BADGE_METRICS,
+  badgeColor,
+  renderBadge,
+};

--- a/src/audit/shared.js
+++ b/src/audit/shared.js
@@ -18,7 +18,7 @@ const DEFAULT_AUDIT_TOKEN_PATTERN = '^--(space|spacing)-';
 
 const DEFAULT_TOKEN_CANDIDATE_MIN_COUNT = 2;
 
-const VALID_FORMATS = new Set(['text', 'json', 'json-v1', 'markdown', 'html', 'github']);
+const VALID_FORMATS = new Set(['text', 'json', 'json-v1', 'markdown', 'html', 'github', 'badge']);
 
 const SKIP_DIRS = new Set([
   '.git',
@@ -69,6 +69,7 @@ function createDefaultAuditOptions() {
     configPath: DEFAULT_CONFIG_PATH,
     dir: null,
     failOnNewDrift: false,
+    badgeMetric: 'drift',
     format: 'text',
     ignorePath: DEFAULT_IGNORE_PATH,
     ignorePatterns: [],

--- a/src/cli/audit.js
+++ b/src/cli/audit.js
@@ -13,6 +13,7 @@ const {
   toAuditContractReport,
 } = require('../audit/contract');
 const { renderGithub } = require('../audit/render-github');
+const { renderBadge } = require('../audit/render-badge');
 const { renderHtml } = require('../audit/render-html');
 const { renderMarkdown } = require('../audit/render-markdown');
 const { renderText } = require('../audit/render-text');
@@ -73,6 +74,11 @@ async function run() {
     return;
   }
 
+  if (parsed.format === 'badge') {
+    writeOutput(renderBadge(report, { metric: parsed.badgeMetric }), parsed.outputPath);
+    return;
+  }
+
   if (parsed.format === 'github') {
     writeOutput(renderGithub(report), parsed.outputPath);
     finish(auditFailures);
@@ -108,6 +114,7 @@ module.exports = {
   createAuditReport,
   loadAuditConfig,
   parseArgs,
+  renderBadge,
   renderHtml,
   run,
   toAuditContractReport,

--- a/test/audit-badge.test.js
+++ b/test/audit-badge.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { badgeColor, renderBadge } = require('../src/audit/render-badge');
+
+test('renderBadge emits a shields.io endpoint document for spacing drift', () => {
+  const report = { scaleCleanliness: 97, findings: { css: [], tailwind: [] } };
+  const badge = JSON.parse(renderBadge(report));
+
+  assert.deepEqual(badge, {
+    schemaVersion: 1,
+    label: 'spacing drift',
+    message: '3%',
+    color: 'green',
+  });
+});
+
+test('renderBadge can report the off-scale finding count instead', () => {
+  const report = {
+    scaleCleanliness: 50,
+    findings: {
+      css: [{ type: 'off-scale' }, { type: 'off-scale' }, { type: 'token-opportunity' }],
+      tailwind: [{ token: 'p-[13px]' }],
+    },
+  };
+  const badge = JSON.parse(renderBadge(report, { metric: 'findings' }));
+
+  assert.equal(badge.label, 'off-scale values');
+  assert.equal(badge.message, '3');
+  assert.equal(badge.color, 'green');
+});
+
+test('badgeColor thresholds for drift percent', () => {
+  assert.equal(badgeColor('drift', 0), 'brightgreen');
+  assert.equal(badgeColor('drift', 2), 'brightgreen');
+  assert.equal(badgeColor('drift', 3), 'green');
+  assert.equal(badgeColor('drift', 5), 'green');
+  assert.equal(badgeColor('drift', 6), 'yellow');
+  assert.equal(badgeColor('drift', 15), 'yellow');
+  assert.equal(badgeColor('drift', 16), 'orange');
+});
+
+test('badgeColor thresholds for finding counts', () => {
+  assert.equal(badgeColor('findings', 0), 'brightgreen');
+  assert.equal(badgeColor('findings', 10), 'green');
+  assert.equal(badgeColor('findings', 11), 'yellow');
+  assert.equal(badgeColor('findings', 50), 'yellow');
+  assert.equal(badgeColor('findings', 51), 'orange');
+});
+
+test('renderBadge rejects an unknown metric', () => {
+  assert.throws(() => renderBadge({ scaleCleanliness: 100, findings: { css: [], tailwind: [] } }, { metric: 'vibes' }), /badge metric/);
+});

--- a/test/audit-cli.test.js
+++ b/test/audit-cli.test.js
@@ -137,6 +137,26 @@ test('audit CLI markdown emits a PR-ready design-system report', () => {
   assert.match(result.stdout, /`md:p-\[12px\]`/);
 });
 
+test('audit CLI --format badge writes a shields.io endpoint document', () => {
+  const fixtureDir = createAuditFixture();
+  const result = runAudit(fixtureDir, '--format', 'badge');
+
+  assert.equal(result.status, 0, result.stderr);
+  const badge = JSON.parse(result.stdout);
+  assert.equal(badge.schemaVersion, 1);
+  assert.equal(badge.label, 'spacing drift');
+  assert.equal(badge.message, '100%');
+  assert.equal(badge.color, 'orange');
+
+  const counted = runAudit(fixtureDir, '--format', 'badge', '--badge-metric', 'findings');
+  assert.equal(counted.status, 0, counted.stderr);
+  assert.equal(JSON.parse(counted.stdout).message, '3');
+
+  const written = runAudit(fixtureDir, '--format', 'badge', '--output', path.join(fixtureDir, 'badges', 'spacing.json'));
+  assert.equal(written.status, 0, written.stderr);
+  assert.equal(JSON.parse(fs.readFileSync(path.join(fixtureDir, 'badges', 'spacing.json'), 'utf8')).label, 'spacing drift');
+});
+
 test('audit CLI ignores root-relative paths before scanning', () => {
   const fixtureDir = createAuditFixture();
   const ignoredDir = path.join(fixtureDir, 'src', 'legacy');

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -27,7 +27,9 @@ export interface AuditOptions {
   configPath?: string;
   dir?: string;
   failOnNewDrift?: boolean;
-  format?: "json" | "json-v1" | "markdown" | "text" | "html" | "github";
+  /** Badge value when `format` is "badge": drift percent or off-scale count. */
+  badgeMetric?: "drift" | "findings";
+  format?: "json" | "json-v1" | "markdown" | "text" | "html" | "github" | "badge";
   ignorePath?: string;
   ignorePatterns?: string[];
   includeMotion?: boolean;


### PR DESCRIPTION
Closes #68.

- `rhythmguard audit --format badge` writes a shields.io endpoint document (`schemaVersion`, `label`, `message`, `color`).
- Default metric `drift`: 100 minus scale cleanliness, labelled `spacing drift`. `--badge-metric findings`: off-scale CSS values plus Tailwind findings, labelled `off-scale values`.
- Colour thresholds: drift 0–2% brightgreen, ≤5% green, ≤15% yellow, else orange; findings 0 / ≤10 / ≤50 / else.
- `--output` works as for the other formats. Types updated (`badgeMetric`, `format` union).
- Docs: badge section in `docs/AUDIT.md`, publishing workflow as section 5 of `docs/CI_ADOPTION.md`, one line in the README.

Local gate: lint, typecheck, 174 tests, all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
