### PR TITLE
refactor(rules): one primitive per repeated rule concern

### DIFF
--- a/src/core/length.js
+++ b/src/core/length.js
@@ -182,7 +182,28 @@ function nearestScaleValues(target, scale) {
   };
 }
 
+/**
+ * The replacement text for an off-scale length, or null when the value's unit
+ * is not one the rule may rewrite. Keeps the sign, and with the `exact` unit
+ * strategy keeps the unit as written instead of converting through px.
+ */
+function fixedLengthValue(parsedLength, nearestPx, { baseFontSize, unitStrategy, units }) {
+  const unit = parsedLength.unit || 'px';
+  if (unit === '%' || !units.includes(unit)) {
+    return null;
+  }
+
+  const signedNearest = parsedLength.number < 0 ? -Math.abs(nearestPx) : nearestPx;
+  if (unitStrategy === 'exact') {
+    return formatLength(signedNearest, unit);
+  }
+
+  const converted = fromPx(signedNearest, unit, baseFontSize);
+  return converted === null ? null : formatLength(converted, unit);
+}
+
 module.exports = {
+  fixedLengthValue,
   formatLength,
   fromPx,
   isHairlineLength,

--- a/src/core/options.js
+++ b/src/core/options.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { normalizeScale, normalizeScaleByUnit } = require('./length');
+
 const { all: knownCssProperties = [] } = require('known-css-properties');
 const {
   DEFAULT_IGNORE_KEYWORDS,
@@ -639,6 +641,27 @@ function buildTokenOptions(rawOptions) {
   };
 }
 
+/**
+ * Per-property scale lookup with a cache, because a stylesheet repeats the
+ * same few properties thousands of times and normalising a scale is not free.
+ */
+function createPropertyScaleResolver(options) {
+  const cache = new Map();
+  return (prop) => {
+    const cached = cache.get(prop);
+    if (cached) {
+      return cached;
+    }
+    const selectedScale = resolvePropertyScale(prop, options);
+    const state = {
+      scaleByUnit: normalizeScaleByUnit(selectedScale),
+      scalePx: normalizeScale(selectedScale, options.baseFontSize),
+    };
+    cache.set(prop, state);
+    return state;
+  };
+}
+
 function resolvePropertyScale(prop, options) {
   if (!Array.isArray(options.propertyScaleOverrides)) {
     return options.scale;
@@ -674,6 +697,7 @@ module.exports = {
   USE_SCALE_VALIDATION_SCHEMA,
   buildScaleOptions,
   buildTokenOptions,
+  createPropertyScaleResolver,
   isPlainObject,
   resolvePropertyScale,
 };

--- a/src/core/scale-inference.js
+++ b/src/core/scale-inference.js
@@ -403,6 +403,27 @@ function fallbackInference(rejected = null) {
   };
 }
 
+/**
+ * Apply `scale: "auto"` to built rule options: the inferred scale replaces the
+ * placeholder and the inference is kept for the fallback note. Options with
+ * an explicit scale pass through untouched.
+ */
+function withResolvedScale(options, root) {
+  if (!options.scaleAuto) {
+    return options;
+  }
+  const inference = resolveAutoScale({
+    baseFontSize: options.baseFontSize,
+    root,
+    scaleSources: options.scaleSources,
+    tailwindConfigPath: options.tailwindConfigPath,
+    tokenPattern: options.tokenPatternExplicit ? options.tokenPattern : DEFAULT_AUTO_TOKEN_PATTERN,
+  });
+  options.scale = inference.scale;
+  options.scaleInference = inference;
+  return options;
+}
+
 function autoScaleFallbackNote(inference) {
   if (!inference || inference.source !== 'fallback') {
     return '';
@@ -421,4 +442,5 @@ module.exports = {
   discoverTokenPackages,
   resolveAutoScale,
   scaleFromDefinitions,
+  withResolvedScale,
 };

--- a/src/rules/no-offscale-transform/index.js
+++ b/src/rules/no-offscale-transform/index.js
@@ -3,22 +3,19 @@
 const stylelint = require('stylelint');
 const valueParser = require('postcss-value-parser');
 const {
+  fixedLengthValue,
   formatLength,
-  fromPx,
   isHairlineLength,
   nearestScaleValues,
-  normalizeScale,
-  normalizeScaleByUnit,
   numbersEqual,
   parseLengthToken,
   toPx,
 } = require('../../core/length');
 const {
   buildScaleOptions,
-  resolvePropertyScale,
+  createPropertyScaleResolver,
 } = require('../../core/options');
 const {
-  declarationValueIndex,
   isMathFunction,
   shouldLintMathArgument,
   walkRootValueNodes,
@@ -26,11 +23,12 @@ const {
 } = require('../../core/value-nodes');
 
 const {
-  DEFAULT_AUTO_TOKEN_PATTERN,
-  resolveAutoScale,
+  withResolvedScale,
 } = require('../../core/scale-inference');
 
-const { validateNoOffscaleTransformSecondaryOptions } = require('../validate');
+const { validatePrimary, validateNoOffscaleTransformSecondaryOptions } = require('../validate');
+
+const { reportInvalidPreset, reportValueNode } = require('../report');
 
 const ruleName = 'rhythmguard/no-offscale-transform';
 const messages = stylelint.utils.ruleMessages(ruleName, {
@@ -40,33 +38,9 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
     `Unexpected transform translation value "${value}". Use scale values (nearest: ${lower} or ${upper}).`,
 });
 
-function getFixedNodeValue(parsedLength, nearestPx, options) {
-  const unit = parsedLength.unit || 'px';
-  if (unit === '%' || !options.units.includes(unit)) {
-    return null;
-  }
-
-  const signedNearest = parsedLength.number < 0 ? -Math.abs(nearestPx) : nearestPx;
-
-  if (options.unitStrategy === 'exact') {
-    return formatLength(signedNearest, parsedLength.unit || 'px');
-  }
-
-  const converted = fromPx(signedNearest, unit, options.baseFontSize);
-
-  if (converted === null) {
-    return null;
-  }
-
-  return formatLength(converted, unit);
-}
-
 const ruleFunction = (primary, secondaryOptions) => {
   return (root, result) => {
-    const valid = stylelint.utils.validateOptions(result, ruleName, {
-      actual: primary,
-      possible: [true],
-    });
+    const valid = validatePrimary(result, ruleName, primary);
 
     if (!valid) {
       return;
@@ -82,43 +56,11 @@ const ruleFunction = (primary, secondaryOptions) => {
     }
 
     const options = buildScaleOptions(secondaryOptions);
-    if (options.invalidPreset) {
-      stylelint.utils.report({
-        message: messages.invalidPreset(options.invalidPreset, options.presetNames),
-        node: root,
-        result,
-        ruleName,
-      });
-    }
+    reportInvalidPreset(options, { message: messages.invalidPreset, result, root, ruleName });
 
-    if (options.scaleAuto) {
-      const inference = resolveAutoScale({
-        baseFontSize: options.baseFontSize,
-        root,
-        scaleSources: options.scaleSources,
-        tailwindConfigPath: options.tailwindConfigPath,
-        tokenPattern: options.tokenPatternExplicit ? options.tokenPattern : DEFAULT_AUTO_TOKEN_PATTERN,
-      });
-      options.scale = inference.scale;
-      options.scaleInference = inference;
-    }
+    withResolvedScale(options, root);
 
-    const scaleCache = new Map();
-    const getScaleStateForProperty = (prop) => {
-      const cached = scaleCache.get(prop);
-      if (cached) {
-        return cached;
-      }
-
-      const selectedScale = resolvePropertyScale(prop, options);
-      const next = {
-        scaleByUnit: normalizeScaleByUnit(selectedScale),
-        scalePx: normalizeScale(selectedScale, options.baseFontSize),
-      };
-
-      scaleCache.set(prop, next);
-      return next;
-    };
+    const getScaleStateForProperty = createPropertyScaleResolver(options);
 
     root.walkDecls((decl) => {
       const prop = decl.prop.toLowerCase();
@@ -131,30 +73,18 @@ const ruleFunction = (primary, secondaryOptions) => {
       let changed = false;
 
       const report = (node, nearest, nearestUnit, fixedValue = null) => {
-        const index = declarationValueIndex(decl) + node.sourceIndex;
-        const endIndex = index + node.value.length;
-
-        const payload = {
-          endIndex,
-          index,
+        reportValueNode({
+          decl,
           message: messages.rejected(
             node.value,
             formatLength(nearest.lower, nearestUnit),
             formatLength(nearest.upper, nearestUnit),
           ),
-          node: decl,
+          node,
+          replacement: fixedValue,
           result,
           ruleName,
-        };
-
-        if (fixedValue) {
-          payload.fix = () => {
-            node.value = fixedValue;
-            return true;
-          };
-        }
-
-        stylelint.utils.report(payload);
+        });
       };
 
       const checkNode = (node) => {
@@ -206,7 +136,7 @@ const ruleFunction = (primary, secondaryOptions) => {
           }
 
           const fixedValue = options.fixToScale
-            ? getFixedNodeValue(parsedLength, nearest.nearest, options)
+            ? fixedLengthValue(parsedLength, nearest.nearest, options)
             : null;
 
           report(node, nearest, unit, fixedValue);
@@ -230,7 +160,7 @@ const ruleFunction = (primary, secondaryOptions) => {
         }
 
         const fixedValue = options.fixToScale
-          ? getFixedNodeValue(parsedLength, nearest.nearest, options)
+          ? fixedLengthValue(parsedLength, nearest.nearest, options)
           : null;
 
         report(node, nearest, 'px', fixedValue);

--- a/src/rules/prefer-token/index.js
+++ b/src/rules/prefer-token/index.js
@@ -5,18 +5,15 @@ const valueParser = require('postcss-value-parser');
 const {
   formatLength,
   isHairlineLength,
-  normalizeScale,
-  normalizeScaleByUnit,
   numbersEqual,
   parseLengthToken,
   toPx,
 } = require('../../core/length');
 const {
   buildTokenOptions,
-  resolvePropertyScale,
+  createPropertyScaleResolver,
 } = require('../../core/options');
 const {
-  declarationValueIndex,
   isKeyword,
   isMathFunction,
   isTokenFunction,
@@ -28,12 +25,11 @@ const {
 const { buildEffectiveTokenMap } = require('../../core/token-map');
 
 const {
-  DEFAULT_AUTO_TOKEN_PATTERN,
-  resolveAutoScale,
+  withResolvedScale,
 } = require('../../core/scale-inference');
 
-const { createTokenRegex } = require('../report');
-const { validatePreferTokenSecondaryOptions } = require('../validate');
+const { createTokenRegex, reportInvalidPreset, reportValueNode } = require('../report');
+const { validatePrimary, validatePreferTokenSecondaryOptions } = require('../validate');
 
 const ruleName = 'rhythmguard/prefer-token';
 
@@ -91,10 +87,7 @@ function resolveTokenReplacement(tokenMap, raw, parsedLength, options) {
 
 const ruleFunction = (primary, secondaryOptions) => {
   return (root, result) => {
-    const valid = stylelint.utils.validateOptions(result, ruleName, {
-      actual: primary,
-      possible: [true],
-    });
+    const valid = validatePrimary(result, ruleName, primary);
 
     if (!valid) {
       return;
@@ -110,26 +103,9 @@ const ruleFunction = (primary, secondaryOptions) => {
     }
 
     const options = buildTokenOptions(secondaryOptions);
-    if (options.invalidPreset) {
-      stylelint.utils.report({
-        message: messages.invalidPreset(options.invalidPreset, options.presetNames),
-        node: root,
-        result,
-        ruleName,
-      });
-    }
+    reportInvalidPreset(options, { message: messages.invalidPreset, result, root, ruleName });
 
-    if (options.scaleAuto) {
-      const inference = resolveAutoScale({
-        baseFontSize: options.baseFontSize,
-        root,
-        scaleSources: options.scaleSources,
-        tailwindConfigPath: options.tailwindConfigPath,
-        tokenPattern: options.tokenPatternExplicit ? options.tokenPattern : DEFAULT_AUTO_TOKEN_PATTERN,
-      });
-      options.scale = inference.scale;
-      options.scaleInference = inference;
-    }
+    withResolvedScale(options, root);
 
     const tokenRegex = createTokenRegex(options.tokenPattern, result, ruleName);
     const tokenMap = buildEffectiveTokenMap({
@@ -138,23 +114,7 @@ const ruleFunction = (primary, secondaryOptions) => {
       tokenRegex,
     });
 
-    const scaleCache = new Map();
-
-    const getScaleStateForProperty = (prop) => {
-      const cached = scaleCache.get(prop);
-      if (cached) {
-        return cached;
-      }
-
-      const selectedScale = resolvePropertyScale(prop, options);
-      const next = {
-        scaleByUnit: normalizeScaleByUnit(selectedScale),
-        scalePx: normalizeScale(selectedScale, options.baseFontSize),
-      };
-
-      scaleCache.set(prop, next);
-      return next;
-    };
+    const getScaleStateForProperty = createPropertyScaleResolver(options);
 
     root.walkDecls((decl) => {
       const prop = decl.prop.toLowerCase();
@@ -171,26 +131,7 @@ const ruleFunction = (primary, secondaryOptions) => {
       let changed = false;
 
       const reportNode = (node, replacement = null) => {
-        const index = declarationValueIndex(decl) + node.sourceIndex;
-        const endIndex = index + node.value.length;
-
-        const payload = {
-          endIndex,
-          index,
-          message: messages.rejected(node.value),
-          node: decl,
-          result,
-          ruleName,
-        };
-
-        if (replacement) {
-          payload.fix = () => {
-            node.value = replacement;
-            return true;
-          };
-        }
-
-        stylelint.utils.report(payload);
+        reportValueNode({ decl, message: messages.rejected(node.value), node, replacement, result, ruleName });
       };
 
       const checkWordNode = (node, context) => {

--- a/src/rules/report.js
+++ b/src/rules/report.js
@@ -6,6 +6,7 @@
  * and the same primitives can serve the ESLint plugin and the audit.
  */
 const stylelint = require('stylelint');
+const { declarationValueIndex } = require('../core/value-nodes');
 
 /**
  * Compile a user-supplied token pattern. An invalid pattern is reported once
@@ -26,6 +27,49 @@ function createTokenRegex(tokenPattern, result, ruleName) {
   }
 }
 
+/**
+ * Report one value node inside a declaration, positioned on the node rather
+ * than the whole declaration, with an optional fix. The default fix replaces
+ * the node's text; pass `fix` for anything else.
+ */
+function reportValueNode({ decl, fix = null, length = null, message, node, replacement = null, result, ruleName }) {
+  const index = declarationValueIndex(decl) + node.sourceIndex;
+  const payload = {
+    endIndex: index + (length === null ? node.value.length : length),
+    index,
+    message,
+    node: decl,
+    result,
+    ruleName,
+  };
+
+  if (fix) {
+    payload.fix = fix;
+  } else if (replacement) {
+    payload.fix = () => {
+      node.value = replacement;
+      return true;
+    };
+  }
+
+  stylelint.utils.report(payload);
+}
+
+/** A preset name the options did not recognise is reported once, on the root. */
+function reportInvalidPreset(options, { message, result, root, ruleName }) {
+  if (!options.invalidPreset) {
+    return;
+  }
+  stylelint.utils.report({
+    message: message(options.invalidPreset, options.presetNames),
+    node: root,
+    result,
+    ruleName,
+  });
+}
+
 module.exports = {
   createTokenRegex,
+  reportInvalidPreset,
+  reportValueNode,
 };

--- a/src/rules/use-motion-scale/index.js
+++ b/src/rules/use-motion-scale/index.js
@@ -7,7 +7,6 @@ const {
   numbersEqual,
 } = require('../../core/length');
 const {
-  declarationValueIndex,
   walkRootValueNodes,
 } = require('../../core/value-nodes');
 const {
@@ -18,6 +17,9 @@ const {
   parseTimeToken,
   toMs,
 } = require('../../core/time');
+
+const { reportValueNode } = require('../report');
+const { validatePrimary } = require('../validate');
 
 const ruleName = 'rhythmguard/use-motion-scale';
 const DURATION_PROPERTIES = new Set([
@@ -99,12 +101,7 @@ function functionToString(node) {
 
 const ruleFunction = (primary, secondaryOptions) => {
   return (root, result) => {
-    const valid = stylelint.utils.validateOptions(result, ruleName, {
-      actual: primary,
-      possible: [true],
-    });
-
-    if (!valid || !validateSecondaryOptions(result, secondaryOptions)) {
+    if (!validatePrimary(result, ruleName, primary) || !validateSecondaryOptions(result, secondaryOptions)) {
       return;
     }
 
@@ -120,10 +117,8 @@ const ruleFunction = (primary, secondaryOptions) => {
       let changed = false;
 
       const reportDuration = (node, nearest, fixedValue = null) => {
-        const index = declarationValueIndex(decl) + node.sourceIndex;
-        const payload = {
-          endIndex: index + node.value.length,
-          index,
+        reportValueNode({
+          decl,
           message: nearest
             ? messages.rejectedDuration(
               node.value,
@@ -131,43 +126,31 @@ const ruleFunction = (primary, secondaryOptions) => {
               formatTime(nearest.upper, 'ms'),
             )
             : messages.invalidDuration(node.value),
-          node: decl,
+          node,
+          replacement: fixedValue,
           result,
           ruleName,
-        };
-
-        if (fixedValue) {
-          payload.fix = () => {
-            node.value = fixedValue;
-            return true;
-          };
-        }
-
-        stylelint.utils.report(payload);
+        });
       };
 
       const reportEasing = (node, replacement = null) => {
         const source = functionToString(node);
-        const index = declarationValueIndex(decl) + node.sourceIndex;
-        const payload = {
-          endIndex: index + source.length,
-          index,
+        reportValueNode({
+          decl,
+          fix: replacement
+            ? () => {
+              node.type = 'word';
+              node.value = replacement;
+              delete node.nodes;
+              return true;
+            }
+            : null,
+          length: source.length,
           message: messages.rejectedEasing(source),
-          node: decl,
+          node,
           result,
           ruleName,
-        };
-
-        if (replacement) {
-          payload.fix = () => {
-            node.type = 'word';
-            node.value = replacement;
-            delete node.nodes;
-            return true;
-          };
-        }
-
-        stylelint.utils.report(payload);
+        });
       };
 
       walkRootValueNodes(parsed, (node) => {

--- a/src/rules/use-scale/index.js
+++ b/src/rules/use-scale/index.js
@@ -3,22 +3,19 @@
 const stylelint = require('stylelint');
 const valueParser = require('postcss-value-parser');
 const {
+  fixedLengthValue,
   formatLength,
-  fromPx,
   isHairlineLength,
   nearestScaleValues,
-  normalizeScale,
-  normalizeScaleByUnit,
   numbersEqual,
   parseLengthToken,
   toPx,
 } = require('../../core/length');
 const {
   buildScaleOptions,
-  resolvePropertyScale,
+  createPropertyScaleResolver,
 } = require('../../core/options');
 const {
-  declarationValueIndex,
   isKeyword,
   isMathFunction,
   isTokenFunction,
@@ -29,13 +26,12 @@ const {
 } = require('../../core/value-nodes');
 
 const {
-  DEFAULT_AUTO_TOKEN_PATTERN,
   autoScaleFallbackNote,
-  resolveAutoScale,
+  withResolvedScale,
 } = require('../../core/scale-inference');
 
-const { createTokenRegex } = require('../report');
-const { validateUseScaleSecondaryOptions } = require('../validate');
+const { createTokenRegex, reportInvalidPreset, reportValueNode } = require('../report');
+const { validatePrimary, validateUseScaleSecondaryOptions } = require('../validate');
 
 const ruleName = 'rhythmguard/use-scale';
 
@@ -45,28 +41,6 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
   rejected: (value, lower, upper, note = '') =>
     `Unexpected off-scale value "${value}". Use scale values (nearest: ${lower} or ${upper}).${note ? ` ${note}` : ''}`,
 });
-
-function getFixedNodeValue(parsedLength, nearestPx, options) {
-  const unit = parsedLength.unit || 'px';
-
-  if (unit === '%' || !options.units.includes(unit)) {
-    return null;
-  }
-
-  const signedNearest = parsedLength.number < 0 ? -Math.abs(nearestPx) : nearestPx;
-
-  if (options.unitStrategy === 'exact') {
-    return formatLength(signedNearest, parsedLength.unit || 'px');
-  }
-
-  const converted = fromPx(signedNearest, unit, options.baseFontSize);
-
-  if (converted === null) {
-    return null;
-  }
-
-  return formatLength(converted, unit);
-}
 
 function checkLengthValue({
   decl,
@@ -136,7 +110,7 @@ function checkLengthValue({
     }
 
     const fixedValue = options.fixToScale
-      ? getFixedNodeValue(parsedLength, nearest.nearest, options)
+      ? fixedLengthValue(parsedLength, nearest.nearest, options)
       : null;
 
     report(node.value, decl, node, nearest, fixedValue, unit);
@@ -160,7 +134,7 @@ function checkLengthValue({
   }
 
   const fixedValue = options.fixToScale
-    ? getFixedNodeValue(parsedLength, nearest.nearest, options)
+    ? fixedLengthValue(parsedLength, nearest.nearest, options)
     : null;
 
   report(node.value, decl, node, nearest, fixedValue, 'px');
@@ -169,10 +143,7 @@ function checkLengthValue({
 
 const ruleFunction = (primary, secondaryOptions) => {
   return (root, result) => {
-    const valid = stylelint.utils.validateOptions(result, ruleName, {
-      actual: primary,
-      possible: [true],
-    });
+    const valid = validatePrimary(result, ruleName, primary);
 
     if (!valid) {
       return;
@@ -188,71 +159,26 @@ const ruleFunction = (primary, secondaryOptions) => {
     }
 
     const options = buildScaleOptions(secondaryOptions);
-    if (options.invalidPreset) {
-      stylelint.utils.report({
-        message: messages.invalidPreset(options.invalidPreset, options.presetNames),
-        node: root,
-        result,
-        ruleName,
-      });
-    }
+    reportInvalidPreset(options, { message: messages.invalidPreset, result, root, ruleName });
 
-    if (options.scaleAuto) {
-      const inference = resolveAutoScale({
-        baseFontSize: options.baseFontSize,
-        root,
-        scaleSources: options.scaleSources,
-        tailwindConfigPath: options.tailwindConfigPath,
-        tokenPattern: options.tokenPatternExplicit ? options.tokenPattern : DEFAULT_AUTO_TOKEN_PATTERN,
-      });
-      options.scale = inference.scale;
-      options.scaleInference = inference;
-    }
+    withResolvedScale(options, root);
 
     const tokenRegex = createTokenRegex(options.tokenPattern, result, ruleName);
-    const scaleCache = new Map();
     let fallbackNote = autoScaleFallbackNote(options.scaleInference);
-
-    const getScaleStateForProperty = (prop) => {
-      const cached = scaleCache.get(prop);
-      if (cached) {
-        return cached;
-      }
-
-      const selectedScale = resolvePropertyScale(prop, options);
-      const next = {
-        scaleByUnit: normalizeScaleByUnit(selectedScale),
-        scalePx: normalizeScale(selectedScale, options.baseFontSize),
-      };
-
-      scaleCache.set(prop, next);
-      return next;
-    };
+    const getScaleStateForProperty = createPropertyScaleResolver(options);
 
     const report = (value, decl, node, nearest, fixedValue = null, nearestUnit = 'px') => {
-      const index = declarationValueIndex(decl) + node.sourceIndex;
-      const endIndex = index + node.value.length;
       const lower = nearest ? formatLength(nearest.lower, nearestUnit) : 'n/a';
       const upper = nearest ? formatLength(nearest.upper, nearestUnit) : 'n/a';
-
-      const payload = {
-        endIndex,
-        index,
+      reportValueNode({
+        decl,
         message: messages.rejected(value, lower, upper, fallbackNote),
-        node: decl,
+        node,
+        replacement: fixedValue,
         result,
         ruleName,
-      };
-
-      if (fixedValue) {
-        payload.fix = () => {
-          node.value = fixedValue;
-          return true;
-        };
-      }
-
+      });
       fallbackNote = '';
-      stylelint.utils.report(payload);
     };
 
     root.walkDecls((decl) => {

--- a/src/rules/validate.js
+++ b/src/rules/validate.js
@@ -119,7 +119,13 @@ function validatePreferTokenSecondaryOptions(result, ruleName, secondaryOptions)
   });
 }
 
+/** Every Rhythmguard rule takes `true` as its primary option and nothing else. */
+function validatePrimary(result, ruleName, primary) {
+  return stylelint.utils.validateOptions(result, ruleName, { actual: primary, possible: [true] });
+}
+
 module.exports = {
+  validatePrimary,
   validateNoOffscaleTransformSecondaryOptions,
   validatePreferTokenSecondaryOptions,
   validateUseScaleSecondaryOptions,

--- a/test/rule-kit.test.js
+++ b/test/rule-kit.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+/**
+ * Contract tests for the primitives the Stylelint rules are built from. The
+ * rule suites prove end-to-end behaviour; these pin the pieces a fifth rule
+ * would reuse.
+ */
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { fixedLengthValue, parseLengthToken } = require('../src/core/length');
+const { buildScaleOptions, createPropertyScaleResolver } = require('../src/core/options');
+const { withResolvedScale } = require('../src/core/scale-inference');
+
+const px = { baseFontSize: 16, unitStrategy: 'convert', units: ['px', 'rem', 'em'] };
+
+test('fixedLengthValue keeps the sign and the unit, converting through px unless the strategy is exact', () => {
+  assert.equal(fixedLengthValue(parseLengthToken('13px'), 12, px), '12px');
+  assert.equal(fixedLengthValue(parseLengthToken('-13px'), 12, px), '-12px');
+  assert.equal(fixedLengthValue(parseLengthToken('0.8rem'), 12, px), '0.75rem');
+  assert.equal(fixedLengthValue(parseLengthToken('13vw'), 12, px), null, 'units the rule may not rewrite give no fix');
+  assert.equal(fixedLengthValue(parseLengthToken('50%'), 12, { ...px, units: ['%'] }), null, 'percentages are never rewritten');
+  assert.equal(fixedLengthValue(parseLengthToken('0.8rem'), 12, { ...px, unitStrategy: 'exact' }), '12rem', 'exact keeps the unit as written');
+});
+
+test('createPropertyScaleResolver returns one normalised scale state per property and caches it', () => {
+  const options = buildScaleOptions({ scale: [0, 4, 8], propertyScales: { gap: [0, 10, 20] } });
+  const resolve = createPropertyScaleResolver(options);
+  const margin = resolve('margin');
+  assert.deepEqual(margin.scalePx, [0, 4, 8]);
+  assert.deepEqual(resolve('gap').scalePx, [0, 10, 20]);
+  assert.equal(resolve('margin'), margin, 'same object on the second lookup');
+});
+
+test('withResolvedScale leaves options with an explicit scale untouched', () => {
+  const options = buildScaleOptions({ scale: [0, 4, 8] });
+  const before = options.scale;
+  assert.equal(withResolvedScale(options, null), options);
+  assert.equal(options.scale, before);
+  assert.equal(options.scaleInference, undefined);
+});


### PR DESCRIPTION
Stage 2 of the architecture work. Behaviour unchanged: lint, typecheck, 209 tests, and `bench:quiet --check` reports zero moved findings across 57 repositories.

Four concerns that every length rule copied now have one home each:

| Concern | Was | Now |
| --- | --- | --- |
| Formatting the fix for an off-scale length | `getFixedNodeValue` in two rules | `core/length.fixedLengthValue` |
| Per-property scale normalisation and cache | closure in three rules | `core/options.createPropertyScaleResolver` |
| Applying `scale: "auto"` | block in three rules | `core/scale-inference.withResolvedScale` |
| Reporting a value node with a fix | payload assembly in four rules | `rules/report.reportValueNode` |

Plus `reportInvalidPreset` and `validatePrimary`. No rule calls `stylelint.utils.report` directly any more, which is what makes the fifth rule an assembly of primitives rather than a copy of the first. Rule bodies shrank by 20 to 25 percent. `test/rule-kit.test.js` pins the primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)