### PR TITLE
fix(audit): apply exit gates to --format badge

### DIFF
--- a/src/cli/audit.js
+++ b/src/cli/audit.js
@@ -76,6 +76,7 @@ async function run() {
 
   if (parsed.format === 'badge') {
     writeOutput(renderBadge(report, { metric: parsed.badgeMetric }), parsed.outputPath);
+    finish(auditFailures);
     return;
   }
 

--- a/test/audit-cli.test.js
+++ b/test/audit-cli.test.js
@@ -152,6 +152,10 @@ test('audit CLI --format badge writes a shields.io endpoint document', () => {
   assert.equal(counted.status, 0, counted.stderr);
   assert.equal(JSON.parse(counted.stdout).message, '3');
 
+  const gated = runAudit(fixtureDir, '--format', 'badge', '--max-findings', '0');
+  assert.equal(gated.status, 1, 'gate flags apply to the badge format too');
+  assert.equal(JSON.parse(gated.stdout).label, 'spacing drift', 'the badge is still written when the gate fails');
+
   const written = runAudit(fixtureDir, '--format', 'badge', '--output', path.join(fixtureDir, 'badges', 'spacing.json'));
   assert.equal(written.status, 0, written.stderr);
   assert.equal(JSON.parse(fs.readFileSync(path.join(fixtureDir, 'badges', 'spacing.json'), 'utf8')).label, 'spacing drift');


### PR DESCRIPTION
The badge branch in `src/cli/audit.js` returned before `finish(auditFailures)`, so `--max-findings`, `--min-cleanliness` and `--fail-on-new-drift" were silently ignored with `--format badge`. Fixed, with a CLI test asserting exit 1 and that the badge is still written. Lint and the audit suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)