### PR TITLE
feat(bench): plausibility check for inferred scales in editions and drafts

### DIFF
--- a/docs/STATE_OF_SPACING.md
+++ b/docs/STATE_OF_SPACING.md
@@ -8,19 +8,19 @@ This is not a ranking of teams. It is a reading of one signal on a fixed commit,
 npx rhythmguard audit . --scale auto --format markdown
 ```
 
-Across the set: 7471 off-scale values in 8585 CSS files; 39 of 57 repositories had no discoverable spacing tokens and were measured against the `rhythmic-4` fallback, which says more about token discovery than about their CSS.
+Across the set: 7471 off-scale values in 8585 CSS files; 39 of 57 repositories had no discoverable spacing tokens and were measured against the `rhythmic-4` fallback, which says more about token discovery than about their CSS, and 5 more had an inference the plausibility check rejected (marked `unreliable`; usually component-local variables, see issue #54).
 
 ## Repositories
 
 | Repo | Commit | Scale source | Off-scale | per 100 CSS files | Cleanliness | Top values | Top properties |
 | --- | --- | --- | ---: | ---: | ---: | --- | --- |
-| [zulip](https://github.com/zulip/zulip) | `9b991a8` | scanned-css | 1743 | 2601 | 16% | `10px` ×437, `20px` ×206, `4px` ×122 | `padding` ×658, `margin` ×349, `margin-top` ×178 |
+| [zulip](https://github.com/zulip/zulip) | `9b991a8` | scanned-css (unreliable) | 1743 | 2601 | 16% | `10px` ×437, `20px` ×206, `4px` ×122 | `padding` ×658, `margin` ×349, `margin-top` ×178 |
 | [mastodon](https://github.com/mastodon/mastodon) | `0a32b4a` | scanned-css | 564 | 1567 | 53% | `10px` ×165, `15px` ×112, `5px` ×70 | `padding` ×206, `margin-bottom` ×99, `gap` ×41 |
 | [mattermost-webapp](https://github.com/mattermost/mattermost) | `502cf7e` | fallback | 1058 | 1027 | 23% | `10px` ×162, `5px` ×150, `20px` ×108 | `padding` ×400, `margin` ×219, `margin-right` ×90 |
 | [calcom](https://github.com/calcom/cal.com) | `e91bb0c` | fallback | 40 | 1000 | 95% | `10px` ×9, `2px` ×9, `6px` ×3 | `padding` ×15, `class-string` ×13, `margin` ×2 |
 | [grafana](https://github.com/grafana/grafana) | `c6fad86` | scanned-css | 57 | 950 | 83% | `10px` ×9, `15px` ×9, `5px` ×7 | `padding` ×34, `padding-left` ×8, `margin-top` ×4 |
 | [ghost-admin](https://github.com/TryGhost/Ghost) | `26746d3` | fallback | 745 | 626 | 82% | `2px` ×70, `10px` ×69, `6px` ×62 | `padding` ×294, `margin` ×167, `margin-top` ×68 |
-| [shadcn-ui](https://github.com/shadcn-ui/ui) | `7c9eaba` | scanned-css | 58 | 446 | 99% | `-2.5rem` ×8, `2.5rem` ×8, `2px` ×5 | `class-string` ×47, `padding` ×6, `margin-block-start` ×2 |
+| [shadcn-ui](https://github.com/shadcn-ui/ui) | `7c9eaba` | scanned-css (unreliable) | 58 | 446 | 99% | `-2.5rem` ×8, `2.5rem` ×8, `2px` ×5 | `class-string` ×47, `padding` ×6, `margin-block-start` ×2 |
 | [forem](https://github.com/forem/forem) | `e8a0729` | fallback | 590 | 415 | 53% | `10px` ×87, `2px` ×57, `5px` ×57 | `padding` ×266, `margin` ×119, `margin-top` ×46 |
 | [adminlte](https://github.com/ColorlibHQ/AdminLTE) | `12b4b06` | fallback | 126 | 274 | 63% | `10px` ×20, `1.25rem` ×9, `2px` ×9 | `padding` ×50, `margin-top` ×17, `margin` ×15 |
 | [directus-app](https://github.com/directus/directus) | `3df2ba9` | fallback | 63 | 217 | 59% | `-0.3125rem` ×17, `0.4375rem` ×9, `-0.1875rem` ×6 | `padding` ×17, `inset-inline-start` ×6, `inset-block-start` ×5 |
@@ -34,7 +34,7 @@ Across the set: 7471 off-scale values in 8585 CSS files; 39 of 57 repositories h
 | [liveblocks-react-ui](https://github.com/liveblocks/liveblocks) | `98332db` | fallback | 9 | 150 | 99% | `-0.35rem` ×2, `0.1em` ×1, `0.2em` ×1 | `padding` ×4, `padding-inline-start` ×2, `inset-block-start` ×1 |
 | [hashicorp-design-system](https://github.com/hashicorp/design-system) | `83cac84` | fallback | 109 | 120 | 53% | `2px` ×24, `10px` ×13, `3px` ×12 | `padding` ×65, `margin` ×15, `margin-top` ×13 |
 | [carbon-styles](https://github.com/carbon-design-system/carbon) | `4cc7900` | fallback | 272 | 96 | 81% | `13px` ×28, `2px` ×23, `7px` ×19 | `inset-block-start` ×60, `padding` ×37, `padding-block` ×36 |
-| [discourse](https://github.com/discourse/discourse) | `c7b7a0b` | scanned-css | 349 | 93 | 34% | `0.15em` ×38, `15px` ×34, `0.35em` ×27 | `padding` ×130, `margin-top` ×34, `margin` ×33 |
+| [discourse](https://github.com/discourse/discourse) | `c7b7a0b` | scanned-css (unreliable) | 349 | 93 | 34% | `0.15em` ×38, `15px` ×34, `0.35em` ×27 | `padding` ×130, `margin-top` ×34, `margin` ×33 |
 | [primer-css](https://github.com/primer/css) | `72564a3` | scanned-css | 103 | 91 | 75% | `5px` ×17, `6px` ×11, `7px` ×9 | `padding` ×45, `margin` ×22, `margin-left` ×8 |
 | [materialize](https://github.com/materializecss/materialize) | `c9d6914` | scanned-css | 9 | 60 | 80% | `10px` ×3, `15px` ×2, `14px` ×1 | `padding` ×5, `padding-left` ×2, `margin` ×1 |
 | [metabase](https://github.com/metabase/metabase) | `e621647` | fallback | 55 | 56 | 94% | `0.375rem` ×6, `2px` ×5, `15px` ×4 | `padding` ×24, `padding-right` ×8, `padding-left` ×3 |
@@ -47,7 +47,7 @@ Across the set: 7471 off-scale values in 8585 CSS files; 39 of 57 repositories h
 | [daisyui](https://github.com/saadeghi/daisyui) | `1435c65` | fallback | 37 | 34 | 93% | `0.125rem` ×3, `1.4rem` ×3, `5px` ×3 | `padding` ×12, `inset-inline-end` ×5, `class-string` ×4 |
 | [utrecht](https://github.com/nl-design-system/utrecht) | `ecedc4b` | fallback | 47 | 29 | 99% | `3rem` ×8, `26px` ×7, `10px` ×5 | `padding` ×12, `margin-bottom` ×4, `margin-left` ×4 |
 | [foundation-sites](https://github.com/foundation/foundation-sites) | `337be7a` | fallback | 34 | 29 | 85% | `10px` ×5, `2.5rem` ×4, `30px` ×4 | `padding` ×11, `margin-bottom` ×8, `transform` ×4 |
-| [mantine](https://github.com/mantinedev/mantine) | `3862b09` | scanned-css | 30 | 29 | 98% | `4px` ×6, `5px` ×6, `8px` ×4 | `padding` ×10, `inset-inline-start` ×3, `margin-top` ×3 |
+| [mantine](https://github.com/mantinedev/mantine) | `3862b09` | scanned-css (unreliable) | 30 | 29 | 98% | `4px` ×6, `5px` ×6, `8px` ×4 | `padding` ×10, `inset-inline-start` ×3, `margin-top` ×3 |
 | [nhsuk-frontend](https://github.com/nhsuk/nhsuk-frontend) | `10caad9` | fallback | 28 | 19 | 97% | `-6px` ×7, `2px` ×5, `6px` ×5 | `margin-left` ×8, `margin-right` ×8, `padding-top` ×5 |
 | [mozilla-protocol](https://github.com/mozilla/protocol) | `6bcf867` | fallback | 18 | 17 | 83% | `-60px` ×2, `0.35em` ×2, `1.25em` ×2 | `padding` ×5, `transform` ×4, `margin` ×3 |
 | [ui5-webcomponents](https://github.com/SAP/ui5-webcomponents) | `9856f4f` | fallback | 75 | 14 | 85% | `0.125rem` ×18, `0.375rem` ×7, `0.1875rem` ×6 | `padding` ×21, `inset` ×7, `margin-inline-start` ×6 |
@@ -68,7 +68,7 @@ Across the set: 7471 off-scale values in 8585 CSS files; 39 of 57 repositories h
 | [ionic-core](https://github.com/ionic-team/ionic-framework) | `5874331` | fallback | 8 | 2 | 99% | `2px` ×4, `-10px` ×1, `10px` ×1 | `margin-top` ×5, `margin-bottom` ×1, `padding-bottom` ×1 |
 | [spectrum-css](https://github.com/adobe/spectrum-css) | `3762086` | fallback | 5 | 2 | 99% | `-10px` ×3, `20px` ×1, `40px` ×1 | `inset-block-end` ×1, `margin` ×1, `margin-inline-end` ×1 |
 | [mittwald-flow](https://github.com/mittwald/flow) | `17efdf9` | fallback | 2 | 2 | 100% | `2px` ×2 | `padding-inline-end` ×1, `padding-inline-start` ×1 |
-| [semi-design](https://github.com/DouyinFE/semi-design) | `8bed560` | scanned-css | 2 | 1 | 98% | `0.8em` ×1, `3.8em` ×1 | `padding-left` ×1, `padding-right` ×1 |
+| [semi-design](https://github.com/DouyinFE/semi-design) | `8bed560` | scanned-css (unreliable) | 2 | 1 | 98% | `0.8em` ×1, `3.8em` ×1 | `padding-left` ×1, `padding-right` ×1 |
 | [open-props](https://github.com/argyleink/open-props) | `530682d` | fallback | 0 | 0 | 100% | none | none |
 | [skeleton](https://github.com/skeletonlabs/skeleton) | `e65535e` | scanned-css | 0 | 0 | 100% | none | none |
 
@@ -78,6 +78,7 @@ Across the set: 7471 off-scale values in 8585 CSS files; 39 of 57 repositories h
 - **Top values** are the numbers that drifted. Three values usually explain most of a repository's drift, and each one is a single decision: a missing step, a mistake, or a token that was never defined.
 - **Top properties** are where the layout decision lives. A table led by sibling margins usually means the parent should own the spacing with `gap`; a table led by `padding` is component-internal and is fixed per component.
 - **Top properties** may include `class-string`, which is a Tailwind arbitrary value in a template rather than a CSS declaration.
+- **Scale source** `unreliable` marks a scanned scale that failed a plausibility check (fractional steps, no four-based ladder, or sources that are component files rather than token files). Its row is measured against a scale the repository probably did not design; treat it like a fallback.
 - **Scale source** `fallback` means the audit found fewer than three spacing tokens and used a default scale. Treat those rows as a to-do for token discovery, not as a verdict on the CSS.
 
 ## Method and caveats

--- a/docs/outreach/audits/discourse.md
+++ b/docs/outreach/audits/discourse.md
@@ -1,17 +1,12 @@
-# Spacing scale audit: 349 literal spacing values off your own token scale
+# Spacing scale: where do your spacing tokens live? (audit from the Rhythmguard benchmark)
 
 Hi. I maintain [stylelint-plugin-rhythmguard](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard), a Stylelint rule that checks spacing values against a project's own scale. To keep it quiet on code I do not control, I run it against public design systems on pinned commits and publish the numbers. This repository is one of them, and I would rather you saw the audit here than in a report first.
 
 **What was run.** `npx rhythmguard audit . --scale auto` at `c7b7a0b` over `app/assets/stylesheets`. Hairlines of one pixel or less, percentages, and generated or test paths are excluded. Anyone can reproduce it in a checkout of that commit.
 
-**What it found.** Scale `0, 1, 1.3, 2, 3, 4, 5, 5.28, 6, 7, 8, 9, 9.28, 10, 11, 12, 14, 16, 20, 24, 28, 32, 36, 40, 44, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 384` inferred from your own spacing tokens in the stylesheets. 349 literal spacing values are off that scale.
+**What it found.** Scale inference picked up variables that do not form a spacing scale (it derived `0, 1, 1.3, 2, 3, 4, 5, 5.28, 6, 7, 8, 9, 9.28, 10, 11, 12, 14, 16, 20, 24, 28, 32, 36, 40, 44, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 384` from `app/assets/stylesheets/admin/schema_setting_editor.scss`, `app/assets/stylesheets/common/base/discourse.scss` and others), most likely component-local spacing variables rather than your tokens. Measured against that, it reported 349 values, which is my tool's mistake and not a number I will quote.
 
-- Values: `0.15em` ×38, `15px` ×34, `0.35em` ×27, `0.2em` ×20, `0.1em` ×19
-- Properties: `padding` ×130, `margin-top` ×34, `margin` ×33, `margin-left` ×29, `gap` ×26
-
-Three values usually explain most of the count, and each is a single decision: a step the scale is missing, a slip, or a token nobody defined. A property table led by sibling margins often means the parent could own the spacing with `gap`.
-
-**The ask.** Nothing is required. If the numbers are useful, I can open a small PR for the top value with before and after screenshots, or a one-rule Stylelint config at warning level that reports new off-scale values against your tokens and nothing else. If the findings are wrong for this codebase, tell me which ones; false positives are the most valuable report the tool gets and they change its defaults.
+**The ask.** If you can point me at where the spacing scale is defined (a token file, a Sass map, a package), I will teach the tool to prefer it, re-run the audit on the real scale, and post the result here. If spacing is intentionally not on a scale, saying so is just as useful and I will mark the row that way.
 
 The row for this repository will appear in a periodic "State of Spacing" table in the Rhythmguard repository, with this issue linked. If you would rather not be listed, say so here and I will remove it.
 

--- a/docs/outreach/audits/mantine.md
+++ b/docs/outreach/audits/mantine.md
@@ -1,17 +1,12 @@
-# Spacing scale audit: 30 literal spacing values off your own token scale
+# Spacing scale: where do your spacing tokens live? (audit from the Rhythmguard benchmark)
 
 Hi. I maintain [stylelint-plugin-rhythmguard](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard), a Stylelint rule that checks spacing values against a project's own scale. To keep it quiet on code I do not control, I run it against public design systems on pinned commits and publish the numbers. This repository is one of them, and I would rather you saw the audit here than in a report first.
 
 **What was run.** `npx rhythmguard audit . --scale auto` at `3862b09` over `packages/@mantine/core/src`. Hairlines of one pixel or less, percentages, and generated or test paths are excluded. Anyone can reproduce it in a checkout of that commit.
 
-**What it found.** Scale `0, 1, 2, 10, 12, 16, 20, 22, 32` inferred from your own spacing tokens in the stylesheets. 30 literal spacing values are off that scale.
+**What it found.** Scale inference picked up variables that do not form a spacing scale (it derived `0, 1, 2, 10, 12, 16, 20, 22, 32` from `packages/@mantine/core/src/components/Avatar/Avatar.module.css`, `packages/@mantine/core/src/components/Chip/Chip.module.css` and others), most likely component-local spacing variables rather than your tokens. Measured against that, it reported 30 values, which is my tool's mistake and not a number I will quote.
 
-- Values: `4px` ×6, `5px` ×6, `8px` ×4, `-4px` ×2, `0.3em` ×2
-- Properties: `padding` ×10, `inset-inline-start` ×3, `margin-top` ×3, `transform` ×3, `gap` ×2
-
-Three values usually explain most of the count, and each is a single decision: a step the scale is missing, a slip, or a token nobody defined. A property table led by sibling margins often means the parent could own the spacing with `gap`.
-
-**The ask.** Nothing is required. If the numbers are useful, I can open a small PR for the top value with before and after screenshots, or a one-rule Stylelint config at warning level that reports new off-scale values against your tokens and nothing else. If the findings are wrong for this codebase, tell me which ones; false positives are the most valuable report the tool gets and they change its defaults.
+**The ask.** If you can point me at where the spacing scale is defined (a token file, a Sass map, a package), I will teach the tool to prefer it, re-run the audit on the real scale, and post the result here. If spacing is intentionally not on a scale, saying so is just as useful and I will mark the row that way.
 
 The row for this repository will appear in a periodic "State of Spacing" table in the Rhythmguard repository, with this issue linked. If you would rather not be listed, say so here and I will remove it.
 

--- a/docs/outreach/audits/semi-design.md
+++ b/docs/outreach/audits/semi-design.md
@@ -1,17 +1,12 @@
-# Spacing scale audit: 2 literal spacing values off your own token scale
+# Spacing scale: where do your spacing tokens live? (audit from the Rhythmguard benchmark)
 
 Hi. I maintain [stylelint-plugin-rhythmguard](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard), a Stylelint rule that checks spacing values against a project's own scale. To keep it quiet on code I do not control, I run it against public design systems on pinned commits and publish the numbers. This repository is one of them, and I would rather you saw the audit here than in a report first.
 
 **What was run.** `npx rhythmguard audit . --scale auto` at `8bed560` over `packages/semi-foundation`. Hairlines of one pixel or less, percentages, and generated or test paths are excluded. Anyone can reproduce it in a checkout of that commit.
 
-**What it found.** Scale `0, 0.4, 0.7, 0.8, 1, 1.1, 1.4, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 23, 24, 25, 26, 28, 29, 30, 31, 32, 34, 36, 40, 48, 50, 52, 60, 64, 68, 80, 100, 120, 132, 280` inferred from your own spacing tokens in the stylesheets. 2 literal spacing values are off that scale.
+**What it found.** Scale inference picked up variables that do not form a spacing scale (it derived `0, 0.4, 0.7, 0.8, 1, 1.1, 1.4, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 23, 24, 25, 26, 28, 29, 30, 31, 32, 34, 36, 40, 48, 50, 52, 60, 64, 68, 80, 100, 120, 132, 280` from `packages/semi-foundation/aiChatDialogue/variables.scss`, `packages/semi-foundation/aiChatInput/variables.scss` and others), most likely component-local spacing variables rather than your tokens. Measured against that, it reported 2 values, which is my tool's mistake and not a number I will quote.
 
-- Values: `0.8em` ×1, `3.8em` ×1
-- Properties: `padding-left` ×1, `padding-right` ×1
-
-Three values usually explain most of the count, and each is a single decision: a step the scale is missing, a slip, or a token nobody defined. A property table led by sibling margins often means the parent could own the spacing with `gap`.
-
-**The ask.** Nothing is required. If the numbers are useful, I can open a small PR for the top value with before and after screenshots, or a one-rule Stylelint config at warning level that reports new off-scale values against your tokens and nothing else. If the findings are wrong for this codebase, tell me which ones; false positives are the most valuable report the tool gets and they change its defaults.
+**The ask.** If you can point me at where the spacing scale is defined (a token file, a Sass map, a package), I will teach the tool to prefer it, re-run the audit on the real scale, and post the result here. If spacing is intentionally not on a scale, saying so is just as useful and I will mark the row that way.
 
 The row for this repository will appear in a periodic "State of Spacing" table in the Rhythmguard repository, with this issue linked. If you would rather not be listed, say so here and I will remove it.
 

--- a/docs/outreach/audits/shadcn-ui.md
+++ b/docs/outreach/audits/shadcn-ui.md
@@ -1,17 +1,12 @@
-# Spacing scale audit: 58 literal spacing values off your own token scale
+# Spacing scale: where do your spacing tokens live? (audit from the Rhythmguard benchmark)
 
 Hi. I maintain [stylelint-plugin-rhythmguard](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard), a Stylelint rule that checks spacing values against a project's own scale. To keep it quiet on code I do not control, I run it against public design systems on pinned commits and publish the numbers. This repository is one of them, and I would rather you saw the audit here than in a report first.
 
 **What was run.** `npx rhythmguard audit . --scale auto` at `7c9eaba` over `apps/v4/app`, `apps/v4/registry`, `apps/v4/components`. Hairlines of one pixel or less, percentages, and generated or test paths are excluded. Anyone can reproduce it in a checkout of that commit.
 
-**What it found.** Scale `0, 1.6, 1.778, 3.2, 3.555, 3.556, 4.8, 5.333, 6.4, 7.11, 7.111, 8, 8.888, 8.889, 9.6, 10.666, 10.667, 11.2, 12.443, 12.444, 12.8, 14.221, 14.222, 16, 17.776, 17.778, 19.2, 21.331, 21.333, 22.4, 24.886, 24.889, 25.6, 28.442, 28.444, 28.8, 31.997, 32, 35.2, 35.552, 35.556, 38.4, 39.107, 39.111, 42.662, 42.667, 44.8, 49.773, 49.778, 51.2, 56.883, 56.889, 64, 71.104, 71.111, 76.8, 85.325, 85.333, 89.6, 99.546, 99.555, 102.4, 113.766, 113.778, 115.2, 127.987, 128, 140.8, 142.208, 142.222, 153.6, 156.429, 156.444, 166.4, 170.65, 170.666, 179.2, 184.87, 184.889, 192, 199.091, 199.111, 204.8, 213.312, 213.333, 227.533, 227.555, 230.4, 255.974, 256, 284.416, 284.444, 307.2, 341.299, 341.333` inferred from your own spacing tokens in the stylesheets. 58 literal spacing values are off that scale.
+**What it found.** Scale inference picked up variables that do not form a spacing scale (it derived `0, 1.6, 1.778, 3.2, 3.555, 3.556, 4.8, 5.333, 6.4, 7.11, 7.111, 8, 8.888, 8.889, 9.6, 10.666, 10.667, 11.2, 12.443, 12.444, 12.8, 14.221, 14.222, 16, 17.776, 17.778, 19.2, 21.331, 21.333, 22.4, 24.886, 24.889, 25.6, 28.442, 28.444, 28.8, 31.997, 32, 35.2, 35.552, 35.556, 38.4, 39.107, 39.111, 42.662, 42.667, 44.8, 49.773, 49.778, 51.2, 56.883, 56.889, 64, 71.104, 71.111, 76.8, 85.325, 85.333, 89.6, 99.546, 99.555, 102.4, 113.766, 113.778, 115.2, 127.987, 128, 140.8, 142.208, 142.222, 153.6, 156.429, 156.444, 166.4, 170.65, 170.666, 179.2, 184.87, 184.889, 192, 199.091, 199.111, 204.8, 213.312, 213.333, 227.533, 227.555, 230.4, 255.974, 256, 284.416, 284.444, 307.2, 341.299, 341.333` from `apps/v4/app/legacy-themes.css`, `apps/v4/registry/styles/style-luma.css` and others), most likely component-local spacing variables rather than your tokens. Measured against that, it reported 58 values, which is my tool's mistake and not a number I will quote.
 
-- Values: `-2.5rem` ×8, `2.5rem` ×8, `2px` ×5, `-5px` ×4, `0.25em` ×4
-- Properties: `class-string` ×47, `padding` ×6, `margin-block-start` ×2, `padding-inline-start` ×2, `padding-block` ×1
-
-Three values usually explain most of the count, and each is a single decision: a step the scale is missing, a slip, or a token nobody defined. A property table led by sibling margins often means the parent could own the spacing with `gap`.
-
-**The ask.** Nothing is required. If the numbers are useful, I can open a small PR for the top value with before and after screenshots, or a one-rule Stylelint config at warning level that reports new off-scale values against your tokens and nothing else. If the findings are wrong for this codebase, tell me which ones; false positives are the most valuable report the tool gets and they change its defaults.
+**The ask.** If you can point me at where the spacing scale is defined (a token file, a Sass map, a package), I will teach the tool to prefer it, re-run the audit on the real scale, and post the result here. If spacing is intentionally not on a scale, saying so is just as useful and I will mark the row that way.
 
 The row for this repository will appear in a periodic "State of Spacing" table in the Rhythmguard repository, with this issue linked. If you would rather not be listed, say so here and I will remove it.
 

--- a/docs/outreach/audits/zulip.md
+++ b/docs/outreach/audits/zulip.md
@@ -1,17 +1,12 @@
-# Spacing scale audit: 1743 literal spacing values off your own token scale
+# Spacing scale: where do your spacing tokens live? (audit from the Rhythmguard benchmark)
 
 Hi. I maintain [stylelint-plugin-rhythmguard](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard), a Stylelint rule that checks spacing values against a project's own scale. To keep it quiet on code I do not control, I run it against public design systems on pinned commits and publish the numbers. This repository is one of them, and I would rather you saw the audit here than in a report first.
 
 **What was run.** `npx rhythmguard audit . --scale auto` at `9b991a8` over `web/styles`. Hairlines of one pixel or less, percentages, and generated or test paths are excluded. Anyone can reproduce it in a checkout of that commit.
 
-**What it found.** Scale `0, 2, 3, 5, 6, 25` inferred from your own spacing tokens in the stylesheets. 1743 literal spacing values are off that scale.
+**What it found.** Scale inference picked up variables that do not form a spacing scale (it derived `0, 2, 3, 5, 6, 25` from `web/styles/app_variables.css`), most likely component-local spacing variables rather than your tokens. Measured against that, it reported 1743 values, which is my tool's mistake and not a number I will quote.
 
-- Values: `10px` ×437, `20px` ×206, `4px` ×122, `30px` ×88, `50px` ×88
-- Properties: `padding` ×658, `margin` ×349, `margin-top` ×178, `margin-bottom` ×143, `gap` ×86
-
-Three values usually explain most of the count, and each is a single decision: a step the scale is missing, a slip, or a token nobody defined. A property table led by sibling margins often means the parent could own the spacing with `gap`.
-
-**The ask.** Nothing is required. If the numbers are useful, I can open a small PR for the top value with before and after screenshots, or a one-rule Stylelint config at warning level that reports new off-scale values against your tokens and nothing else. If the findings are wrong for this codebase, tell me which ones; false positives are the most valuable report the tool gets and they change its defaults.
+**The ask.** If you can point me at where the spacing scale is defined (a token file, a Sass map, a package), I will teach the tool to prefer it, re-run the audit on the real scale, and post the result here. If spacing is intentionally not on a scale, saying so is just as useful and I will mark the row that way.
 
 The row for this repository will appear in a periodic "State of Spacing" table in the Rhythmguard repository, with this issue linked. If you would rather not be listed, say so here and I will remove it.
 

--- a/docs/state-of-spacing/2026-09.json
+++ b/docs/state-of-spacing/2026-09.json
@@ -12,6 +12,10 @@
       "drift": 1743,
       "driftPer100Files": 2601,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "not a four-based ladder"
+      ],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -59,6 +63,8 @@
       "drift": 564,
       "driftPer100Files": 1567,
       "driftDelta": null,
+      "scaleReliable": true,
+      "scaleReasons": [],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -112,6 +118,10 @@
       "drift": 1058,
       "driftPer100Files": 1027,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -160,6 +170,10 @@
       "drift": 40,
       "driftPer100Files": 1000,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -208,6 +222,8 @@
       "drift": 57,
       "driftPer100Files": 950,
       "driftDelta": null,
+      "scaleReliable": true,
+      "scaleReasons": [],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -256,6 +272,10 @@
       "drift": 745,
       "driftPer100Files": 626,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -304,6 +324,12 @@
       "drift": 58,
       "driftPer100Files": 446,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fractional values",
+        "not a four-based ladder",
+        "sources are component files"
+      ],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -440,6 +466,10 @@
       "drift": 590,
       "driftPer100Files": 415,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -488,6 +518,10 @@
       "drift": 126,
       "driftPer100Files": 274,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -536,6 +570,10 @@
       "drift": 63,
       "driftPer100Files": 217,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -584,6 +622,10 @@
       "drift": 23,
       "driftPer100Files": 209,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -632,6 +674,10 @@
       "drift": 74,
       "driftPer100Files": 195,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -680,6 +726,10 @@
       "drift": 30,
       "driftPer100Files": 188,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -728,6 +778,8 @@
       "drift": 143,
       "driftPer100Files": 186,
       "driftDelta": null,
+      "scaleReliable": true,
+      "scaleReasons": [],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -783,6 +835,10 @@
       "drift": 126,
       "driftPer100Files": 170,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -831,6 +887,10 @@
       "drift": 80,
       "driftPer100Files": 157,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -879,6 +939,10 @@
       "drift": 222,
       "driftPer100Files": 152,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -927,6 +991,10 @@
       "drift": 9,
       "driftPer100Files": 150,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -975,6 +1043,10 @@
       "drift": 109,
       "driftPer100Files": 120,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -1023,6 +1095,10 @@
       "drift": 272,
       "driftPer100Files": 96,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -1071,6 +1147,10 @@
       "drift": 349,
       "driftPer100Files": 93,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "sources are component files"
+      ],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -1155,6 +1235,8 @@
       "drift": 103,
       "driftPer100Files": 91,
       "driftDelta": null,
+      "scaleReliable": true,
+      "scaleReasons": [],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -1209,6 +1291,8 @@
       "drift": 9,
       "driftPer100Files": 60,
       "driftDelta": null,
+      "scaleReliable": true,
+      "scaleReasons": [],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -1257,6 +1341,10 @@
       "drift": 55,
       "driftPer100Files": 56,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -1305,6 +1393,10 @@
       "drift": 4,
       "driftPer100Files": 50,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -1353,6 +1445,8 @@
       "drift": 37,
       "driftPer100Files": 49,
       "driftDelta": null,
+      "scaleReliable": true,
+      "scaleReasons": [],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -1401,6 +1495,10 @@
       "drift": 35,
       "driftPer100Files": 44,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -1449,6 +1547,8 @@
       "drift": 53,
       "driftPer100Files": 43,
       "driftDelta": null,
+      "scaleReliable": true,
+      "scaleReasons": [],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -1496,6 +1596,10 @@
       "drift": 33,
       "driftPer100Files": 43,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -1544,6 +1648,10 @@
       "drift": 137,
       "driftPer100Files": 40,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -1592,6 +1700,10 @@
       "drift": 37,
       "driftPer100Files": 34,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -1640,6 +1752,10 @@
       "drift": 47,
       "driftPer100Files": 29,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -1688,6 +1804,10 @@
       "drift": 34,
       "driftPer100Files": 29,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -1736,6 +1856,10 @@
       "drift": 30,
       "driftPer100Files": 29,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "sources are component files"
+      ],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -1786,6 +1910,10 @@
       "drift": 28,
       "driftPer100Files": 19,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -1834,6 +1962,10 @@
       "drift": 18,
       "driftPer100Files": 17,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -1882,6 +2014,10 @@
       "drift": 75,
       "driftPer100Files": 14,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -1930,6 +2066,10 @@
       "drift": 58,
       "driftPer100Files": 13,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -1978,6 +2118,10 @@
       "drift": 7,
       "driftPer100Files": 13,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -2026,6 +2170,10 @@
       "drift": 30,
       "driftPer100Files": 11,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -2074,6 +2222,10 @@
       "drift": 22,
       "driftPer100Files": 11,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -2122,6 +2274,10 @@
       "drift": 27,
       "driftPer100Files": 8,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -2170,6 +2326,8 @@
       "drift": 5,
       "driftPer100Files": 8,
       "driftDelta": null,
+      "scaleReliable": true,
+      "scaleReasons": [],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -2219,6 +2377,10 @@
       "drift": 21,
       "driftPer100Files": 7,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -2267,6 +2429,10 @@
       "drift": 17,
       "driftPer100Files": 6,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -2315,6 +2481,10 @@
       "drift": 13,
       "driftPer100Files": 6,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -2363,6 +2533,8 @@
       "drift": 12,
       "driftPer100Files": 6,
       "driftDelta": null,
+      "scaleReliable": true,
+      "scaleReasons": [],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -2418,6 +2590,8 @@
       "drift": 7,
       "driftPer100Files": 5,
       "driftDelta": null,
+      "scaleReliable": true,
+      "scaleReasons": [],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -2469,6 +2643,8 @@
       "drift": 5,
       "driftPer100Files": 3,
       "driftDelta": null,
+      "scaleReliable": true,
+      "scaleReasons": [],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -2516,6 +2692,10 @@
       "drift": 3,
       "driftPer100Files": 3,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -2560,6 +2740,8 @@
       "drift": 11,
       "driftPer100Files": 2,
       "driftDelta": null,
+      "scaleReliable": true,
+      "scaleReasons": [],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -2620,6 +2802,10 @@
       "drift": 8,
       "driftPer100Files": 2,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -2668,6 +2854,10 @@
       "drift": 5,
       "driftPer100Files": 2,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -2716,6 +2906,10 @@
       "drift": 2,
       "driftPer100Files": 2,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -2752,6 +2946,10 @@
       "drift": 2,
       "driftPer100Files": 1,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "not a four-based ladder"
+      ],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -2833,6 +3031,10 @@
       "drift": 0,
       "driftPer100Files": 0,
       "driftDelta": null,
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
       "scaleSource": "fallback",
       "scaleValues": [
         0,
@@ -2855,6 +3057,8 @@
       "drift": 0,
       "driftPer100Files": 0,
       "driftDelta": null,
+      "scaleReliable": true,
+      "scaleReasons": [],
       "scaleSource": "scanned-css",
       "scaleValues": [
         0,
@@ -2900,6 +3104,7 @@
     "cssFiles": 8585,
     "drift": 7471,
     "repos": 57,
-    "fallbackScales": 39
+    "fallbackScales": 39,
+    "unreliableScales": 5
   }
 }

--- a/docs/state-of-spacing/2026-09.md
+++ b/docs/state-of-spacing/2026-09.md
@@ -8,19 +8,19 @@ This is not a ranking of teams. It is a reading of one signal on a fixed commit,
 npx rhythmguard audit . --scale auto --format markdown
 ```
 
-Across the set: 7471 off-scale values in 8585 CSS files; 39 of 57 repositories had no discoverable spacing tokens and were measured against the `rhythmic-4` fallback, which says more about token discovery than about their CSS.
+Across the set: 7471 off-scale values in 8585 CSS files; 39 of 57 repositories had no discoverable spacing tokens and were measured against the `rhythmic-4` fallback, which says more about token discovery than about their CSS, and 5 more had an inference the plausibility check rejected (marked `unreliable`; usually component-local variables, see issue #54).
 
 ## Repositories
 
 | Repo | Commit | Scale source | Off-scale | per 100 CSS files | Cleanliness | Top values | Top properties |
 | --- | --- | --- | ---: | ---: | ---: | --- | --- |
-| [zulip](https://github.com/zulip/zulip) | `9b991a8` | scanned-css | 1743 | 2601 | 16% | `10px` ×437, `20px` ×206, `4px` ×122 | `padding` ×658, `margin` ×349, `margin-top` ×178 |
+| [zulip](https://github.com/zulip/zulip) | `9b991a8` | scanned-css (unreliable) | 1743 | 2601 | 16% | `10px` ×437, `20px` ×206, `4px` ×122 | `padding` ×658, `margin` ×349, `margin-top` ×178 |
 | [mastodon](https://github.com/mastodon/mastodon) | `0a32b4a` | scanned-css | 564 | 1567 | 53% | `10px` ×165, `15px` ×112, `5px` ×70 | `padding` ×206, `margin-bottom` ×99, `gap` ×41 |
 | [mattermost-webapp](https://github.com/mattermost/mattermost) | `502cf7e` | fallback | 1058 | 1027 | 23% | `10px` ×162, `5px` ×150, `20px` ×108 | `padding` ×400, `margin` ×219, `margin-right` ×90 |
 | [calcom](https://github.com/calcom/cal.com) | `e91bb0c` | fallback | 40 | 1000 | 95% | `10px` ×9, `2px` ×9, `6px` ×3 | `padding` ×15, `class-string` ×13, `margin` ×2 |
 | [grafana](https://github.com/grafana/grafana) | `c6fad86` | scanned-css | 57 | 950 | 83% | `10px` ×9, `15px` ×9, `5px` ×7 | `padding` ×34, `padding-left` ×8, `margin-top` ×4 |
 | [ghost-admin](https://github.com/TryGhost/Ghost) | `26746d3` | fallback | 745 | 626 | 82% | `2px` ×70, `10px` ×69, `6px` ×62 | `padding` ×294, `margin` ×167, `margin-top` ×68 |
-| [shadcn-ui](https://github.com/shadcn-ui/ui) | `7c9eaba` | scanned-css | 58 | 446 | 99% | `-2.5rem` ×8, `2.5rem` ×8, `2px` ×5 | `class-string` ×47, `padding` ×6, `margin-block-start` ×2 |
+| [shadcn-ui](https://github.com/shadcn-ui/ui) | `7c9eaba` | scanned-css (unreliable) | 58 | 446 | 99% | `-2.5rem` ×8, `2.5rem` ×8, `2px` ×5 | `class-string` ×47, `padding` ×6, `margin-block-start` ×2 |
 | [forem](https://github.com/forem/forem) | `e8a0729` | fallback | 590 | 415 | 53% | `10px` ×87, `2px` ×57, `5px` ×57 | `padding` ×266, `margin` ×119, `margin-top` ×46 |
 | [adminlte](https://github.com/ColorlibHQ/AdminLTE) | `12b4b06` | fallback | 126 | 274 | 63% | `10px` ×20, `1.25rem` ×9, `2px` ×9 | `padding` ×50, `margin-top` ×17, `margin` ×15 |
 | [directus-app](https://github.com/directus/directus) | `3df2ba9` | fallback | 63 | 217 | 59% | `-0.3125rem` ×17, `0.4375rem` ×9, `-0.1875rem` ×6 | `padding` ×17, `inset-inline-start` ×6, `inset-block-start` ×5 |
@@ -34,7 +34,7 @@ Across the set: 7471 off-scale values in 8585 CSS files; 39 of 57 repositories h
 | [liveblocks-react-ui](https://github.com/liveblocks/liveblocks) | `98332db` | fallback | 9 | 150 | 99% | `-0.35rem` ×2, `0.1em` ×1, `0.2em` ×1 | `padding` ×4, `padding-inline-start` ×2, `inset-block-start` ×1 |
 | [hashicorp-design-system](https://github.com/hashicorp/design-system) | `83cac84` | fallback | 109 | 120 | 53% | `2px` ×24, `10px` ×13, `3px` ×12 | `padding` ×65, `margin` ×15, `margin-top` ×13 |
 | [carbon-styles](https://github.com/carbon-design-system/carbon) | `4cc7900` | fallback | 272 | 96 | 81% | `13px` ×28, `2px` ×23, `7px` ×19 | `inset-block-start` ×60, `padding` ×37, `padding-block` ×36 |
-| [discourse](https://github.com/discourse/discourse) | `c7b7a0b` | scanned-css | 349 | 93 | 34% | `0.15em` ×38, `15px` ×34, `0.35em` ×27 | `padding` ×130, `margin-top` ×34, `margin` ×33 |
+| [discourse](https://github.com/discourse/discourse) | `c7b7a0b` | scanned-css (unreliable) | 349 | 93 | 34% | `0.15em` ×38, `15px` ×34, `0.35em` ×27 | `padding` ×130, `margin-top` ×34, `margin` ×33 |
 | [primer-css](https://github.com/primer/css) | `72564a3` | scanned-css | 103 | 91 | 75% | `5px` ×17, `6px` ×11, `7px` ×9 | `padding` ×45, `margin` ×22, `margin-left` ×8 |
 | [materialize](https://github.com/materializecss/materialize) | `c9d6914` | scanned-css | 9 | 60 | 80% | `10px` ×3, `15px` ×2, `14px` ×1 | `padding` ×5, `padding-left` ×2, `margin` ×1 |
 | [metabase](https://github.com/metabase/metabase) | `e621647` | fallback | 55 | 56 | 94% | `0.375rem` ×6, `2px` ×5, `15px` ×4 | `padding` ×24, `padding-right` ×8, `padding-left` ×3 |
@@ -47,7 +47,7 @@ Across the set: 7471 off-scale values in 8585 CSS files; 39 of 57 repositories h
 | [daisyui](https://github.com/saadeghi/daisyui) | `1435c65` | fallback | 37 | 34 | 93% | `0.125rem` ×3, `1.4rem` ×3, `5px` ×3 | `padding` ×12, `inset-inline-end` ×5, `class-string` ×4 |
 | [utrecht](https://github.com/nl-design-system/utrecht) | `ecedc4b` | fallback | 47 | 29 | 99% | `3rem` ×8, `26px` ×7, `10px` ×5 | `padding` ×12, `margin-bottom` ×4, `margin-left` ×4 |
 | [foundation-sites](https://github.com/foundation/foundation-sites) | `337be7a` | fallback | 34 | 29 | 85% | `10px` ×5, `2.5rem` ×4, `30px` ×4 | `padding` ×11, `margin-bottom` ×8, `transform` ×4 |
-| [mantine](https://github.com/mantinedev/mantine) | `3862b09` | scanned-css | 30 | 29 | 98% | `4px` ×6, `5px` ×6, `8px` ×4 | `padding` ×10, `inset-inline-start` ×3, `margin-top` ×3 |
+| [mantine](https://github.com/mantinedev/mantine) | `3862b09` | scanned-css (unreliable) | 30 | 29 | 98% | `4px` ×6, `5px` ×6, `8px` ×4 | `padding` ×10, `inset-inline-start` ×3, `margin-top` ×3 |
 | [nhsuk-frontend](https://github.com/nhsuk/nhsuk-frontend) | `10caad9` | fallback | 28 | 19 | 97% | `-6px` ×7, `2px` ×5, `6px` ×5 | `margin-left` ×8, `margin-right` ×8, `padding-top` ×5 |
 | [mozilla-protocol](https://github.com/mozilla/protocol) | `6bcf867` | fallback | 18 | 17 | 83% | `-60px` ×2, `0.35em` ×2, `1.25em` ×2 | `padding` ×5, `transform` ×4, `margin` ×3 |
 | [ui5-webcomponents](https://github.com/SAP/ui5-webcomponents) | `9856f4f` | fallback | 75 | 14 | 85% | `0.125rem` ×18, `0.375rem` ×7, `0.1875rem` ×6 | `padding` ×21, `inset` ×7, `margin-inline-start` ×6 |
@@ -68,7 +68,7 @@ Across the set: 7471 off-scale values in 8585 CSS files; 39 of 57 repositories h
 | [ionic-core](https://github.com/ionic-team/ionic-framework) | `5874331` | fallback | 8 | 2 | 99% | `2px` ×4, `-10px` ×1, `10px` ×1 | `margin-top` ×5, `margin-bottom` ×1, `padding-bottom` ×1 |
 | [spectrum-css](https://github.com/adobe/spectrum-css) | `3762086` | fallback | 5 | 2 | 99% | `-10px` ×3, `20px` ×1, `40px` ×1 | `inset-block-end` ×1, `margin` ×1, `margin-inline-end` ×1 |
 | [mittwald-flow](https://github.com/mittwald/flow) | `17efdf9` | fallback | 2 | 2 | 100% | `2px` ×2 | `padding-inline-end` ×1, `padding-inline-start` ×1 |
-| [semi-design](https://github.com/DouyinFE/semi-design) | `8bed560` | scanned-css | 2 | 1 | 98% | `0.8em` ×1, `3.8em` ×1 | `padding-left` ×1, `padding-right` ×1 |
+| [semi-design](https://github.com/DouyinFE/semi-design) | `8bed560` | scanned-css (unreliable) | 2 | 1 | 98% | `0.8em` ×1, `3.8em` ×1 | `padding-left` ×1, `padding-right` ×1 |
 | [open-props](https://github.com/argyleink/open-props) | `530682d` | fallback | 0 | 0 | 100% | none | none |
 | [skeleton](https://github.com/skeletonlabs/skeleton) | `e65535e` | scanned-css | 0 | 0 | 100% | none | none |
 
@@ -78,6 +78,7 @@ Across the set: 7471 off-scale values in 8585 CSS files; 39 of 57 repositories h
 - **Top values** are the numbers that drifted. Three values usually explain most of a repository's drift, and each one is a single decision: a missing step, a mistake, or a token that was never defined.
 - **Top properties** are where the layout decision lives. A table led by sibling margins usually means the parent should own the spacing with `gap`; a table led by `padding` is component-internal and is fixed per component.
 - **Top properties** may include `class-string`, which is a Tailwind arbitrary value in a template rather than a CSS declaration.
+- **Scale source** `unreliable` marks a scanned scale that failed a plausibility check (fractional steps, no four-based ladder, or sources that are component files rather than token files). Its row is measured against a scale the repository probably did not design; treat it like a fallback.
 - **Scale source** `fallback` means the audit found fewer than three spacing tokens and used a default scale. Treat those rows as a to-do for token discovery, not as a verdict on the CSS.
 
 ## Method and caveats

--- a/scripts/bench/outreach.mjs
+++ b/scripts/bench/outreach.mjs
@@ -11,7 +11,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { topCounts } from './state-of-spacing.mjs';
+import { assessScale, topCounts } from './state-of-spacing.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const resultsDir = path.join(repoRoot, 'benchmarks', 'quiet', 'results');
@@ -32,11 +32,12 @@ export function draftIssue(result) {
   const topValues = topCounts(drift, 'value', 5);
   const topProperties = topCounts(drift, 'property', 5);
   const fallback = result.scale.source === 'fallback';
+  const unreliable = !fallback && !assessScale(result.scale).plausible;
   const scale = result.scale.values.join(', ');
   const paths = result.paths.map((p) => `\`${p}\``).join(', ');
   const driftCount = result.summary.drift;
 
-  const title = fallback
+  const title = fallback || unreliable
     ? 'Spacing scale: where do your spacing tokens live? (audit from the Rhythmguard benchmark)'
     : `Spacing scale audit: ${driftCount} literal spacing values off your own token scale`;
 
@@ -47,7 +48,13 @@ export function draftIssue(result) {
     '',
   ];
 
-  if (fallback) {
+  if (unreliable) {
+    lines.push(
+      `**What it found.** Scale inference picked up variables that do not form a spacing scale (it derived \`${scale}\` from ${result.scale.files.slice(0, 2).map((f) => `\`${f}\``).join(', ')}${result.scale.files.length > 2 ? ' and others' : ''}), most likely component-local spacing variables rather than your tokens. Measured against that, it reported ${driftCount} values, which is my tool's mistake and not a number I will quote.`,
+      '',
+      '**The ask.** If you can point me at where the spacing scale is defined (a token file, a Sass map, a package), I will teach the tool to prefer it, re-run the audit on the real scale, and post the result here. If spacing is intentionally not on a scale, saying so is just as useful and I will mark the row that way.',
+    );
+  } else if (fallback) {
     lines.push(
       `**What it found.** The audit could not find a spacing token set here (it looks for \`--space-*\` / \`--spacing-*\` custom properties, Sass \`$spacer\` / \`$spacing-*\` variables and maps, or a Tailwind \`--spacing\` base), so it measured against a default 4px scale and reported ${driftCount} literal values off that scale. That number says more about my token discovery than about your CSS, so I am not going to quote it.`,
       '',

--- a/scripts/bench/state-of-spacing.mjs
+++ b/scripts/bench/state-of-spacing.mjs
@@ -33,6 +33,34 @@ export function topCounts(items, key, limit = 3) {
     .slice(0, limit);
 }
 
+const TOKEN_PATH_PATTERN = /(token|variable|spacing|space|theme|primitive|global|scale|layout)/i;
+
+/**
+ * Inference can pick up component-local variables (`--chip-spacing: 3px`) and
+ * report a "scale" nobody designed. Explicit sources are trusted; a scanned
+ * scale is plausible when it is a ladder of mostly whole, mostly four-multiple
+ * values, and either most of its files look like token files or the ladder is
+ * overwhelmingly four-multiples. Fallback is never plausible: it is not the
+ * repository's scale.
+ */
+export function assessScale(scale) {
+  if (!scale || scale.source === 'fallback') return { plausible: false, reasons: ['fallback'] };
+  if (scale.source !== 'scanned-css') return { plausible: true, reasons: [] };
+  const positives = (scale.values || []).map(Number).filter((value) => Number.isFinite(value) && value > 0);
+  const integers = positives.filter(Number.isInteger);
+  const multiplesOfFour = integers.filter((value) => value % 4 === 0);
+  const integerShare = positives.length ? integers.length / positives.length : 0;
+  const fourShare = positives.length ? multiplesOfFour.length / positives.length : 0;
+  const files = scale.files || [];
+  const tokenFileShare = files.length ? files.filter((file) => TOKEN_PATH_PATTERN.test(file)).length / files.length : 0;
+  const reasons = [];
+  if (positives.length < 4) reasons.push('fewer than four positive steps');
+  if (integerShare < 0.8) reasons.push('fractional values');
+  if (fourShare < 0.5) reasons.push('not a four-based ladder');
+  if (tokenFileShare < 0.5 && fourShare < 0.8) reasons.push('sources are component files');
+  return { plausible: reasons.length === 0, reasons };
+}
+
 export function buildEdition(results, { id, previous = null, generatedAt = new Date().toISOString().slice(0, 10) } = {}) {
   if (!id) throw new Error('An edition id is required, for example 2026-09.');
   const previousRows = new Map((previous && previous.rows ? previous.rows : []).map((row) => [row.name, row]));
@@ -42,6 +70,7 @@ export function buildEdition(results, { id, previous = null, generatedAt = new D
     const driftCount = result.summary && Number.isFinite(result.summary.drift) ? result.summary.drift : drift.length;
     const cssFiles = result.cssFilesScanned || 0;
     const before = previousRows.get(result.name);
+    const assessment = assessScale(result.scale);
     return {
       name: result.name,
       url: String(result.url || '').replace(/\.git$/, ''),
@@ -51,6 +80,8 @@ export function buildEdition(results, { id, previous = null, generatedAt = new D
       drift: driftCount,
       driftPer100Files: cssFiles > 0 ? Math.round((driftCount / cssFiles) * 100) : 0,
       driftDelta: before ? driftCount - before.drift : null,
+      scaleReliable: assessment.plausible,
+      scaleReasons: assessment.reasons,
       scaleSource: result.scale ? result.scale.source : 'unknown',
       scaleValues: result.scale ? result.scale.values : [],
       topProperties: topCounts(drift, 'property'),
@@ -70,6 +101,7 @@ export function buildEdition(results, { id, previous = null, generatedAt = new D
       drift: rows.reduce((sum, row) => sum + row.drift, 0),
       repos: rows.length,
       fallbackScales: rows.filter((row) => row.scaleSource === 'fallback').length,
+      unreliableScales: rows.filter((row) => row.scaleSource !== 'fallback' && !row.scaleReliable).length,
     },
   };
 }
@@ -97,7 +129,7 @@ export function renderEdition(edition) {
     'npx rhythmguard audit . --scale auto --format markdown',
     '```',
     '',
-    `Across the set: ${edition.totals.drift} off-scale values in ${edition.totals.cssFiles} CSS files; ${edition.totals.fallbackScales} of ${edition.totals.repos} repositories had no discoverable spacing tokens and were measured against the \`rhythmic-4\` fallback, which says more about token discovery than about their CSS.${withDelta ? ` Changes are since ${edition.previousId}.` : ''}`,
+    `Across the set: ${edition.totals.drift} off-scale values in ${edition.totals.cssFiles} CSS files; ${edition.totals.fallbackScales} of ${edition.totals.repos} repositories had no discoverable spacing tokens and were measured against the \`rhythmic-4\` fallback, which says more about token discovery than about their CSS${edition.totals.unreliableScales > 0 ? `, and ${edition.totals.unreliableScales} more had an inference the plausibility check rejected (marked \`unreliable\`; usually component-local variables, see issue #54)` : ''}.${withDelta ? ` Changes are since ${edition.previousId}.` : ''}`,
     '',
     '## Repositories',
     '',
@@ -106,7 +138,7 @@ export function renderEdition(edition) {
   ];
 
   for (const row of edition.rows) {
-    lines.push(`| [${row.name}](${row.url}) | \`${row.sha}\` | ${row.scaleSource} | ${row.drift} | ${row.driftPer100Files} | ${row.cleanliness}% | ${formatCounts(row.topValues)} | ${formatCounts(row.topProperties)} |${withDelta ? ` ${formatDelta(row.driftDelta)} |` : ''}`);
+    lines.push(`| [${row.name}](${row.url}) | \`${row.sha}\` | ${row.scaleSource}${row.scaleSource !== 'fallback' && !row.scaleReliable ? ' (unreliable)' : ''} | ${row.drift} | ${row.driftPer100Files} | ${row.cleanliness}% | ${formatCounts(row.topValues)} | ${formatCounts(row.topProperties)} |${withDelta ? ` ${formatDelta(row.driftDelta)} |` : ''}`);
   }
 
   lines.push(
@@ -117,6 +149,7 @@ export function renderEdition(edition) {
     '- **Top values** are the numbers that drifted. Three values usually explain most of a repository\'s drift, and each one is a single decision: a missing step, a mistake, or a token that was never defined.',
     '- **Top properties** are where the layout decision lives. A table led by sibling margins usually means the parent should own the spacing with `gap`; a table led by `padding` is component-internal and is fixed per component.',
     '- **Top properties** may include `class-string`, which is a Tailwind arbitrary value in a template rather than a CSS declaration.',
+    '- **Scale source** `unreliable` marks a scanned scale that failed a plausibility check (fractional steps, no four-based ladder, or sources that are component files rather than token files). Its row is measured against a scale the repository probably did not design; treat it like a fallback.',
     '- **Scale source** `fallback` means the audit found fewer than three spacing tokens and used a default scale. Treat those rows as a to-do for token discovery, not as a verdict on the CSS.',
     '',
     '## Method and caveats',

--- a/test/outreach.test.js
+++ b/test/outreach.test.js
@@ -46,3 +46,13 @@ test('draftIssue for a fallback-scale repository asks where the tokens live and 
   assert.match(body, /I am not going to quote it/);
   assert.doesNotMatch(body, /- Values:/);
 });
+
+test('draftIssue treats an implausible inferred scale like a fallback and says why', async () => {
+  const { draftIssue } = await load();
+  const { body, title } = draftIssue({ ...base, scale: { source: 'scanned-css', values: [0, 2, 3, 5, 6, 25], tokenCount: 12, files: ['web/styles/app_variables.css'] } });
+
+  assert.match(title, /where do your spacing tokens live/);
+  assert.match(body, /picked up variables that do not form a spacing scale/);
+  assert.match(body, /`0, 2, 3, 5, 6, 25`/);
+  assert.doesNotMatch(body, /- Values:/);
+});

--- a/test/state-of-spacing.test.js
+++ b/test/state-of-spacing.test.js
@@ -80,3 +80,32 @@ test('renderEdition shows deltas with a sign and marks new rows', async () => {
   assert.match(markdown, /\| new \|/);
   assert.match(markdown, /since 2026-06/);
 });
+
+test('assessScale flags inferred scales that do not look like a spacing scale', async () => {
+  const { assessScale } = await load();
+  const ok = (scale) => assessScale(scale).plausible;
+
+  assert.equal(ok({ source: 'scanned-css', values: [0, 4, 8, 12, 16, 24, 32], files: ['src/tokens/space.css'] }), true);
+  assert.equal(ok({ source: 'scanned-css', values: [0, 2, 4, 6, 8, 12, 16, 20, 24, 32, 48, 64], files: ['src/_primitives.scss', 'src/markdown.scss', 'src/markdown.scss'] }), true, 'mostly multiples of four passes even from mixed files');
+  assert.equal(ok({ source: 'scanned-css', values: [0, 2, 3, 5, 6, 25], files: ['web/styles/app_variables.css'] }), false, 'zulip: not a spacing ladder');
+  assert.equal(ok({ source: 'scanned-css', values: [0, 1, 2, 10, 12, 16, 20, 22, 32], files: ['core/src/components/Avatar/Avatar.module.css', 'core/src/components/Chip/Chip.module.css', 'core/src/core/MantineProvider/default-css-variables.css'] }), false, 'mantine: polluted by component-local variables');
+  assert.equal(ok({ source: 'scanned-css', values: [0, 0.4, 0.7, 0.8, 1, 1.1, 1.4, 2, 3, 4], files: ['a/variables.scss'] }), false, 'fractional values');
+  assert.equal(ok({ source: 'fallback', values: [0, 4, 8], files: [] }), false, 'fallback is never plausible');
+  assert.equal(ok({ source: 'token-sources', values: [0, 4, 8, 12], files: ['tokens.json'] }), true, 'explicit sources are trusted');
+});
+
+test('buildEdition marks unreliable scales and counts them with fallbacks', async () => {
+  const { buildEdition, renderEdition } = await load();
+  const edition = buildEdition([
+    result({ name: 'zulip', scale: { source: 'scanned-css', values: [0, 2, 3, 5, 6, 25], tokenCount: 12, files: ['web/styles/app_variables.css'] } }),
+    result(),
+  ], { id: '2026-09' });
+
+  const zulip = edition.rows.find((row) => row.name === 'zulip');
+  assert.equal(zulip.scaleReliable, false);
+  assert.equal(edition.rows.find((row) => row.name === 'acme').scaleReliable, true);
+  assert.equal(edition.totals.unreliableScales, 1);
+  const markdown = renderEdition(edition);
+  assert.match(markdown, /\| \[zulip\]\([^)]*\) \| `abc1234` \| scanned-css \(unreliable\) \|/);
+  assert.match(markdown, /1 more had an inference the plausibility check rejected/);
+});


### PR DESCRIPTION
Reviewing the drafts showed Zulip's inferred scale as `0, 2, 3, 5, 6, 25`, which is component variables, not a scale. Quoting 1743 findings against it would have been wrong.

- `assessScale` in `state-of-spacing.mjs`: explicit sources trusted; scanned scales must be mostly whole, mostly four-multiples, and come mostly from token-looking files (or be overwhelmingly four-multiples). Fallback is never plausible.
- Edition rows show `scanned-css (unreliable)` and the intro counts them separately; the reading guide explains the mark.
- Drafts for unreliable scales use the where-do-your-tokens-live variant and say plainly that the number is the tool's mistake.
- On the 57 results this rejects zulip, shadcn-ui, discourse, mantine and semi-design and keeps the other thirteen scanned scales. Evidence for #54.

Local gate: lint, typecheck, 188 tests, all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)