### PR TITLE
feat(audit): content-keyed baselines and a since-baseline headline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ## [Unreleased]
 
+### Changed
+
+- Baselines key findings by content (rule, file, property, value, occurrence) instead of line and column, so moving or reformatting code no longer produces matching "new" and "resolved" pairs while a second identical off-scale declaration is still new. Baseline files are `formatVersion: 2`; version 1 files still compare and upgrade on the next `--write-baseline`. Text, Markdown and GitHub output lead with `Since baseline: N resolved, M new`.
+
 ## [3.5.0] - 2026-09-08
 
 ### Fixed

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -122,6 +122,9 @@ A token source object may also carry `tokenPattern`, a regular expression applie
 
 The step-by-step rollout, including a GitHub Actions job and a PR comment, is in [`CI_ADOPTION.md`](./CI_ADOPTION.md).
 
+
+A baseline names each finding by what it is, not where it sits: rule, file, property, value, and its occurrence index among identical findings in that file. Moving code, adding a comment above a declaration or reformatting a file does not turn old findings into "new" and "resolved" pairs; a second identical off-scale declaration is still new. Baseline files carry `formatVersion: 2`; files written by earlier versions (`formatVersion: 1`, keyed by line and column) still compare, with the key they were written with, and are upgraded the next time you run `--write-baseline`. Every output leads with the change since the baseline (`Since baseline: 12 resolved, 0 new`), so a pull request shows what it improved before what it left.
+
 ## JSON 2.0 contract and API
 
 `--format json` emits the stable contract (`schemaVersion: "2.0"`). `--format json-v1` keeps the pre-2.0 shape during migration, see [`MIGRATING_TO_2.md`](./MIGRATING_TO_2.md). `--schema` prints the JSON schema.

--- a/src/audit/baseline.js
+++ b/src/audit/baseline.js
@@ -4,6 +4,16 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { formatPath } = require('./shared');
 
+/**
+ * Baseline keys name a finding by what it is, not where it sits: rule, type,
+ * file, property (or Tailwind class), value, and the occurrence index among
+ * identical findings in that file. Inserting a comment above a declaration no
+ * longer turns it into one "resolved" and one "new"; adding a second identical
+ * off-scale declaration still counts as new. Version 1 baselines keyed by line
+ * and column are still compared with the key they were written with.
+ */
+const BASELINE_FORMAT_VERSION = 2;
+
 function applyBaselineComparison(report, baselinePath) {
   const resolvedPath = path.resolve(process.cwd(), baselinePath);
   if (!fs.existsSync(resolvedPath)) {
@@ -12,11 +22,15 @@ function applyBaselineComparison(report, baselinePath) {
 
   const baseline = JSON.parse(fs.readFileSync(resolvedPath, 'utf8'));
   const baselineFindings = Array.isArray(baseline.findings) ? baseline.findings : [];
-  const baselineKeys = new Set(baselineFindings.map((finding) => finding.key || createFindingKey(finding)));
+  const legacy = baseline.formatVersion !== BASELINE_FORMAT_VERSION;
   const currentFindings = getAllFindings(report);
-  const currentKeys = new Set(currentFindings.map(createFindingKey));
-  const newFindings = currentFindings.filter((finding) => !baselineKeys.has(createFindingKey(finding)));
-  const resolvedFindings = baselineFindings.filter((finding) => !currentKeys.has(finding.key || createFindingKey(finding)));
+  const currentKeys = legacy
+    ? new Map(currentFindings.map((finding) => [finding, createLegacyFindingKey(finding)]))
+    : assignFindingKeys(currentFindings);
+  const baselineKeys = new Set(baselineFindings.map((finding) => finding.key || createLegacyFindingKey(finding)));
+  const currentKeySet = new Set(currentKeys.values());
+  const newFindings = currentFindings.filter((finding) => !baselineKeys.has(currentKeys.get(finding)));
+  const resolvedFindings = baselineFindings.filter((finding) => !currentKeySet.has(finding.key || createLegacyFindingKey(finding)));
 
   report.baseline = {
     baselineFindings: baselineFindings.length,
@@ -31,14 +45,16 @@ function applyBaselineComparison(report, baselinePath) {
 
 function writeBaseline(report, baselinePath) {
   const resolvedPath = path.resolve(process.cwd(), baselinePath);
+  const findings = getAllFindings(report);
+  const keys = assignFindingKeys(findings);
   fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
   fs.writeFileSync(
     resolvedPath,
     `${JSON.stringify({
       createdAt: new Date().toISOString(),
       directory: report.directory,
-      findings: getAllFindings(report).map(toBaselineFinding),
-      formatVersion: 1,
+      findings: findings.map((finding) => toBaselineFinding(finding, keys.get(finding))),
+      formatVersion: BASELINE_FORMAT_VERSION,
       summary: {
         scaleCleanliness: report.scaleCleanliness,
         totalFindings: report.totalWarnings,
@@ -60,12 +76,13 @@ function getAllFindings(report) {
   ];
 }
 
-function toBaselineFinding(finding) {
+function toBaselineFinding(finding, key) {
   return {
     column: finding.column,
     file: finding.file,
-    key: createFindingKey(finding),
+    key,
     line: finding.line,
+    property: finding.property || undefined,
     rule: finding.rule,
     text: finding.text,
     token: finding.token,
@@ -74,7 +91,33 @@ function toBaselineFinding(finding) {
   };
 }
 
-function createFindingKey(finding) {
+function findingIdentity(finding) {
+  return [
+    finding.rule || '',
+    finding.type || '',
+    finding.file || '',
+    finding.property || finding.token || '',
+    finding.value || finding.rawValue || '',
+  ].join('\u001f');
+}
+
+/** Content keys for a set of findings: identity plus the occurrence index in source order. */
+function assignFindingKeys(findings) {
+  const ordered = [...findings].sort((a, b) =>
+    String(a.file).localeCompare(String(b.file)) || (a.line || 0) - (b.line || 0) || (a.column || 0) - (b.column || 0));
+  const seen = new Map();
+  const keys = new Map();
+  for (const finding of ordered) {
+    const identity = findingIdentity(finding);
+    const occurrence = seen.get(identity) || 0;
+    seen.set(identity, occurrence + 1);
+    keys.set(finding, `${identity}\u001f${occurrence}`);
+  }
+  return keys;
+}
+
+/** The version 1 key: position-based, kept so existing baseline files keep working. */
+function createLegacyFindingKey(finding) {
   return [
     finding.rule || '',
     finding.type || '',
@@ -105,10 +148,11 @@ function getAuditFailures(report, parsed) {
 }
 
 module.exports = {
+  BASELINE_FORMAT_VERSION,
   applyBaselineComparison,
-  createFindingKey,
+  assignFindingKeys,
+  createLegacyFindingKey,
   getAllFindings,
   getAuditFailures,
-  toBaselineFinding,
   writeBaseline,
 };

--- a/src/audit/render-github.js
+++ b/src/audit/render-github.js
@@ -4,9 +4,12 @@ const { getAllFindings } = require('./baseline');
 
 function renderGithub(report) {
   const findings = getAllFindings(report);
-  const lines = findings.map((finding) =>
+  const lines = report.baseline
+    ? [`::notice title=Rhythmguard audit::Since baseline: ${report.baseline.resolvedFindingsCount} resolved, ${report.baseline.newFindingsCount} new`]
+    : [];
+  lines.push(...findings.map((finding) =>
     `::warning file=${escapeGithubProperty(finding.file)},line=${finding.line || 1},col=${finding.column || 1},title=${escapeGithubProperty(finding.rule || 'rhythmguard')}::${escapeGithubData(finding.text || '')}`,
-  );
+  ));
   const findingWord = findings.length === 1 ? 'finding' : 'findings';
   const fileWord = report.filesWithIssues === 1 ? 'file' : 'files';
   lines.push(

--- a/src/audit/render-markdown.js
+++ b/src/audit/render-markdown.js
@@ -16,6 +16,7 @@ function renderMarkdown(report) {
   const lines = [
     '# Rhythmguard Design-System Audit',
     '',
+    ...(report.baseline ? [`**Since baseline:** ${report.baseline.resolvedFindingsCount} resolved, ${report.baseline.newFindingsCount} new.`, ''] : []),
     `Directory: \`${report.directory}\``,
     '',
     '## Summary',

--- a/src/audit/render-text.js
+++ b/src/audit/render-text.js
@@ -31,6 +31,9 @@ function renderText(report) {
     const rejected = report.scale.rejected ? ` (${report.scale.rejected.source} rejected: ${report.scale.rejected.reasons.join(', ')})` : '';
     lines.push(`  Scale source             ${report.scale.source}${files}${rejected}`);
   }
+  if (report.baseline) {
+    lines.push(`  Since baseline           ${report.baseline.resolvedFindingsCount} resolved, ${report.baseline.newFindingsCount} new`);
+  }
   lines.push('');
 
   appendHistogram(lines, 'CSS OFF-SCALE VALUES', report.offScaleValues);

--- a/test/cli/audit-cli.test.js
+++ b/test/cli/audit-cli.test.js
@@ -895,3 +895,72 @@ test('audit CLI honours a per-source tokenPattern from the config file for scale
   assert.equal(scale.source, 'token-sources');
   assert.deepEqual(scale.values, [0, 4, 8, 16, 24]);
 });
+
+test('baseline keys survive line shifts and still catch an identical new occurrence', () => {
+  const fixtureDir = createAuditFixture();
+  const cssPath = path.join(fixtureDir, 'src', 'card.css');
+  const baselinePath = path.join(fixtureDir, 'drift.json');
+  assert.equal(runAudit(fixtureDir, '--write-baseline', baselinePath).status, 0);
+  assert.equal(JSON.parse(fs.readFileSync(baselinePath, 'utf8')).formatVersion, 2);
+
+  // Two comment lines at the top move every finding down; nothing changed.
+  fs.writeFileSync(cssPath, `/* header */\n/* header */\n${fs.readFileSync(cssPath, 'utf8')}`);
+  let result = runAudit(fixtureDir, '--since-baseline', baselinePath, '--format', 'json');
+  assert.equal(result.status, 0, result.stderr);
+  let baseline = JSON.parse(result.stdout).baseline;
+  assert.equal(baseline.newFindingsCount, 0, 'a line shift is not new drift');
+  assert.equal(baseline.resolvedFindingsCount, 0, 'a line shift resolves nothing');
+
+  // A second, identical off-scale padding in the same file is new drift.
+  fs.appendFileSync(cssPath, '.card-footer { padding: 13px; }\n');
+  result = runAudit(fixtureDir, '--since-baseline', baselinePath, '--format', 'json');
+  baseline = JSON.parse(result.stdout).baseline;
+  assert.equal(baseline.newFindingsCount, 2, 'an identical second occurrence is new: use-scale and prefer-token each report it');
+  assert.equal(baseline.resolvedFindingsCount, 0);
+});
+
+test('a formatVersion 1 baseline keyed by line still compares', () => {
+  const fixtureDir = createAuditFixture();
+  const baselinePath = path.join(fixtureDir, 'legacy.json');
+  const report = JSON.parse(runAudit(fixtureDir, '--format', 'json-v1').stdout);
+  const legacy = {
+    createdAt: '2026-01-01T00:00:00.000Z',
+    directory: report.directory,
+    formatVersion: 1,
+    findings: [...report.findings.css, ...report.findings.tailwind].map((finding) => ({
+      column: finding.column,
+      file: finding.file,
+      key: [finding.rule || '', finding.type || '', finding.file || '', finding.line || '', finding.column || '', finding.value || finding.rawValue || finding.token || '', finding.text || ''].join('\u001f'),
+      line: finding.line,
+      rule: finding.rule,
+      text: finding.text,
+      token: finding.token,
+      type: finding.type,
+      value: finding.value || finding.rawValue,
+    })),
+  };
+  fs.writeFileSync(baselinePath, JSON.stringify(legacy));
+
+  const result = runAudit(fixtureDir, '--since-baseline', baselinePath, '--format', 'json');
+  assert.equal(result.status, 0, result.stderr);
+  const baseline = JSON.parse(result.stdout).baseline;
+  assert.equal(baseline.newFindingsCount, 0);
+  assert.equal(baseline.resolvedFindingsCount, 0);
+});
+
+test('outputs lead with what changed since the baseline', () => {
+  const fixtureDir = createAuditFixture();
+  const baselinePath = path.join(fixtureDir, 'drift.json');
+  runAudit(fixtureDir, '--write-baseline', baselinePath);
+  // Removing the off-scale padding resolves both findings on it (use-scale and prefer-token).
+  fs.writeFileSync(path.join(fixtureDir, 'src', 'card.css'), '@theme { --spacing-4: 16px; }\n.card { gap: 16px; margin: var(--spacing-missing); }\n');
+
+  const markdown = runAudit(fixtureDir, '--since-baseline', baselinePath, '--format', 'markdown').stdout;
+  assert.match(markdown, /^# Rhythmguard Design-System Audit\n\n\*\*Since baseline:\*\* 2 resolved, 0 new\./m);
+
+  const text = runAudit(fixtureDir, '--since-baseline', baselinePath).stdout;
+  assert.match(text, /Since baseline\s+2 resolved, 0 new/);
+
+  const github = runAudit(fixtureDir, '--since-baseline', baselinePath, '--format', 'github').stdout;
+  assert.match(github.split('\n')[0], /^::notice title=Rhythmguard audit::Since baseline: 2 resolved, 0 new/);
+});


### PR DESCRIPTION
Remediation item 5, and the prerequisite for saying what improved without lying.

- Baseline keys were position-based (line, column, message text), so inserting a comment above a declaration made one "resolved" and one "new" finding of the same drift. Keys are now content-based: rule, type, file, property (or Tailwind class), value, and the occurrence index among identical findings in that file. A line shift changes nothing; a second identical off-scale declaration is still new.
- Baseline files carry `formatVersion: 2`. A version 1 file still compares, using the position key it was written with, and upgrades on the next `--write-baseline`. Test covers both.
- Text, Markdown and GitHub outputs lead with `Since baseline: N resolved, M new`, so a PR annotation shows the improvement first.

Local gate: lint, typecheck, 228 tests, all exit 0. Snapshots key the benchmark differently and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)