### PR TITLE
fix(core): bound Sass map and expression nesting in the token evaluator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ### Fixed
 
+- The Sass token evaluator bounds map nesting (16 levels) and expression nesting (64 levels). Generated or adversarial input past those limits is skipped like any other expression it cannot evaluate, instead of overflowing the stack and aborting the audit.
 - `scale: "auto"` prefers root-level declarations. When the custom properties in `:root`, `html`, `:host` or `@theme` (through conditional at-rules) form a scale on their own, variables declared inside component selectors no longer join it. Mantine now infers exactly its `--mantine-spacing-*` ladder instead of a mix with `--chip-spacing`. When the root carries no scale, every declaration still counts. ([#54](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/issues/54))
 - `postcss-value-parser` is declared as a runtime dependency. The rules require it at runtime but it was only a dev dependency, resolved through Stylelint's hoisted copy; strict package managers could not install the plugin without it.
 

--- a/src/core/token-sources.js
+++ b/src/core/token-sources.js
@@ -494,7 +494,16 @@ function splitTopLevel(text, separator) {
   return parts;
 }
 
+// Real token maps nest two or three levels; generated or adversarial input can
+// nest without bound. Past these limits the value is treated like any other
+// expression the evaluator cannot handle: skipped, never guessed, never thrown.
+const MAX_SCSS_MAP_DEPTH = 16;
+const MAX_SCSS_EXPRESSION_DEPTH = 64;
+
 function walkScssMap(raw, pathSegments, visit) {
+  if (pathSegments.length > MAX_SCSS_MAP_DEPTH) {
+    return;
+  }
   const inner = raw.slice(1, -1);
   for (const entry of splitTopLevel(inner, ',')) {
     const pair = splitTopLevel(entry, ':');
@@ -567,7 +576,18 @@ function evaluateScssExpression(expression, resolveVariable, stack) {
     return { number: op === '+' ? left.number + right.number : left.number - right.number, unit: left.unit || right.unit };
   };
 
+  let depth = 0;
   const parsePrimary = () => {
+    if (depth > MAX_SCSS_EXPRESSION_DEPTH) return null;
+    depth += 1;
+    try {
+      return parsePrimaryInner();
+    } finally {
+      depth -= 1;
+    }
+  };
+
+  const parsePrimaryInner = () => {
     const token = next();
     if (!token) return null;
     if (token.type === 'number') return parseNumber(token.raw);

--- a/test/unit/token-sources-scss.test.js
+++ b/test/unit/token-sources-scss.test.js
@@ -132,3 +132,15 @@ test('collectCssTokens records whether a custom property is declared at root lev
     '$spacer': 'root',
   });
 });
+
+test('collectScssTokens fails predictably on adversarial nesting instead of overflowing the stack', () => {
+  const deepMap = `$spacing-map: ${'(a: '.repeat(2000)}4px${')'.repeat(2000)};`;
+  assert.doesNotThrow(() => collectScssTokens(deepMap, spacing));
+
+  const deepExpression = `$spacing-1: ${'('.repeat(5000)}4px${')'.repeat(5000)};`;
+  assert.doesNotThrow(() => collectScssTokens(deepExpression, spacing));
+
+  const shallow = byName(collectScssTokens('$spacing-1: ((4px));\n$spacing-map: (a: (b: (c: 8px)));', spacing));
+  assert.equal(shallow['$spacing-1'], '4px', 'ordinary nesting still evaluates');
+  assert.equal(shallow['$spacing-map.a.b.c'], '8px');
+});


### PR DESCRIPTION
From the robustness item of the architecture audit: inputs may be generated or adversarial and the project should fail predictably. A deeply nested Sass map or expression threw `RangeError` through `collectScssTokens` and aborted the audit. Both recursions are now bounded (16 map levels, 64 expression levels); past the limit the value is skipped, which is what the evaluator already does for anything it cannot evaluate. Test pins both adversarial shapes and ordinary nesting. 220 tests, lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)