### PR TITLE
docs: tend README, CONTRIBUTING, SECURITY and the release checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ npm ci
 npm test
 ```
 
-Node 20.19 or newer. No build step; the source runs as is. Tests use `node --test` and take about ten seconds. They are grouped by what they prove:
+Node 20.19 or newer. No build step; the source runs as is. Tests use `node --test` through `scripts/test.mjs` and take about ten seconds. They are grouped by what they prove:
 
 | Folder | Proves | Run one |
 | --- | --- | --- |
@@ -58,7 +58,10 @@ npm run test:compat-floor      # Stylelint 16.0.0, the oldest supported
 npm run test:pack-smoke        # pack the tarball and install it in a temp project
 npm run scales:validate        # community scale JSON
 npm run bench:quiet -- --check # findings on the benchmark repos must match snapshots
+npm run build:agents           # after editing the block in docs/FOR_AGENTS.md
 ```
+
+The local gate runs on whatever Node you have installed; CI runs Node 20 and 22. Node 20.19 is the floor, so avoid features that arrived in Node 21 or later. Glob patterns for `node --test` were one such feature, and they took a release run down.
 
 If your shell's npm registry is overridden by a corporate `.npmrc`, add `--registry https://registry.npmjs.org` to `npm ci` and prefix `test:pack-smoke` with `npm_config_registry=https://registry.npmjs.org`.
 
@@ -88,14 +91,14 @@ CI for this repository runs on self-hosted runners for pushes and same-repo bran
 - Minor: new options, presets, sources, or behaviour that does not change existing reports.
 - Major: any change to default reports for existing configs, to autofix behaviour, or to exported entry points.
 
-`configs/recommended`, `configs/strict`, `configs/tailwind` and `configs/embed` stay stable within a major. The `embed` config's shape is frozen for 2.x because shared configs depend on it.
+`configs/recommended`, `configs/strict`, `configs/tailwind`, `configs/motion` and `configs/embed` stay stable within a major. The `embed` config's shape is frozen within a major because shared configs depend on it.
 
 ## Compatibility
 
 - Stylelint `^16.0.0 || ^17.0.0`. The 16.0.0 floor has known autofix differences; CI runs the floor suite against it.
 - Node `>=20.19.0`.
 - CommonJS and ESM entry points; every export has a declaration under `types/`.
-- One runtime dependency, `known-css-properties`. `postcss-scss`, `stylelint-config-tailwindcss` and `stylelint-plugin-logical-css` are optional peers and dev dependencies here.
+- Two runtime dependencies, `known-css-properties` and `postcss-value-parser`. `postcss-scss`, `stylelint-config-tailwindcss` and `stylelint-plugin-logical-css` are optional peers and dev dependencies here. `test/contracts/architecture.test.js` fails if a runtime import is not declared.
 
 ## Review
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/petrilahdelma/stylelint-plugin-rhythmguard/main/assets/rhythmguard-banner.svg?v=9" width="100%" alt="Rhythmguard banner showing spacing scale ruler and lint output" />
+  <img src="https://raw.githubusercontent.com/petrilahdelma/stylelint-plugin-rhythmguard/main/assets/rhythmguard-banner.svg?v=9" width="100%" alt="Rhythmguard: stable local evidence for design system drift" />
 </p>
 
 # stylelint-plugin-rhythmguard
@@ -11,9 +11,9 @@ Nobody chose 13px. Rhythmguard catches off-scale spacing in CSS and Tailwind cla
 [![npm downloads](https://img.shields.io/npm/dm/stylelint-plugin-rhythmguard.svg)](https://www.npmjs.com/package/stylelint-plugin-rhythmguard)
 [![License: MIT](https://img.shields.io/badge/license-MIT-white.svg)](./LICENSE)
 
-Rhythmguard is scale-aware rather than a blanket ban: values on your scale pass, values off it are reported with the two nearest steps, and tokens are only ever suggested from a map you control. It works on CSS declarations through Stylelint and on Tailwind class strings through an ESLint companion, and it ships an audit CLI so you can measure drift and ratchet it down before enforcing anything.
+Rhythmguard is scale-aware rather than a blanket ban: values on your scale pass, values off it are reported with the two nearest steps, and tokens are only ever suggested from a map you control. It works on CSS and SCSS declarations through Stylelint and on Tailwind class strings through an ESLint companion, and it ships an audit CLI so you can measure drift and ratchet it down before enforcing anything.
 
-What it is not: it does not check colors or hex values, and the Stylelint rules do not see Tailwind class strings (that is the separate ESLint companion below). Pair it with a color linter if you need one; do not expect one tool to do both. SCSS is audited when `postcss-scss` is installed.
+What it is not: it does not check colors or hex values, and the Stylelint rules do not see Tailwind class strings (that is the separate ESLint companion below). Pair it with a color linter if you need one; do not expect one tool to do both.
 
 ## Start here
 
@@ -81,11 +81,9 @@ npx rhythmguard audit ./src --since-baseline --fail-on-new-drift
 npx rhythmguard audit ./src --format github
 ```
 
-The audit scans CSS declarations, Tailwind class strings and your token contract, prints a scale-cleanliness score, and supports baselines so legacy codebases can gate only new drift. Formats: text, Markdown, JSON 2.0, HTML, and GitHub Actions annotations. Full reference in [docs/AUDIT.md](docs/AUDIT.md), rollout recipe in [docs/CI_ADOPTION.md](docs/CI_ADOPTION.md).
+The audit scans CSS declarations, Tailwind class strings and your token contract, prints a scale-cleanliness score, and supports baselines so legacy codebases can gate only new drift. Formats: text, Markdown, JSON 2.0, HTML, GitHub Actions annotations, and a shields.io badge document for your README. Full reference in [docs/AUDIT.md](docs/AUDIT.md), rollout recipe and the badge workflow in [docs/CI_ADOPTION.md](docs/CI_ADOPTION.md).
 
-`npx rhythmguard init` writes a starter config for your stack. `npx rhythmguard doctor` checks the setup.
-
-A README badge comes from the same audit: `--format badge` writes a shields.io endpoint document, see [`docs/CI_ADOPTION.md`](./docs/CI_ADOPTION.md#5-show-a-badge).
+`npx rhythmguard init` writes a starter config for your stack, and `init --agents all` installs the coding-agent instructions. `npx rhythmguard doctor` checks the setup.
 
 ## Guides
 
@@ -99,11 +97,11 @@ A README badge comes from the same audit: `--format badge` writes a shields.io e
 - [State of Spacing](docs/STATE_OF_SPACING.md): dated editions of the same data, ranked by drift density, with the values and properties that drifted
 - [Architecture](docs/ARCHITECTURE.md): the layers, the rule kit, the invariants and where each is enforced
 - [Product direction](docs/STRATEGY_2026-09.md)
-- Browser playground: [petrilahdelma.github.io/stylelint-plugin-rhythmguard](https://petrilahdelma.github.io/stylelint-plugin-rhythmguard/)
+- Browser playground: [petrilahdelma.github.io/stylelint-plugin-rhythmguard](https://petrilahdelma.github.io/stylelint-plugin-rhythmguard/), a simplified re-implementation for trying values in the browser; the real rules run under Node ([#57](https://github.com/PetriLahdelma/stylelint-plugin-rhythmguard/issues/57) tracks bundling them)
 
 ## Compatibility
 
-Stylelint 16 and 17. Node 20.19 or newer. One runtime dependency (`known-css-properties`); `postcss-scss`, `stylelint-config-tailwindcss` and `stylelint-plugin-logical-css` are optional peers. CommonJS and ESM entry points, TypeScript declarations for every export. The CI matrix runs Node 20 and 22 against Stylelint 16.0.0, 16.x and 17.x. Upgrading from 2.x: [docs/MIGRATING_TO_3.md](docs/MIGRATING_TO_3.md).
+Stylelint 16 and 17. Node 20.19 or newer. Two runtime dependencies (`known-css-properties`, `postcss-value-parser`); `postcss-scss`, `stylelint-config-tailwindcss` and `stylelint-plugin-logical-css` are optional peers. CommonJS and ESM entry points, TypeScript declarations for every export. The CI matrix runs Node 20 and 22 against Stylelint 16.0.0, 16.x and 17.x. Upgrading from 2.x: [docs/MIGRATING_TO_3.md](docs/MIGRATING_TO_3.md).
 
 ## Contributing and support
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,9 @@
 
 | Version | Supported |
 | --- | --- |
-| 2.x | Yes |
-| < 2.0 | No, upgrade to 2.x |
+| 3.x | Yes |
+| 2.x | Security fixes only until 2027-03-01 |
+| < 2.0 | No, upgrade to 3.x |
 
 ## Reporting a Vulnerability
 

--- a/docs/CONFIGS.md
+++ b/docs/CONFIGS.md
@@ -4,7 +4,7 @@ Every config is a one-line `extends`. Pick the first one that fits and move down
 
 | Config | Enables | Use when |
 | --- | --- | --- |
-| `embed` | `use-scale` at warning level with `scale: "auto"` | You maintain a shared config that other teams install. Shape frozen for 2.x. See [`FOR_CONFIG_AUTHORS.md`](./FOR_CONFIG_AUTHORS.md) |
+| `embed` | `use-scale` at warning level with `scale: "auto"` | You maintain a shared config that other teams install. Shape frozen within a major. See [`FOR_CONFIG_AUTHORS.md`](./FOR_CONFIG_AUTHORS.md) |
 | `recommended` | `use-scale` on the spacing group | You want spacing on a scale and nothing else decided for you |
 | `strict` | `use-scale` + `prefer-token` + `no-offscale-transform` | Tokens exist and raw literals should be errors |
 | `tailwind` | `strict` + `stylelint-config-tailwindcss` + `@theme` token extraction | Tailwind v3 or v4 project. Install `stylelint-config-tailwindcss` yourself; it is an optional peer |

--- a/docs/FOR_CONFIG_AUTHORS.md
+++ b/docs/FOR_CONFIG_AUTHORS.md
@@ -98,7 +98,7 @@ Zero, percentages, and hairlines (non-zero lengths of one CSS pixel or less such
 - Stylelint 16 and 17. Node 20.19 or newer.
 - Runtime dependency: `known-css-properties`, nothing else. Optional peers: `postcss-scss` to audit SCSS, `stylelint-config-tailwindcss` for the `tailwind` config, `stylelint-plugin-logical-css` if you compose with it. `embed` needs none of them.
 - CommonJS and ESM entry points, TypeScript declarations for every export.
-- The `embed` config's shape and defaults will not change within 2.x. Changes to inference sources are additive.
+- The `embed` config's shape and defaults will not change within a major version. Changes to inference sources are additive.
 - Bugs and false positives: [open an issue](https://github.com/petrilahdelma/stylelint-plugin-rhythmguard/issues). A finding your consumers consider wrong is exactly what the quiet benchmark exists to catch; a reproduction in an issue is enough.
 
 ## Going further

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,33 +1,62 @@
-# Release Checklist
+# Release checklist
 
-## Pre-release
+Releases are maintainer-run and take about twenty minutes of attention. The publish itself is automated: a GitHub release triggers `release.yml`, which verifies on the self-hosted matrix (Node 20 and 22 against Stylelint 16.0.0, 16 and 17) and publishes from a GitHub-hosted job through npm trusted publishing (OIDC). No npm token exists anywhere. Provenance is attached automatically.
 
-1. Run `npm ci`.
-2. Run `npm run lint`.
-3. Run `npm test`.
-4. Confirm README links and examples still match exported rule names.
-5. Confirm `package.json` version and changelog notes.
+## 1. Decide the version
 
-## GitHub Release
+- Patch: fixes, docs, internal changes.
+- Minor: new options, sources, packages, formats, or behaviour that does not change existing reports.
+- Major: a change to default reports, to autofix output, or to exported entry points. Write `docs/MIGRATING_TO_<n>.md` first.
 
-1. Create/update tag (example: `v0.1.0`).
-2. Push `main` and tag.
-3. Create a GitHub Release from the tag with:
-   - summary of changes
-   - upgrade notes
-   - migration notes if rule defaults changed
+## 2. Cut it on a branch
 
-## npm Publish
+```bash
+git checkout -b release/vX.Y.Z origin/main
+npm version X.Y.Z --no-git-tag-version
+```
 
-1. Publishing is done by `release.yml` through npm trusted publishing (OIDC). The trusted publisher on npmjs.com is bound to `PetriLahdelma/stylelint-plugin-rhythmguard` and the workflow file `release.yml`; no npm token is stored anywhere.
-2. The publish job must run on a GitHub-hosted runner (npm does not support trusted publishing from self-hosted runners). Provenance is attached automatically.
-3. Verify package metadata, provenance badge and README on npm.
+Rename the `## [Unreleased]` section of `CHANGELOG.md` to `## [X.Y.Z] - YYYY-MM-DD`, leaving an empty `## [Unreleased]` above it.
 
-## Post-release
+## 3. Run the local gate
 
-1. Smoke-test install in clean project:
-   - `npm i -D stylelint stylelint-plugin-rhythmguard`
-2. Validate both configs:
-   - `stylelint-plugin-rhythmguard/configs/recommended`
-   - `stylelint-plugin-rhythmguard/configs/strict`
-3. Open tracking issue for next version scope.
+```bash
+npm run lint
+npm run typecheck
+npm test
+npm run test:compat-floor
+npm_config_registry=https://registry.npmjs.org npm run test:pack-smoke
+```
+
+All five must exit 0. If your change could move benchmark findings, `npm run bench:quiet -- --check` too.
+
+## 4. Merge and release
+
+Open the PR, merge it, then create the release against the merge commit:
+
+```bash
+gh release create vX.Y.Z --target <merge-sha> --title vX.Y.Z --notes-file notes.md
+```
+
+The notes are the changelog section rewritten for a reader who has not followed the repository, with an upgrade line at the end.
+
+## 5. Verify
+
+- `gh run list --workflow release.yml --limit 1`: all verify jobs and `publish` green.
+- `npm view stylelint-plugin-rhythmguard@X.Y.Z version dist-tags.latest dist.attestations`: the version is `latest` and carries SLSA provenance.
+- The `Post Publish Smoke` workflow, which installs the published package into a clean project, is green.
+
+## 6. If the run fails before publish
+
+Nothing was published, so keep the version number. Fix on `main`, then move the release to the fixed commit:
+
+```bash
+gh release delete vX.Y.Z --yes --cleanup-tag
+gh release create vX.Y.Z --target <new-sha> --title vX.Y.Z --notes-file notes.md
+```
+
+Release-event workflows run the workflow file at the tag, so the tag must point at the fixed commit.
+
+## 7. Afterwards
+
+- Refresh the README banner if the version is drawn on it (`assets/rhythmguard-banner.svg`), bumping the `?v=` cache key on its URL in `README.md` and `docs/index.html`.
+- Add a wiki capture or changelog note for anything a future maintainer would need to know.


### PR DESCRIPTION
A staleness pass over the documents a newcomer reads first.

- README said one runtime dependency (there are two since 3.4.0), described a banner that no longer exists, left the badge format out of the formats list, and advertised the playground without saying it is a simplified re-implementation.
- CONTRIBUTING said the embed shape is frozen for 2.x in a 3.x repository, listed one runtime dependency, omitted `motion` from the stable configs and `build:agents` from the commands, and said nothing about the Node floor that took a release run down this week.
- SECURITY still listed 2.x as the supported line.
- CONFIGS and FOR_CONFIG_AUTHORS said within 2.x.
- RELEASE_CHECKLIST still had `v0.1.0` and validate both configs; rewritten to the flow we run, with the re-cut procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)