### PR TITLE
docs(outreach): GOV.UK follow-up logged

### DIFF
--- a/docs/outreach/embed-log.md
+++ b/docs/outreach/embed-log.md
@@ -61,3 +61,4 @@ Every audit issue opened from the benchmark, and every response, so the pattern 
 | hashicorp-design-system | 2026-09-06 | skipped: blank issues disabled; use their template by hand |  |
 | fundamental-styles | 2026-09-06 | opened | https://github.com/SAP/fundamental-styles/issues/6390 |
 | ui5-webcomponents | 2026-09-06 | opened | https://github.com/UI5/webcomponents/issues/14027 |
+| govuk-frontend | 2026-09-06 | follow-up: tool now reads $govuk-spacing-points; 21 findings against their own scale posted | https://github.com/alphagov/govuk-frontend/issues/7401#issuecomment-5558916556 |


### PR DESCRIPTION
The promised follow-up on alphagov/govuk-frontend#7401, posted after 3.3.0 shipped the fix that reads `$govuk-spacing-points`. Log row only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)