### PR TITLE
fix(audit): keep per-source tokenPattern from config and typed sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- `audit.tokenSources` entries in `.rhythmguardrc.json` and typed sources passed to the API keep their `tokenPattern`. Both normalisers dropped it, so a per-source pattern was silently ignored by the audit while the same key worked for the package allowlist.
+
 ### Added
 
 - Token-package discovery reads five more packages, each named by its maintainers in the audit issues: `bootstrap` (`$spacer`, `$spacers`; Bootstrap-derived systems such as AdminLTE inherit it), `@patternfly/patternfly`, `@mittwald/flow-design-tokens` (`--size-px--*` and `--size-rem--*`, one ladder in two units), `govuk-frontend` and `nhsuk-frontend`. A contract test checks every allowlist entry.

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -111,7 +111,7 @@ Shared settings go in `.rhythmguardrc.json`, loaded automatically when present. 
 }
 ```
 
-Token source paths in the config resolve from the config file's directory. CLI `--token-source` paths resolve from the current working directory. Supported source formats: CSS custom properties and Tailwind v4 `@theme`, flat JSON, Style Dictionary JSON, and DTCG JSON. CLI scalar flags override config values.
+A token source object may also carry `tokenPattern`, a regular expression applied to token names instead of the built-in spacing name matcher, for systems whose scale is not called space or spacing (`{ "path": "./node_modules/@mittwald/flow-design-tokens/dist/css/base.css", "tokenPattern": "^--size-(?:px|rem)--" }`). Token source paths in the config resolve from the config file's directory. CLI `--token-source` paths resolve from the current working directory. Supported source formats: CSS custom properties and Tailwind v4 `@theme`, flat JSON, Style Dictionary JSON, and DTCG JSON. CLI scalar flags override config values.
 
 ## Baselines and gates
 

--- a/src/audit/config.js
+++ b/src/audit/config.js
@@ -141,6 +141,7 @@ function normalizeCliTokenSources(sources, format) {
         baseDir: source.baseDir || process.cwd(),
         format: source.format || format,
         path: source.path || source.file,
+        ...(typeof source.tokenPattern === 'string' && source.tokenPattern ? { tokenPattern: source.tokenPattern } : {}),
       };
     }
     return {
@@ -177,10 +178,15 @@ function normalizeConfigTokenSources(sources, baseDir) {
       throw new Error('Invalid Rhythmguard config: token source objects must include a path.');
     }
 
+    if (source.tokenPattern !== undefined && (typeof source.tokenPattern !== 'string' || source.tokenPattern.trim().length === 0)) {
+      throw new Error('Invalid Rhythmguard config: token source tokenPattern must be a non-empty string.');
+    }
+
     return {
       baseDir,
       format: normalizeTokenSourceFormat(source.format || 'auto'),
       path: source.path,
+      ...(source.tokenPattern ? { tokenPattern: source.tokenPattern } : {}),
     };
   });
 }

--- a/test/cli/audit-cli.test.js
+++ b/test/cli/audit-cli.test.js
@@ -879,3 +879,19 @@ test('audit CLI --scale auto infers from root-level tokens and reports only thei
   assert.deepEqual(scale.values, [0, 10, 12, 16, 20, 32]);
   assert.deepEqual(scale.files.map((file) => path.basename(file)), ['theme.css']);
 });
+
+test('audit CLI honours a per-source tokenPattern from the config file for scale inference', () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-audit-pattern-'));
+  fs.mkdirSync(path.join(fixtureDir, 'src'));
+  fs.writeFileSync(path.join(fixtureDir, 'tokens.css'), ':root { --size-px--xs: 4px; --size-px--s: 8px; --size-px--m: 16px; --size-px--l: 24px; --button--spacing: var(--size-px--m); }\n');
+  fs.writeFileSync(path.join(fixtureDir, 'src', 'a.css'), '.a { padding: 13px; }\n');
+  fs.writeFileSync(path.join(fixtureDir, '.rhythmguardrc.json'), JSON.stringify({
+    audit: { tokenSources: [{ path: './tokens.css', tokenPattern: '^--size-px--' }] },
+  }));
+
+  const result = runAuditCommand(fixtureDir, path.join(fixtureDir, 'src'), '--scale', 'auto', '--format', 'json');
+  assert.equal(result.status, 0, result.stderr);
+  const scale = JSON.parse(result.stdout).contracts.scale;
+  assert.equal(scale.source, 'token-sources');
+  assert.deepEqual(scale.values, [0, 4, 8, 16, 24]);
+});


### PR DESCRIPTION
Both token-source normalisers in `src/audit/config.js` copied only `path` and `format`, so a `tokenPattern` on a `.rhythmguardrc.json` entry or on a typed source passed to the API was silently dropped. The package allowlist path kept it, which is why it worked there and not here. Found while re-running the mittwald Flow audit against its `--size-px--*` tokens. Test pins scale inference from a patterned config source; the audit page documents the key. 225 tests, lint, typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)