### PR TITLE
refactor(cli): audit flags as one option table with derived help; CJS/ESM parity test

### DIFF
--- a/src/audit/args.js
+++ b/src/audit/args.js
@@ -11,322 +11,117 @@ const {
   normalizeIgnorePattern,
 } = require('./shared');
 
-const HELP = `Usage: rhythmguard audit <dir> [options]
+/**
+ * Every audit flag is one entry here. `kind` says whether the flag takes a
+ * value (`value`), may take one (`optional`: the next argument is consumed
+ * unless it starts with a dash), or is a switch (`flag`). `apply` writes the
+ * parsed result; `cliOptions` records which keys the command line set so the
+ * config file loader can tell an explicit value from a default. The help text
+ * is rendered from this table, so a flag cannot exist without documentation.
+ */
+const setFrom = (parsed, key) => parsed.cliOptions.add(key);
 
-Options:
-  --format <text|json|json-v1|markdown|html|github|badge> Output format (default: text)
-                                 github = GitHub Actions workflow-command annotations
-                                 badge = shields.io endpoint JSON for a README badge
-  --badge-metric <drift|findings> Badge value: drift percent or off-scale count (default: drift)
-  --json                         Alias for --format json
-  --markdown                     Alias for --format markdown
-  --schema                       Print the audit JSON schema and exit
-  --output <file>                Write json, markdown, html or badge output to a file
-  --config <file>                Load audit config (default: .rhythmguardrc.json when present)
-  --no-config                    Ignore .rhythmguardrc.json discovery
-  --ignore <pattern>             Exclude root-relative path/glob (repeatable, comma-separated)
-  --ignore-path <file>           Load ignore patterns from file (default: .rhythmguardignore when present)
-  --baseline <file>              Baseline file path (default: .rhythmguard-baseline.json)
-  --write-baseline [file]        Write current findings as a baseline
-  --since-baseline [file]        Compare current findings against a baseline
-  --fail-on-new-drift            Exit 1 when --since-baseline finds new drift
-  --max-findings <number>        Exit 1 when total findings exceed this count
-  --min-cleanliness <percent>    Exit 1 when scale cleanliness is lower than this percent
-  --since <git-ref>              Scan only changed files since a git ref
-  --staged                       Scan only staged files
-  --include-motion               Include opt-in motion duration/easing drift
-  --token-source <file>          External token source (repeatable, comma-separated)
-  --token-source-format <format> Token source format: auto, css, flat-json, style-dictionary, dtcg (default: auto)
-  --token-kind <kind>            Token kind: spacing, radius, typography, size, motion, all (default: spacing)
-  --token-candidate-min-count <n> Minimum repeated raw value count for token candidates (default: 2)
-  --scale <values|auto>          Comma-separated scale values (default: 0,4,8,12,16,24,32);
-                                 auto infers the scale from token sources, then --space-*/--spacing-*
-                                 custom properties and Sass variables in scanned CSS/SCSS, then
-                                 installed design-token packages, and reports where it came from
-  --base-font-size <number>      px base for rem/em conversion (default: 16)
+const OPTIONS = [
+  { flag: '--format', kind: 'value', value: '<text|json|json-v1|markdown|html|github|badge>', help: ['Output format (default: text)', 'github = GitHub Actions workflow-command annotations', 'badge = shields.io endpoint JSON for a README badge'],
+    apply: (p, raw) => { p.format = String(raw || '').toLowerCase(); } },
+  { flag: '--badge-metric', kind: 'value', value: '<drift|findings>', help: 'Badge value: drift percent or off-scale count (default: drift)',
+    apply: (p, raw) => { p.badgeMetric = String(raw || '').toLowerCase(); } },
+  { flag: '--json', kind: 'flag', help: 'Alias for --format json', apply: (p) => { p.format = 'json'; } },
+  { flag: '--markdown', kind: 'flag', help: 'Alias for --format markdown', apply: (p) => { p.format = 'markdown'; } },
+  { flag: '--schema', kind: 'flag', help: 'Print the audit JSON schema and exit', apply: (p) => { p.schema = true; p.format = 'json'; } },
+  { flag: '--output', kind: 'value', value: '<file>', help: 'Write json, markdown, html or badge output to a file',
+    apply: (p, raw) => { p.outputPath = parsePathOption(raw, '--output'); setFrom(p, 'outputPath'); } },
+  { flag: '--config', kind: 'value', value: '<file>', help: 'Load audit config (default: .rhythmguardrc.json when present)',
+    apply: (p, raw) => { p.configPath = parsePathOption(raw, '--config'); p.configExplicit = true; } },
+  { flag: '--no-config', kind: 'flag', help: 'Ignore .rhythmguardrc.json discovery', apply: (p) => { p.noConfig = true; } },
+  { flag: '--ignore', kind: 'value', value: '<pattern>', help: 'Exclude root-relative path/glob (repeatable, comma-separated)',
+    apply: (p, raw) => { p.ignorePatterns.push(...parseIgnorePatterns(raw)); setFrom(p, 'ignore'); } },
+  { flag: '--ignore-path', kind: 'value', value: '<file>', help: 'Load ignore patterns from file (default: .rhythmguardignore when present)',
+    apply: (p, raw) => { p.ignorePath = parsePathOption(raw, '--ignore-path'); setFrom(p, 'ignorePath'); } },
+  { flag: '--baseline', kind: 'value', value: '<file>', help: 'Baseline file path (default: .rhythmguard-baseline.json)',
+    apply: (p, raw) => { p.baselinePath = parsePathOption(raw, '--baseline'); setFrom(p, 'baselinePath'); } },
+  { flag: '--write-baseline', kind: 'optional', value: '[file]', help: 'Write current findings as a baseline',
+    apply: (p, raw) => { p.writeBaseline = true; setFrom(p, 'writeBaseline'); if (raw !== undefined) { p.baselinePath = parsePathOption(raw, '--write-baseline'); setFrom(p, 'baselinePath'); } } },
+  { flag: '--since-baseline', kind: 'optional', value: '[file]', help: 'Compare current findings against a baseline',
+    apply: (p, raw) => { p.sinceBaseline = true; setFrom(p, 'sinceBaseline'); if (raw !== undefined) { p.baselinePath = parsePathOption(raw, '--since-baseline'); setFrom(p, 'baselinePath'); } } },
+  { flag: '--fail-on-new-drift', kind: 'flag', help: 'Exit 1 when --since-baseline finds new drift',
+    apply: (p) => { p.failOnNewDrift = true; setFrom(p, 'failOnNewDrift'); } },
+  { flag: '--max-findings', kind: 'value', value: '<number>', help: 'Exit 1 when total findings exceed this count',
+    apply: (p, raw) => { p.maxFindings = parseNonNegativeInteger(raw, '--max-findings'); setFrom(p, 'maxFindings'); } },
+  { flag: '--min-cleanliness', kind: 'value', value: '<percent>', help: 'Exit 1 when scale cleanliness is lower than this percent',
+    apply: (p, raw) => { p.minCleanliness = parsePercentage(raw, '--min-cleanliness'); setFrom(p, 'minCleanliness'); } },
+  { flag: '--since', kind: 'value', value: '<git-ref>', help: 'Scan only changed files since a git ref',
+    apply: (p, raw) => { p.since = parsePathOption(raw, '--since'); setFrom(p, 'since'); } },
+  { flag: '--staged', kind: 'flag', help: 'Scan only staged files', apply: (p) => { p.staged = true; setFrom(p, 'staged'); } },
+  { flag: '--include-motion', kind: 'flag', help: 'Include opt-in motion duration/easing drift',
+    apply: (p) => { p.includeMotion = true; setFrom(p, 'includeMotion'); } },
+  { flag: '--token-source', kind: 'value', value: '<file>', help: 'External token source (repeatable, comma-separated)',
+    apply: (p, raw) => { p.tokenSources.push(...parseTokenSourcePaths(raw)); setFrom(p, 'tokenSources'); } },
+  { flag: '--token-source-format', kind: 'value', value: '<format>', help: 'Token source format: auto, css, flat-json, style-dictionary, dtcg (default: auto)',
+    apply: (p, raw) => { p.tokenSourceFormat = normalizeTokenSourceFormat(raw); setFrom(p, 'tokenSourceFormat'); } },
+  { flag: '--token-kind', kind: 'value', value: '<kind>', help: 'Token kind: spacing, radius, typography, size, motion, all (default: spacing)',
+    apply: (p, raw) => { p.tokenKind = normalizeTokenKind(raw); setFrom(p, 'tokenKind'); } },
+  { flag: '--token-candidate-min-count', kind: 'value', value: '<n>', help: 'Minimum repeated raw value count for token candidates (default: 2)',
+    apply: (p, raw) => { p.tokenCandidateMinCount = parsePositiveInteger(raw, '--token-candidate-min-count'); setFrom(p, 'tokenCandidateMinCount'); } },
+  { flag: '--scale', kind: 'value', value: '<values|auto>', help: ['Comma-separated scale values (default: 0,4,8,12,16,24,32);', 'auto infers the scale from token sources, then --space-*/--spacing-*', 'custom properties and Sass variables in scanned CSS/SCSS, then', 'installed design-token packages, and reports where it came from'],
+    apply: (p, raw) => { p.scale = parseScale(raw); setFrom(p, 'scale'); } },
+  { flag: '--base-font-size', kind: 'value', value: '<number>', help: 'px base for rem/em conversion (default: 16)',
+    apply: (p, raw) => { p.baseFontSize = parseBaseFontSize(raw); setFrom(p, 'baseFontSize'); } },
+  { flag: '--help', alias: '-h', kind: 'flag', help: 'Show this help message', apply: (p) => { p.help = true; } },
+];
 
-Scans .css files, and .scss files when postcss-scss is installed. Reports drift by
-value, by property and by file; text output prints histograms, markdown is PR-ready,
-json is the stable 2.0 contract.
-`;
+const HELP_COLUMN = 33;
+
+function renderHelp() {
+  const lines = ['Usage: rhythmguard audit <dir> [options]', '', 'Options:'];
+  for (const option of OPTIONS) {
+    const label = `  ${option.flag}${option.value ? ` ${option.value}` : ''}`;
+    const help = Array.isArray(option.help) ? option.help : [option.help];
+    lines.push(`${label.padEnd(HELP_COLUMN)}${label.length >= HELP_COLUMN ? ' ' : ''}${help[0]}`);
+    for (const extra of help.slice(1)) {
+      lines.push(`${''.padEnd(HELP_COLUMN)}${extra}`);
+    }
+  }
+  lines.push(
+    '',
+    'Scans .css files, and .scss files when postcss-scss is installed. Reports drift by',
+    'value, by property and by file; text output prints histograms, markdown is PR-ready,',
+    'json is the stable 2.0 contract.',
+    '',
+  );
+  return lines.join('\n');
+}
+
+const HELP = renderHelp();
+
+function findOption(arg) {
+  return OPTIONS.find((option) => option.flag === arg || option.alias === arg) || null;
+}
 
 function parseArgs(argv) {
   const parsed = createDefaultAuditOptions();
 
   for (let index = 0; index < argv.length; index++) {
     const arg = argv[index];
+    const equals = arg.indexOf('=');
+    const inline = arg.startsWith('--') && equals !== -1 ? findOption(arg.slice(0, equals)) : null;
 
-    if (arg === '--help' || arg === '-h') {
-      parsed.help = true;
+    if (inline && inline.kind !== 'flag') {
+      inline.apply(parsed, arg.slice(equals + 1));
       continue;
     }
 
-    if (arg === '--schema') {
-      parsed.schema = true;
-      parsed.format = 'json';
-      continue;
-    }
-
-    if (arg === '--json') {
-      parsed.format = 'json';
-      continue;
-    }
-
-    if (arg === '--markdown') {
-      parsed.format = 'markdown';
-      continue;
-    }
-
-    if (arg === '--output') {
-      parsed.outputPath = parsePathOption(argv[++index], '--output');
-      parsed.cliOptions.add('outputPath');
-      continue;
-    }
-
-    if (arg.startsWith('--output=')) {
-      parsed.outputPath = parsePathOption(arg.slice('--output='.length), '--output');
-      parsed.cliOptions.add('outputPath');
-      continue;
-    }
-
-    if (arg === '--ignore') {
-      parsed.ignorePatterns.push(...parseIgnorePatterns(argv[++index]));
-      parsed.cliOptions.add('ignore');
-      continue;
-    }
-
-    if (arg.startsWith('--ignore=')) {
-      parsed.ignorePatterns.push(...parseIgnorePatterns(arg.slice('--ignore='.length)));
-      parsed.cliOptions.add('ignore');
-      continue;
-    }
-
-    if (arg === '--config') {
-      parsed.configPath = parsePathOption(argv[++index], '--config');
-      parsed.configExplicit = true;
-      continue;
-    }
-
-    if (arg.startsWith('--config=')) {
-      parsed.configPath = parsePathOption(arg.slice('--config='.length), '--config');
-      parsed.configExplicit = true;
-      continue;
-    }
-
-    if (arg === '--no-config') {
-      parsed.noConfig = true;
-      continue;
-    }
-
-    if (arg === '--ignore-path') {
-      parsed.ignorePath = parsePathOption(argv[++index], '--ignore-path');
-      parsed.cliOptions.add('ignorePath');
-      continue;
-    }
-
-    if (arg.startsWith('--ignore-path=')) {
-      parsed.ignorePath = parsePathOption(arg.slice('--ignore-path='.length), '--ignore-path');
-      parsed.cliOptions.add('ignorePath');
-      continue;
-    }
-
-    if (arg === '--baseline') {
-      parsed.baselinePath = parsePathOption(argv[++index], '--baseline');
-      parsed.cliOptions.add('baselinePath');
-      continue;
-    }
-
-    if (arg.startsWith('--baseline=')) {
-      parsed.baselinePath = parsePathOption(arg.slice('--baseline='.length), '--baseline');
-      parsed.cliOptions.add('baselinePath');
-      continue;
-    }
-
-    if (arg === '--write-baseline') {
-      parsed.writeBaseline = true;
-      parsed.cliOptions.add('writeBaseline');
-      if (argv[index + 1] && !argv[index + 1].startsWith('-')) {
-        parsed.baselinePath = parsePathOption(argv[++index], '--write-baseline');
-        parsed.cliOptions.add('baselinePath');
+    const option = findOption(arg);
+    if (option) {
+      if (option.kind === 'flag') {
+        option.apply(parsed);
+      } else if (option.kind === 'value') {
+        option.apply(parsed, argv[++index]);
+      } else if (argv[index + 1] !== undefined && !argv[index + 1].startsWith('-')) {
+        option.apply(parsed, argv[++index]);
+      } else {
+        option.apply(parsed, undefined);
       }
-      continue;
-    }
-
-    if (arg.startsWith('--write-baseline=')) {
-      parsed.writeBaseline = true;
-      parsed.baselinePath = parsePathOption(arg.slice('--write-baseline='.length), '--write-baseline');
-      parsed.cliOptions.add('writeBaseline');
-      parsed.cliOptions.add('baselinePath');
-      continue;
-    }
-
-    if (arg === '--since-baseline') {
-      parsed.sinceBaseline = true;
-      parsed.cliOptions.add('sinceBaseline');
-      if (argv[index + 1] && !argv[index + 1].startsWith('-')) {
-        parsed.baselinePath = parsePathOption(argv[++index], '--since-baseline');
-        parsed.cliOptions.add('baselinePath');
-      }
-      continue;
-    }
-
-    if (arg.startsWith('--since-baseline=')) {
-      parsed.sinceBaseline = true;
-      parsed.baselinePath = parsePathOption(arg.slice('--since-baseline='.length), '--since-baseline');
-      parsed.cliOptions.add('sinceBaseline');
-      parsed.cliOptions.add('baselinePath');
-      continue;
-    }
-
-    if (arg === '--fail-on-new-drift') {
-      parsed.failOnNewDrift = true;
-      parsed.cliOptions.add('failOnNewDrift');
-      continue;
-    }
-
-    if (arg === '--max-findings') {
-      parsed.maxFindings = parseNonNegativeInteger(argv[++index], '--max-findings');
-      parsed.cliOptions.add('maxFindings');
-      continue;
-    }
-
-    if (arg.startsWith('--max-findings=')) {
-      parsed.maxFindings = parseNonNegativeInteger(arg.slice('--max-findings='.length), '--max-findings');
-      parsed.cliOptions.add('maxFindings');
-      continue;
-    }
-
-    if (arg === '--min-cleanliness') {
-      parsed.minCleanliness = parsePercentage(argv[++index], '--min-cleanliness');
-      parsed.cliOptions.add('minCleanliness');
-      continue;
-    }
-
-    if (arg.startsWith('--min-cleanliness=')) {
-      parsed.minCleanliness = parsePercentage(
-        arg.slice('--min-cleanliness='.length),
-        '--min-cleanliness',
-      );
-      parsed.cliOptions.add('minCleanliness');
-      continue;
-    }
-
-    if (arg === '--since') {
-      parsed.since = parsePathOption(argv[++index], '--since');
-      parsed.cliOptions.add('since');
-      continue;
-    }
-
-    if (arg.startsWith('--since=')) {
-      parsed.since = parsePathOption(arg.slice('--since='.length), '--since');
-      parsed.cliOptions.add('since');
-      continue;
-    }
-
-    if (arg === '--staged') {
-      parsed.staged = true;
-      parsed.cliOptions.add('staged');
-      continue;
-    }
-
-    if (arg === '--include-motion') {
-      parsed.includeMotion = true;
-      parsed.cliOptions.add('includeMotion');
-      continue;
-    }
-
-    if (arg === '--token-source') {
-      parsed.tokenSources.push(...parseTokenSourcePaths(argv[++index]));
-      parsed.cliOptions.add('tokenSources');
-      continue;
-    }
-
-    if (arg.startsWith('--token-source=')) {
-      parsed.tokenSources.push(...parseTokenSourcePaths(arg.slice('--token-source='.length)));
-      parsed.cliOptions.add('tokenSources');
-      continue;
-    }
-
-    if (arg === '--token-source-format') {
-      parsed.tokenSourceFormat = normalizeTokenSourceFormat(argv[++index]);
-      parsed.cliOptions.add('tokenSourceFormat');
-      continue;
-    }
-
-    if (arg.startsWith('--token-source-format=')) {
-      parsed.tokenSourceFormat = normalizeTokenSourceFormat(arg.slice('--token-source-format='.length));
-      parsed.cliOptions.add('tokenSourceFormat');
-      continue;
-    }
-
-    if (arg === '--token-kind') {
-      parsed.tokenKind = normalizeTokenKind(argv[++index]);
-      parsed.cliOptions.add('tokenKind');
-      continue;
-    }
-
-    if (arg.startsWith('--token-kind=')) {
-      parsed.tokenKind = normalizeTokenKind(arg.slice('--token-kind='.length));
-      parsed.cliOptions.add('tokenKind');
-      continue;
-    }
-
-    if (arg === '--token-candidate-min-count') {
-      parsed.tokenCandidateMinCount = parsePositiveInteger(argv[++index], '--token-candidate-min-count');
-      parsed.cliOptions.add('tokenCandidateMinCount');
-      continue;
-    }
-
-    if (arg.startsWith('--token-candidate-min-count=')) {
-      parsed.tokenCandidateMinCount = parsePositiveInteger(
-        arg.slice('--token-candidate-min-count='.length),
-        '--token-candidate-min-count',
-      );
-      parsed.cliOptions.add('tokenCandidateMinCount');
-      continue;
-    }
-
-    if (arg === '--badge-metric') {
-      parsed.badgeMetric = String(argv[++index] || '').toLowerCase();
-      continue;
-    }
-
-    if (arg.startsWith('--badge-metric=')) {
-      parsed.badgeMetric = arg.slice('--badge-metric='.length).toLowerCase();
-      continue;
-    }
-
-    if (arg === '--format') {
-      parsed.format = String(argv[++index] || '').toLowerCase();
-      continue;
-    }
-
-    if (arg.startsWith('--format=')) {
-      parsed.format = arg.slice('--format='.length).toLowerCase();
-      continue;
-    }
-
-    if (arg === '--scale') {
-      parsed.scale = parseScale(argv[++index]);
-      parsed.cliOptions.add('scale');
-      continue;
-    }
-
-    if (arg.startsWith('--scale=')) {
-      parsed.scale = parseScale(arg.slice('--scale='.length));
-      parsed.cliOptions.add('scale');
-      continue;
-    }
-
-    if (arg === '--base-font-size') {
-      parsed.baseFontSize = parseBaseFontSize(argv[++index]);
-      parsed.cliOptions.add('baseFontSize');
-      continue;
-    }
-
-    if (arg.startsWith('--base-font-size=')) {
-      parsed.baseFontSize = parseBaseFontSize(arg.slice('--base-font-size='.length));
-      parsed.cliOptions.add('baseFontSize');
       continue;
     }
 
@@ -339,7 +134,7 @@ function parseArgs(argv) {
   }
 
   if (!VALID_FORMATS.has(parsed.format)) {
-    throw new Error(`Invalid format "${parsed.format}". Expected text, json, json-v1, markdown, html, or github.`);
+    throw new Error(`Invalid format "${parsed.format}". Expected ${Array.from(VALID_FORMATS).join(', ')}.`);
   }
 
   if (!BADGE_METRICS.has(parsed.badgeMetric)) {
@@ -459,6 +254,7 @@ function parseBaseFontSize(raw) {
 }
 
 module.exports = {
+  OPTIONS,
   HELP,
   parseArgs,
   parseBaseFontSize,

--- a/test/audit-args.test.js
+++ b/test/audit-args.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+/**
+ * Contract tests for the audit option table: each entry is documented, each
+ * kind parses the three spellings a user can type, and the parser refuses what
+ * it does not know instead of guessing.
+ */
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { HELP, OPTIONS, parseArgs } = require('../src/audit/args');
+
+test('every option in the table is documented in the help text, and every documented flag is in the table', () => {
+  for (const option of OPTIONS) {
+    assert.ok(HELP.includes(`  ${option.flag}`), `${option.flag} appears in --help`);
+    assert.ok(option.help, `${option.flag} has help text`);
+    assert.ok(['flag', 'value', 'optional'].includes(option.kind), `${option.flag} has a known kind`);
+    if (option.kind !== 'flag') assert.ok(option.value, `${option.flag} documents its value`);
+  }
+  const documented = [...HELP.matchAll(/^ {2}(--[a-z-]+)/gm)].map((match) => match[1]);
+  assert.deepEqual(documented.sort(), OPTIONS.map((option) => option.flag).sort());
+});
+
+test('value options accept "--flag value" and "--flag=value", optional ones also stand alone', () => {
+  assert.equal(parseArgs(['src', '--max-findings', '3']).maxFindings, 3);
+  assert.equal(parseArgs(['src', '--max-findings=3']).maxFindings, 3);
+
+  const bare = parseArgs(['src', '--write-baseline']);
+  assert.equal(bare.writeBaseline, true);
+  assert.ok(!bare.cliOptions.has('baselinePath'), 'no path consumed');
+
+  const withPath = parseArgs(['src', '--write-baseline', 'drift.json']);
+  assert.equal(withPath.baselinePath, 'drift.json');
+  assert.ok(withPath.cliOptions.has('baselinePath'));
+
+  const beforeFlag = parseArgs(['src', '--write-baseline', '--staged']);
+  assert.equal(beforeFlag.writeBaseline, true);
+  assert.equal(beforeFlag.staged, true, 'a following flag is not swallowed as the path');
+});
+
+test('the positional directory is the first bare argument and unknown options are refused', () => {
+  assert.equal(parseArgs(['./styles', '--json']).dir, './styles');
+  assert.throws(() => parseArgs(['--nope']), /Unknown option: --nope/);
+  assert.throws(() => parseArgs(['src', '--format', 'yaml']), /Invalid format "yaml"/);
+  assert.throws(() => parseArgs(['src', '--fail-on-new-drift']), /requires --since-baseline/);
+  assert.throws(() => parseArgs(['src', '--since', 'main', '--staged']), /either --since or --staged/);
+});

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -127,3 +127,27 @@ test('embed config is the one-liner for shared-config authors: use-scale on auto
   assert.equal(packageJson.exports['./configs/embed'].require, './src/configs/embed.js');
   assert.equal(packageJson.exports['./configs/embed'].import, './src/configs/embed.mjs');
 });
+
+test('every package export resolves to the same module through require and import', async () => {
+  const root = path.join(__dirname, '..');
+  for (const [subpath, conditions] of Object.entries(packageJson.exports)) {
+    assert.ok(conditions.require && conditions.import && conditions.types, `${subpath} declares types, require and import`);
+    for (const file of [conditions.require, conditions.import, conditions.types]) {
+      assert.ok(fs.existsSync(path.join(root, file)), `${subpath}: ${file} exists`);
+    }
+    const cjs = require(path.join(root, conditions.require));
+    const esm = await import(pathToFileURL(path.join(root, conditions.import)).href);
+    assert.equal(esm.default, cjs, `${subpath}: the ESM default export is the CommonJS module object`);
+    for (const name of Object.keys(esm)) {
+      if (name === 'default') continue;
+      assert.equal(esm[name], cjs[name], `${subpath}: named export ${name} is the same value in both formats`);
+    }
+  }
+});
+
+test('the CLI binary and the main entry point are inside the published files list', () => {
+  const published = packageJson.files;
+  for (const file of [packageJson.main, packageJson.bin.rhythmguard, packageJson.types]) {
+    assert.ok(published.some((entry) => file.replace(/^\.\//, '').startsWith(entry)), `${file} is published`);
+  }
+});


### PR DESCRIPTION
Stage 4 of the architecture work. Behaviour unchanged: lint, typecheck, 215 tests.

- `src/audit/args.js`: 44 hand-written `if` blocks became a table of 26 option entries (`flag`, `kind`, `value`, `help`, `apply`) and a 30-line loop. 472 lines to 268. `--help` is rendered from the table, so a flag cannot exist undocumented; `test/audit-args.test.js` pins that, plus the three spellings (`--x v`, `--x=v`, optional value not swallowing a following flag) and the refusals.
- `test/exports.test.js`: for every entry in `package.json#exports`, `require` and `import` must yield the same module object and the same named exports, and the types file must exist. CJS/ESM parity is now automatic for all 13 subpaths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)