### PR TITLE
chore(release): v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-09-08
+
 ### Fixed
 
 - `audit.tokenSources` entries in `.rhythmguardrc.json` and typed sources passed to the API keep their `tokenPattern`. Both normalisers dropped it, so a per-source pattern was silently ignored by the audit while the same key worked for the package allowlist.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stylelint-plugin-rhythmguard",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint-plugin-rhythmguard",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "known-css-properties": "^0.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-rhythmguard",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Nobody chose 13px. Catches off-scale spacing in CSS and Tailwind class strings and snaps it to your scale or tokens. Stylelint rules, an ESLint companion, and an audit CLI.",
   "bin": {
     "rhythmguard": "src/cli/index.js"


### PR DESCRIPTION
Release 3.5.0: version bump and changelog cut. Contents since 3.4.0: five token packages from the maintainer replies, the scale-in-dependency and no-scale-by-design edition marks, and the config tokenPattern fix. Local gate: lint, typecheck, 225 tests, floor suite, pack smoke, all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)