### PR TITLE
refactor(core): one CSS token scanner; validated cache for project discovery

### DIFF
--- a/src/audit/contract.js
+++ b/src/audit/contract.js
@@ -3,7 +3,7 @@
 const fs = require('node:fs');
 const {
   addDefinition,
-  collectScssTokens,
+  collectCssTokens,
   createTokenKindMatcher,
   getNormalizedValueKeys,
 } = require('../core/token-sources');
@@ -95,33 +95,10 @@ function collectTokenContract({
   };
 }
 
+/** Custom properties and Sass tokens declared in one stylesheet, added to the definitions map. */
 function collectTokenDefinitions(source, file, definitions, matchesKind, baseFontSize) {
-  const declarationPattern = /(--[\w-]+)\s*:\s*([^;{}]+)/g;
-  let match;
-
-  while ((match = declarationPattern.exec(source)) !== null) {
-    const token = match[1];
-    if (!matchesKind(token)) {
-      continue;
-    }
-
-    addDefinition(definitions, {
-      baseFontSize,
-      file,
-      source: file,
-      token,
-      value: match[2].trim(),
-    });
-  }
-
-  for (const sassToken of collectScssTokens(source, matchesKind)) {
-    addDefinition(definitions, {
-      baseFontSize,
-      file,
-      source: file,
-      token: sassToken.token,
-      value: sassToken.value,
-    });
+  for (const { token, value } of collectCssTokens(source, matchesKind)) {
+    addDefinition(definitions, { baseFontSize, file, source: file, token, value });
   }
 }
 

--- a/src/core/scale-inference.js
+++ b/src/core/scale-inference.js
@@ -47,10 +47,40 @@ function readDirectDependencies(dir) {
  * installs are found by walking up; a stray global node_modules is never
  * consulted because the walk stops at the repository.
  */
-function projectRoots(cwd) {
+/**
+ * Editors and pre-commit hooks lint one file at a time, and each lint asked
+ * the filesystem the same questions: which package.json files sit between
+ * cwd and the repository, what they declare, and whether a token package is
+ * installed. The answers change only when one of those files changes, so
+ * the result is cached per cwd and revalidated by mtime, which costs a stat
+ * per file instead of a read, a JSON parse and a directory walk.
+ */
+const discoveryCache = new Map();
+
+function fileStamp(file) {
+  try {
+    return fs.statSync(file).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function cachedByFiles(cacheKey, compute) {
+  const cached = discoveryCache.get(cacheKey);
+  if (cached && cached.stamps.every(([file, stamp]) => fileStamp(file) === stamp)) {
+    return cached.value;
+  }
+  const consulted = [];
+  const value = compute((file) => consulted.push([file, fileStamp(file)]));
+  discoveryCache.set(cacheKey, { stamps: consulted, value });
+  return value;
+}
+
+function projectRoots(cwd, consult = () => {}) {
   const roots = [];
   let current = path.resolve(cwd);
   for (;;) {
+    consult(path.join(current, 'package.json'));
     const direct = readDirectDependencies(current);
     if (direct) {
       roots.push({ dir: current, direct });
@@ -65,8 +95,12 @@ function projectRoots(cwd) {
 }
 
 function discoverTokenPackages(cwd = process.cwd()) {
+  return cachedByFiles(`packages:${path.resolve(cwd)}`, (consult) => discoverTokenPackagesUncached(cwd, consult));
+}
+
+function discoverTokenPackagesUncached(cwd, consult) {
   const sources = [];
-  const roots = projectRoots(cwd);
+  const roots = projectRoots(cwd, consult);
   for (const entry of TOKEN_PACKAGES) {
     // Only packages the project depends on directly count. A transitive
     // tailwindcss (for example via stylelint-config-tailwindcss) must not hand
@@ -75,14 +109,17 @@ function discoverTokenPackages(cwd = process.cwd()) {
     if (!owner) {
       continue;
     }
-    const root = roots
-      .map((candidate) => path.join(candidate.dir, 'node_modules', entry.name))
-      .find((dir) => fs.existsSync(path.join(dir, 'package.json')));
+    const candidates = roots.map((candidate) => path.join(candidate.dir, 'node_modules', entry.name));
+    for (const dir of candidates) {
+      consult(path.join(dir, 'package.json'));
+    }
+    const root = candidates.find((dir) => fs.existsSync(path.join(dir, 'package.json')));
     if (!root) {
       continue;
     }
     for (const file of entry.files) {
       const resolved = path.join(root, file);
+      consult(resolved);
       if (fs.existsSync(resolved)) {
         sources.push({
           format: 'auto',
@@ -225,6 +262,13 @@ function firstPositivePx(keys, baseFontSize) {
 
 function rcTokenSources(cwd) {
   const rcPath = path.join(cwd, RC_FILE);
+  return cachedByFiles(`rc:${rcPath}`, (consult) => {
+    consult(rcPath);
+    return rcTokenSourcesUncached(rcPath);
+  });
+}
+
+function rcTokenSourcesUncached(rcPath) {
   if (!fs.existsSync(rcPath)) {
     return [];
   }

--- a/src/core/token-sources.js
+++ b/src/core/token-sources.js
@@ -748,6 +748,7 @@ module.exports = {
   VALID_TOKEN_KINDS,
   VALID_TOKEN_SOURCE_FORMATS,
   addDefinition,
+  collectCssTokens,
   collectScssTokens,
   createTokenKindMatcher,
   getNormalizedValueKeys,

--- a/test/discovery-cache.test.js
+++ b/test/discovery-cache.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { discoverTokenPackages } = require('../src/core/scale-inference');
+
+function countReads(run) {
+  const original = fs.readFileSync;
+  let reads = 0;
+  fs.readFileSync = (...args) => {
+    reads += 1;
+    return original.apply(fs, args);
+  };
+  try {
+    run();
+  } finally {
+    fs.readFileSync = original;
+  }
+  return reads;
+}
+
+test('token-package discovery reads the filesystem once per cwd until a consulted file changes', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-discovery-'));
+  fs.mkdirSync(path.join(dir, '.git'));
+  fs.mkdirSync(path.join(dir, 'node_modules', 'tailwindcss'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"fixture","devDependencies":{"tailwindcss":"^4.1.0"}}');
+  fs.writeFileSync(path.join(dir, 'node_modules', 'tailwindcss', 'package.json'), '{"name":"tailwindcss"}');
+  fs.writeFileSync(path.join(dir, 'node_modules', 'tailwindcss', 'theme.css'), '@theme { --spacing: 0.25rem; }');
+
+  const first = discoverTokenPackages(dir);
+  assert.equal(first.length, 1);
+  assert.equal(countReads(() => assert.equal(discoverTokenPackages(dir), first)), 0, 'second call is served from the cache');
+
+  const later = new Date(Date.now() + 5000);
+  fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"fixture","devDependencies":{}}');
+  fs.utimesSync(path.join(dir, 'package.json'), later, later);
+  assert.ok(countReads(() => assert.equal(discoverTokenPackages(dir).length, 0)) > 0, 'a changed package.json invalidates the entry');
+});


### PR DESCRIPTION
Stage 3 of the architecture work. Behaviour unchanged: lint, typecheck, 210 tests, benchmark check zero moved findings on 57 repositories.

- The audit had its own copy of the custom-property declaration regex next to a call to the Sass collector; the same pair already existed as `collectCssTokens` in core. The audit now calls that. One scanner, so a fix to one path cannot silently diverge from the other (the GOV.UK selector false-match earlier today was found in exactly this duplicated spot).
- `discoverTokenPackages` and `rcTokenSources` ran a package.json walk, JSON parses and existence checks for every linted file. They now cache per cwd and revalidate by mtime of each consulted file: a stat per file instead of read + parse + walk. Measured on this repository: 500 calls went from 13.3 ms to 2.6 ms; the cost the cache removes scales with monorepo depth and allowlist size, which is exactly where editors and pre-commit hooks pay it. A test pins zero reads on a hit and invalidation when package.json changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)