### PR TITLE
docs(outreach): first four responses; VitePress marked no scale by design

### DIFF
--- a/benchmarks/quiet/repos.json
+++ b/benchmarks/quiet/repos.json
@@ -386,7 +386,9 @@
       "paths": [
         "src/client/theme-default/styles"
       ],
-      "notes": "VitePress default theme: plain CSS with --vp-* tokens."
+      "notes": "VitePress default theme: plain CSS with --vp-* tokens. Maintainer (vuejs/vitepress#5423): no spacing scale, none planned; measured against the fallback for information only.",
+      "scaleIntent": "none",
+      "scaleIntentSource": "https://github.com/vuejs/vitepress/issues/5423"
     },
     {
       "name": "starlight",

--- a/docs/STATE_OF_SPACING.md
+++ b/docs/STATE_OF_SPACING.md
@@ -8,7 +8,7 @@ This is not a ranking of teams. It is a reading of one signal on a fixed commit,
 npx rhythmguard audit . --scale auto --format markdown
 ```
 
-Across the set: 8334 off-scale values in 8585 CSS files; 40 of 57 repositories had no discoverable spacing tokens and were measured against the `rhythmic-4` fallback, which says more about token discovery than about their CSS, and 4 more had an inference the plausibility check rejected (marked `rejected`, or `unreliable` when the bench alone rejects it; usually component-local variables, see issues #54 and #88).
+Across the set: 8334 off-scale values in 8585 CSS files; 39 of 57 repositories had no discoverable spacing tokens and were measured against the `rhythmic-4` fallback, which says more about token discovery than about their CSS; 1 told us they have no spacing scale by design and are listed without a count, and 4 more had an inference the plausibility check rejected (marked `rejected`, or `unreliable` when the bench alone rejects it; usually component-local variables, see issues #54 and #88).
 
 ## Repositories
 
@@ -25,7 +25,6 @@ Across the set: 8334 off-scale values in 8585 CSS files; 40 of 57 repositories h
 | [adminlte](https://github.com/ColorlibHQ/AdminLTE) | `12b4b06` | fallback | 126 | 274 | 63% | `10px` ×20, `1.25rem` ×9, `2px` ×9 | `padding` ×50, `margin-top` ×17, `margin` ×15 |
 | [discourse](https://github.com/discourse/discourse) | `c7b7a0b` | fallback (scanned-css rejected) | 970 | 259 | 34% | `10px` ×171, `5px` ×147, `20px` ×55 | `padding` ×313, `margin` ×126, `margin-right` ×90 |
 | [directus-app](https://github.com/directus/directus) | `3df2ba9` | fallback | 63 | 217 | 59% | `-0.3125rem` ×17, `0.4375rem` ×9, `-0.1875rem` ×6 | `padding` ×17, `inset-inline-start` ×6, `inset-block-start` ×5 |
-| [vitepress-theme](https://github.com/vuejs/vitepress) | `3e681e2` | fallback | 23 | 209 | 45% | `1.25rem` ×6, `0.375rem` ×3, `0.625rem` ×2 | `padding` ×13, `margin` ×4, `padding-left` ×2 |
 | [vscode-base-ui](https://github.com/microsoft/vscode) | `1512d0c` | fallback | 74 | 195 | 83% | `2px` ×19, `5px` ×10, `6px` ×10 | `padding` ×33, `margin` ×13, `margin-left` ×6 |
 | [pure](https://github.com/pure-css/pure) | `d35fb6f` | fallback | 30 | 188 | 63% | `0.3em` ×6, `0.2em` ×3, `.3em` ×2 | `padding` ×12, `margin` ×7, `margin-bottom` ×5 |
 | [n8n-design-system](https://github.com/n8n-io/n8n) | `7cb77fb` | scanned-css | 143 | 186 | 95% | `5px` ×44, `10px` ×29, `0.6em` ×10 | `padding` ×40, `margin-left` ×23, `margin-right` ×17 |
@@ -71,6 +70,7 @@ Across the set: 8334 off-scale values in 8585 CSS files; 40 of 57 repositories h
 | [mittwald-flow](https://github.com/mittwald/flow) | `17efdf9` | fallback | 2 | 2 | 100% | `2px` ×2 | `padding-inline-end` ×1, `padding-inline-start` ×1 |
 | [open-props](https://github.com/argyleink/open-props) | `530682d` | fallback | 0 | 0 | 100% | none | none |
 | [skeleton](https://github.com/skeletonlabs/skeleton) | `e65535e` | scanned-css | 0 | 0 | 100% | none | none |
+| [vitepress-theme](https://github.com/vuejs/vitepress) | `3e681e2` | none, by design (maintainer) | n/a | n/a | 45% | not measured | not measured |
 
 ## Reading the columns
 
@@ -78,6 +78,7 @@ Across the set: 8334 off-scale values in 8585 CSS files; 40 of 57 repositories h
 - **Top values** are the numbers that drifted. Three values usually explain most of a repository's drift, and each one is a single decision: a missing step, a mistake, or a token that was never defined.
 - **Top properties** are where the layout decision lives. A table led by sibling margins usually means the parent should own the spacing with `gap`; a table led by `padding` is component-internal and is fixed per component.
 - **Top properties** may include `class-string`, which is a Tailwind arbitrary value in a template rather than a CSS declaration.
+- **Scale source** `none, by design` means the maintainers told us the project has no spacing scale. The row stays for completeness and nothing is counted against it.
 - **Scale source** `fallback (scanned-css rejected)` means tokens were found but the rule itself rejected them as a scale and measured against the preset instead. `unreliable` marks a scanned scale that failed a plausibility check (fractional steps, no four-based ladder, or sources that are component files rather than token files). Its row is measured against a scale the repository probably did not design; treat it like a fallback.
 - **Scale source** `fallback` means the audit found fewer than three spacing tokens and used a default scale. Treat those rows as a to-do for token discovery, not as a verdict on the CSS.
 

--- a/docs/outreach/embed-log.md
+++ b/docs/outreach/embed-log.md
@@ -62,3 +62,7 @@ Every audit issue opened from the benchmark, and every response, so the pattern 
 | fundamental-styles | 2026-09-06 | opened | https://github.com/SAP/fundamental-styles/issues/6390 |
 | ui5-webcomponents | 2026-09-06 | opened | https://github.com/UI5/webcomponents/issues/14027 |
 | govuk-frontend | 2026-09-06 | follow-up: tool now reads $govuk-spacing-points; 21 findings against their own scale posted | https://github.com/alphagov/govuk-frontend/issues/7401#issuecomment-5558916556 |
+| element-plus | 2026-09-06 | closed by bot: repository requires its Issue Helper form; audit does not fit a bug form, not re-posted | https://github.com/element-plus/element-plus/issues/24827 |
+| vitepress-theme | 2026-09-06 | maintainer: no scaling tokens, none planned; row marked "no scale by design" | https://github.com/vuejs/vitepress/issues/5423 |
+| metabase | 2026-09-06 | triaged into their tracker (ENG-10915, priority P3) | https://github.com/metabase/metabase/issues/81996 |
+| mantine | 2026-09-06 | closed as completed, no comment | https://github.com/mantinedev/mantine/issues/9178 |

--- a/docs/state-of-spacing/2026-09.json
+++ b/docs/state-of-spacing/2026-09.json
@@ -12,6 +12,7 @@
       "drift": 1952,
       "driftPer100Files": 2913,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -70,6 +71,7 @@
       "drift": 564,
       "driftPer100Files": 1567,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -126,6 +128,7 @@
       "drift": 1058,
       "driftPer100Files": 1027,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -179,6 +182,7 @@
       "drift": 40,
       "driftPer100Files": 1000,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -232,6 +236,7 @@
       "drift": 57,
       "driftPer100Files": 950,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -283,6 +288,7 @@
       "drift": 745,
       "driftPer100Files": 626,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -336,6 +342,7 @@
       "drift": 61,
       "driftPer100Files": 469,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -397,6 +404,7 @@
       "drift": 590,
       "driftPer100Files": 415,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -450,6 +458,7 @@
       "drift": 126,
       "driftPer100Files": 274,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -503,6 +512,7 @@
       "drift": 970,
       "driftPer100Files": 259,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -562,6 +572,7 @@
       "drift": 63,
       "driftPer100Files": 217,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -607,59 +618,6 @@
       ]
     },
     {
-      "name": "vitepress-theme",
-      "url": "https://github.com/vuejs/vitepress",
-      "sha": "3e681e2",
-      "cssFiles": 11,
-      "cleanliness": 45,
-      "drift": 23,
-      "driftPer100Files": 209,
-      "driftDelta": null,
-      "scaleReliable": false,
-      "scaleReasons": [
-        "fallback"
-      ],
-      "scaleRejected": null,
-      "scaleSource": "fallback",
-      "scaleValues": [
-        0,
-        4,
-        8,
-        12,
-        16,
-        24,
-        32
-      ],
-      "topProperties": [
-        [
-          "padding",
-          13
-        ],
-        [
-          "margin",
-          4
-        ],
-        [
-          "padding-left",
-          2
-        ]
-      ],
-      "topValues": [
-        [
-          "1.25rem",
-          6
-        ],
-        [
-          "0.375rem",
-          3
-        ],
-        [
-          "0.625rem",
-          2
-        ]
-      ]
-    },
-    {
       "name": "vscode-base-ui",
       "url": "https://github.com/microsoft/vscode",
       "sha": "1512d0c",
@@ -668,6 +626,7 @@
       "drift": 74,
       "driftPer100Files": 195,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -721,6 +680,7 @@
       "drift": 30,
       "driftPer100Files": 188,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -774,6 +734,7 @@
       "drift": 143,
       "driftPer100Files": 186,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -832,6 +793,7 @@
       "drift": 126,
       "driftPer100Files": 170,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -885,6 +847,7 @@
       "drift": 80,
       "driftPer100Files": 157,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -938,6 +901,7 @@
       "drift": 222,
       "driftPer100Files": 152,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -991,6 +955,7 @@
       "drift": 9,
       "driftPer100Files": 150,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -1044,6 +1009,7 @@
       "drift": 109,
       "driftPer100Files": 120,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -1097,6 +1063,7 @@
       "drift": 272,
       "driftPer100Files": 96,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -1150,6 +1117,7 @@
       "drift": 103,
       "driftPer100Files": 91,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -1207,6 +1175,7 @@
       "drift": 9,
       "driftPer100Files": 60,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -1258,6 +1227,7 @@
       "drift": 55,
       "driftPer100Files": 56,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -1311,6 +1281,7 @@
       "drift": 4,
       "driftPer100Files": 50,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -1364,6 +1335,7 @@
       "drift": 37,
       "driftPer100Files": 49,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -1415,6 +1387,7 @@
       "drift": 35,
       "driftPer100Files": 44,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -1468,6 +1441,7 @@
       "drift": 53,
       "driftPer100Files": 43,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -1518,6 +1492,7 @@
       "drift": 33,
       "driftPer100Files": 43,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -1571,6 +1546,7 @@
       "drift": 137,
       "driftPer100Files": 40,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -1624,6 +1600,7 @@
       "drift": 36,
       "driftPer100Files": 35,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -1674,6 +1651,7 @@
       "drift": 37,
       "driftPer100Files": 34,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -1727,6 +1705,7 @@
       "drift": 47,
       "driftPer100Files": 29,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -1780,6 +1759,7 @@
       "drift": 34,
       "driftPer100Files": 29,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -1833,6 +1813,7 @@
       "drift": 28,
       "driftPer100Files": 19,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -1887,6 +1868,7 @@
       "drift": 18,
       "driftPer100Files": 17,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -1940,6 +1922,7 @@
       "drift": 75,
       "driftPer100Files": 14,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -1993,6 +1976,7 @@
       "drift": 58,
       "driftPer100Files": 13,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -2046,6 +2030,7 @@
       "drift": 7,
       "driftPer100Files": 13,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -2099,6 +2084,7 @@
       "drift": 30,
       "driftPer100Files": 11,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -2152,6 +2138,7 @@
       "drift": 22,
       "driftPer100Files": 11,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -2205,6 +2192,7 @@
       "drift": 27,
       "driftPer100Files": 8,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -2258,6 +2246,7 @@
       "drift": 5,
       "driftPer100Files": 8,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -2310,6 +2299,7 @@
       "drift": 21,
       "driftPer100Files": 7,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -2364,6 +2354,7 @@
       "drift": 14,
       "driftPer100Files": 7,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -2417,6 +2408,7 @@
       "drift": 17,
       "driftPer100Files": 6,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -2470,6 +2462,7 @@
       "drift": 12,
       "driftPer100Files": 6,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -2528,6 +2521,7 @@
       "drift": 7,
       "driftPer100Files": 5,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -2582,6 +2576,7 @@
       "drift": 26,
       "driftPer100Files": 4,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -2633,6 +2628,7 @@
       "drift": 10,
       "driftPer100Files": 4,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -2691,6 +2687,7 @@
       "drift": 5,
       "driftPer100Files": 3,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -2741,6 +2738,7 @@
       "drift": 3,
       "driftPer100Files": 3,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -2790,6 +2788,7 @@
       "drift": 8,
       "driftPer100Files": 2,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -2843,6 +2842,7 @@
       "drift": 5,
       "driftPer100Files": 2,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -2896,6 +2896,7 @@
       "drift": 2,
       "driftPer100Files": 2,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -2937,6 +2938,7 @@
       "drift": 0,
       "driftPer100Files": 0,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": false,
       "scaleReasons": [
         "fallback"
@@ -2964,6 +2966,7 @@
       "drift": 0,
       "driftPer100Files": 0,
       "driftDelta": null,
+      "scaleIntent": null,
       "scaleReliable": true,
       "scaleReasons": [],
       "scaleRejected": null,
@@ -3006,13 +3009,68 @@
       ],
       "topProperties": [],
       "topValues": []
+    },
+    {
+      "name": "vitepress-theme",
+      "url": "https://github.com/vuejs/vitepress",
+      "sha": "3e681e2",
+      "cssFiles": 11,
+      "cleanliness": 45,
+      "drift": 23,
+      "driftPer100Files": 209,
+      "driftDelta": null,
+      "scaleIntent": "none",
+      "scaleReliable": false,
+      "scaleReasons": [
+        "fallback"
+      ],
+      "scaleRejected": null,
+      "scaleSource": "fallback",
+      "scaleValues": [
+        0,
+        4,
+        8,
+        12,
+        16,
+        24,
+        32
+      ],
+      "topProperties": [
+        [
+          "padding",
+          13
+        ],
+        [
+          "margin",
+          4
+        ],
+        [
+          "padding-left",
+          2
+        ]
+      ],
+      "topValues": [
+        [
+          "1.25rem",
+          6
+        ],
+        [
+          "0.375rem",
+          3
+        ],
+        [
+          "0.625rem",
+          2
+        ]
+      ]
     }
   ],
   "totals": {
     "cssFiles": 8585,
     "drift": 8334,
     "repos": 57,
-    "fallbackScales": 40,
+    "fallbackScales": 39,
+    "noScaleByDesign": 1,
     "unreliableScales": 4
   }
 }

--- a/docs/state-of-spacing/2026-09.md
+++ b/docs/state-of-spacing/2026-09.md
@@ -8,7 +8,7 @@ This is not a ranking of teams. It is a reading of one signal on a fixed commit,
 npx rhythmguard audit . --scale auto --format markdown
 ```
 
-Across the set: 8334 off-scale values in 8585 CSS files; 40 of 57 repositories had no discoverable spacing tokens and were measured against the `rhythmic-4` fallback, which says more about token discovery than about their CSS, and 4 more had an inference the plausibility check rejected (marked `rejected`, or `unreliable` when the bench alone rejects it; usually component-local variables, see issues #54 and #88).
+Across the set: 8334 off-scale values in 8585 CSS files; 39 of 57 repositories had no discoverable spacing tokens and were measured against the `rhythmic-4` fallback, which says more about token discovery than about their CSS; 1 told us they have no spacing scale by design and are listed without a count, and 4 more had an inference the plausibility check rejected (marked `rejected`, or `unreliable` when the bench alone rejects it; usually component-local variables, see issues #54 and #88).
 
 ## Repositories
 
@@ -25,7 +25,6 @@ Across the set: 8334 off-scale values in 8585 CSS files; 40 of 57 repositories h
 | [adminlte](https://github.com/ColorlibHQ/AdminLTE) | `12b4b06` | fallback | 126 | 274 | 63% | `10px` ×20, `1.25rem` ×9, `2px` ×9 | `padding` ×50, `margin-top` ×17, `margin` ×15 |
 | [discourse](https://github.com/discourse/discourse) | `c7b7a0b` | fallback (scanned-css rejected) | 970 | 259 | 34% | `10px` ×171, `5px` ×147, `20px` ×55 | `padding` ×313, `margin` ×126, `margin-right` ×90 |
 | [directus-app](https://github.com/directus/directus) | `3df2ba9` | fallback | 63 | 217 | 59% | `-0.3125rem` ×17, `0.4375rem` ×9, `-0.1875rem` ×6 | `padding` ×17, `inset-inline-start` ×6, `inset-block-start` ×5 |
-| [vitepress-theme](https://github.com/vuejs/vitepress) | `3e681e2` | fallback | 23 | 209 | 45% | `1.25rem` ×6, `0.375rem` ×3, `0.625rem` ×2 | `padding` ×13, `margin` ×4, `padding-left` ×2 |
 | [vscode-base-ui](https://github.com/microsoft/vscode) | `1512d0c` | fallback | 74 | 195 | 83% | `2px` ×19, `5px` ×10, `6px` ×10 | `padding` ×33, `margin` ×13, `margin-left` ×6 |
 | [pure](https://github.com/pure-css/pure) | `d35fb6f` | fallback | 30 | 188 | 63% | `0.3em` ×6, `0.2em` ×3, `.3em` ×2 | `padding` ×12, `margin` ×7, `margin-bottom` ×5 |
 | [n8n-design-system](https://github.com/n8n-io/n8n) | `7cb77fb` | scanned-css | 143 | 186 | 95% | `5px` ×44, `10px` ×29, `0.6em` ×10 | `padding` ×40, `margin-left` ×23, `margin-right` ×17 |
@@ -71,6 +70,7 @@ Across the set: 8334 off-scale values in 8585 CSS files; 40 of 57 repositories h
 | [mittwald-flow](https://github.com/mittwald/flow) | `17efdf9` | fallback | 2 | 2 | 100% | `2px` ×2 | `padding-inline-end` ×1, `padding-inline-start` ×1 |
 | [open-props](https://github.com/argyleink/open-props) | `530682d` | fallback | 0 | 0 | 100% | none | none |
 | [skeleton](https://github.com/skeletonlabs/skeleton) | `e65535e` | scanned-css | 0 | 0 | 100% | none | none |
+| [vitepress-theme](https://github.com/vuejs/vitepress) | `3e681e2` | none, by design (maintainer) | n/a | n/a | 45% | not measured | not measured |
 
 ## Reading the columns
 
@@ -78,6 +78,7 @@ Across the set: 8334 off-scale values in 8585 CSS files; 40 of 57 repositories h
 - **Top values** are the numbers that drifted. Three values usually explain most of a repository's drift, and each one is a single decision: a missing step, a mistake, or a token that was never defined.
 - **Top properties** are where the layout decision lives. A table led by sibling margins usually means the parent should own the spacing with `gap`; a table led by `padding` is component-internal and is fixed per component.
 - **Top properties** may include `class-string`, which is a Tailwind arbitrary value in a template rather than a CSS declaration.
+- **Scale source** `none, by design` means the maintainers told us the project has no spacing scale. The row stays for completeness and nothing is counted against it.
 - **Scale source** `fallback (scanned-css rejected)` means tokens were found but the rule itself rejected them as a scale and measured against the preset instead. `unreliable` marks a scanned scale that failed a plausibility check (fractional steps, no four-based ladder, or sources that are component files rather than token files). Its row is measured against a scale the repository probably did not design; treat it like a fallback.
 - **Scale source** `fallback` means the audit found fewer than three spacing tokens and used a default scale. Treat those rows as a to-do for token discovery, not as a verdict on the CSS.
 

--- a/scripts/bench/outreach.mjs
+++ b/scripts/bench/outreach.mjs
@@ -31,7 +31,7 @@ export function draftIssue(result) {
   const drift = (result.classified || []).filter((item) => item.category === 'drift');
   const topValues = topCounts(drift, 'value', 5);
   const topProperties = topCounts(drift, 'property', 5);
-  const fallback = result.scale.source === 'fallback';
+  const fallback = result.scale.source === 'fallback' || result.scaleIntent === 'none';
   const unreliable = !fallback && !assessScale(result.scale).plausible;
   const scale = result.scale.values.join(', ');
   const paths = result.paths.map((p) => `\`${p}\``).join(', ');

--- a/scripts/bench/quiet.mjs
+++ b/scripts/bench/quiet.mjs
@@ -163,6 +163,7 @@ async function auditRepo(repo, checkout, rules) {
     paths: repo.paths,
     scale: report.scale,
     scaleCleanliness: report.scaleCleanliness,
+    scaleIntent: repo.scaleIntent || null,
     sha: checkout.sha,
     summary,
     tailwindFindings: report.findings.tailwind.length,

--- a/scripts/bench/state-of-spacing.mjs
+++ b/scripts/bench/state-of-spacing.mjs
@@ -59,6 +59,7 @@ export function buildEdition(results, { id, previous = null, generatedAt = new D
       drift: driftCount,
       driftPer100Files: cssFiles > 0 ? Math.round((driftCount / cssFiles) * 100) : 0,
       driftDelta: before ? driftCount - before.drift : null,
+      scaleIntent: result.scaleIntent || null,
       scaleReliable: assessment.plausible,
       scaleReasons: assessment.reasons,
       scaleRejected: result.scale && result.scale.rejected ? { reasons: result.scale.rejected.reasons, source: result.scale.rejected.source } : null,
@@ -69,7 +70,7 @@ export function buildEdition(results, { id, previous = null, generatedAt = new D
     };
   });
 
-  rows.sort((a, b) => b.driftPer100Files - a.driftPer100Files || b.drift - a.drift || a.name.localeCompare(b.name));
+  rows.sort((a, b) => (a.scaleIntent === 'none') - (b.scaleIntent === 'none') || b.driftPer100Files - a.driftPer100Files || b.drift - a.drift || a.name.localeCompare(b.name));
 
   return {
     generatedAt,
@@ -80,7 +81,8 @@ export function buildEdition(results, { id, previous = null, generatedAt = new D
       cssFiles: rows.reduce((sum, row) => sum + row.cssFiles, 0),
       drift: rows.reduce((sum, row) => sum + row.drift, 0),
       repos: rows.length,
-      fallbackScales: rows.filter((row) => row.scaleSource === 'fallback').length,
+      fallbackScales: rows.filter((row) => row.scaleSource === 'fallback' && row.scaleIntent !== 'none').length,
+      noScaleByDesign: rows.filter((row) => row.scaleIntent === 'none').length,
       unreliableScales: rows.filter((row) => (row.scaleSource !== 'fallback' && !row.scaleReliable) || row.scaleRejected).length,
     },
   };
@@ -109,7 +111,7 @@ export function renderEdition(edition) {
     'npx rhythmguard audit . --scale auto --format markdown',
     '```',
     '',
-    `Across the set: ${edition.totals.drift} off-scale values in ${edition.totals.cssFiles} CSS files; ${edition.totals.fallbackScales} of ${edition.totals.repos} repositories had no discoverable spacing tokens and were measured against the \`rhythmic-4\` fallback, which says more about token discovery than about their CSS${edition.totals.unreliableScales > 0 ? `, and ${edition.totals.unreliableScales} more had an inference the plausibility check rejected (marked \`rejected\`, or \`unreliable\` when the bench alone rejects it; usually component-local variables, see issues #54 and #88)` : ''}.${withDelta ? ` Changes are since ${edition.previousId}.` : ''}`,
+    `Across the set: ${edition.totals.drift} off-scale values in ${edition.totals.cssFiles} CSS files; ${edition.totals.fallbackScales} of ${edition.totals.repos} repositories had no discoverable spacing tokens and were measured against the \`rhythmic-4\` fallback, which says more about token discovery than about their CSS${edition.totals.noScaleByDesign > 0 ? `; ${edition.totals.noScaleByDesign} told us they have no spacing scale by design and are listed without a count` : ''}${edition.totals.unreliableScales > 0 ? `, and ${edition.totals.unreliableScales} more had an inference the plausibility check rejected (marked \`rejected\`, or \`unreliable\` when the bench alone rejects it; usually component-local variables, see issues #54 and #88)` : ''}.${withDelta ? ` Changes are since ${edition.previousId}.` : ''}`,
     '',
     '## Repositories',
     '',
@@ -118,6 +120,10 @@ export function renderEdition(edition) {
   ];
 
   for (const row of edition.rows) {
+    if (row.scaleIntent === 'none') {
+      lines.push(`| [${row.name}](${row.url}) | \`${row.sha}\` | none, by design (maintainer) | n/a | n/a | ${row.cleanliness}% | not measured | not measured |${withDelta ? ' n/a |' : ''}`);
+      continue;
+    }
     lines.push(`| [${row.name}](${row.url}) | \`${row.sha}\` | ${row.scaleSource}${row.scaleRejected ? ` (${row.scaleRejected.source} rejected)` : row.scaleSource !== 'fallback' && !row.scaleReliable ? ' (unreliable)' : ''} | ${row.drift} | ${row.driftPer100Files} | ${row.cleanliness}% | ${formatCounts(row.topValues)} | ${formatCounts(row.topProperties)} |${withDelta ? ` ${formatDelta(row.driftDelta)} |` : ''}`);
   }
 
@@ -129,6 +135,7 @@ export function renderEdition(edition) {
     '- **Top values** are the numbers that drifted. Three values usually explain most of a repository\'s drift, and each one is a single decision: a missing step, a mistake, or a token that was never defined.',
     '- **Top properties** are where the layout decision lives. A table led by sibling margins usually means the parent should own the spacing with `gap`; a table led by `padding` is component-internal and is fixed per component.',
     '- **Top properties** may include `class-string`, which is a Tailwind arbitrary value in a template rather than a CSS declaration.',
+    '- **Scale source** `none, by design` means the maintainers told us the project has no spacing scale. The row stays for completeness and nothing is counted against it.',
     '- **Scale source** `fallback (scanned-css rejected)` means tokens were found but the rule itself rejected them as a scale and measured against the preset instead. `unreliable` marks a scanned scale that failed a plausibility check (fractional steps, no four-based ladder, or sources that are component files rather than token files). Its row is measured against a scale the repository probably did not design; treat it like a fallback.',
     '- **Scale source** `fallback` means the audit found fewer than three spacing tokens and used a default scale. Treat those rows as a to-do for token discovery, not as a verdict on the CSS.',
     '',

--- a/test/bench/state-of-spacing.test.js
+++ b/test/bench/state-of-spacing.test.js
@@ -119,3 +119,18 @@ test('buildEdition shows a fallback caused by a rejected inference as such', asy
   assert.equal(edition.totals.unreliableScales, 1);
   assert.match(renderEdition(edition), /\| \[zulip\]\([^)]*\) \| `abc1234` \| fallback \(scanned-css rejected\) \|/);
 });
+
+test('a repository whose maintainers said there is no spacing scale is listed without a count and sorted last', async () => {
+  const { buildEdition, renderEdition } = await load();
+  const edition = buildEdition([
+    result({ name: 'vitepress', scaleIntent: 'none', scale: { source: 'fallback', values: [0, 4, 8], tokenCount: 0, files: [] } }),
+    result(),
+  ], { id: '2026-09' });
+
+  assert.deepEqual(edition.rows.map((row) => row.name), ['acme', 'vitepress']);
+  assert.equal(edition.totals.noScaleByDesign, 1);
+  assert.equal(edition.totals.fallbackScales, 0, 'a declared no-scale repo is not a token-discovery gap');
+  const markdown = renderEdition(edition);
+  assert.match(markdown, /\| \[vitepress\]\([^)]*\) \| `abc1234` \| none, by design \(maintainer\) \| n\/a \| n\/a \|/);
+  assert.match(markdown, /1 told us they have no spacing scale by design/);
+});


### PR DESCRIPTION
First responses to the audit issues, recorded in `docs/outreach/embed-log.md`:

- Element Plus: closed by bot, the repository requires its Issue Helper form. Not re-posted.
- VitePress: maintainer says there are no scaling tokens and none are planned.
- Metabase: triaged into their tracker (ENG-10915, P3).
- Mantine: closed as completed, no comment.

The issue text promised that a repository which says it has no scale by design would be marked that way. `scaleIntent: "none"` in the manifest now does that: the State of Spacing row reads `none, by design (maintainer)` with no count, sorts last, is excluded from the token-discovery gap total, and the draft generator never quotes a number at it. Test added. 221 tests, lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)