### PR TITLE
feat: decisions, the record of what a team decided about each off-scale value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ## [Unreleased]
 
+### Added
+
+- **Decisions.** A `decisions` section in `.rhythmguardrc.json` records what a team decided about each off-scale value: `adopt` (part of the scale, optionally naming the token it should become), `allow` (intentional, optionally on some properties only), `snap` (a slip to fix) or `undecided`. Adopted and allowed values stop being findings in the Stylelint rules and the audit alike; values match by px so `10px` and `0.625rem` are one decision. `rhythmguard audit --plan` proposes the section from the current findings and keeps decisions already made. The audit reports counts in `contracts.decisions`. Rules accept `decisions: false` to ignore the section. Docs: `docs/AUDIT.md#decisions`.
+
 ### Changed
 
 - Baselines key findings by content (rule, file, property, value, occurrence) instead of line and column, so moving or reformatting code no longer produces matching "new" and "resolved" pairs while a second identical off-scale declaration is still new. Baseline files are `formatVersion: 2`; version 1 files still compare and upgrade on the next `--write-baseline`. Text, Markdown and GitHub output lead with `Since baseline: N resolved, M new`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,6 +46,8 @@ The graph has no cycles. `src/index.js` is the only module that imports from eve
 | `core/options.js` | option schemas, defaults, normalisation, per-property scale resolution | a built options object; validation against Stylelint happens in `rules/validate.js` |
 | `core/token-sources.js` | reading tokens from CSS custom properties, Sass variables and maps, flat JSON, Style Dictionary and DTCG files; value normalisation keys | `{ token, value }` entries; definitions keyed by token name |
 | `core/token-map.js` | the effective value-to-token map a rule uses to suggest a token | value key to token name |
+| `core/decisions.js` | the `decisions` section of `.rhythmguardrc.json`: normalisation, matching by px and property scope, cached loading | normalised decisions with a px value |
+| `core/fs-cache.js` | results cached per key and revalidated by the mtime of every file consulted | |
 | `core/scale-inference.js` | `scale: "auto"`: the source order, the plausibility check, package discovery, caches | an inference `{ scale, source, files, rejected? }` |
 | `core/tailwind-class-analysis.js`, `core/tailwind-motion-analysis.js` | reading spacing and motion out of Tailwind class strings | analyses per class segment |
 

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -91,6 +91,36 @@ The value histogram tells you which numbers drifted; the property table tells yo
 
 `drift` (the default) is 100 minus scale cleanliness, the share of scanned files with at least one finding. `--badge-metric findings` reports the number of off-scale CSS values plus Tailwind class-string findings instead, labelled `off-scale values`. Colours: drift 0 to 2% brightgreen, to 5% green, to 15% yellow, above orange; findings 0 brightgreen, to 10 green, to 50 yellow, above orange. Publish the file somewhere public and embed `https://img.shields.io/endpoint?url=<file url>` in the README; the workflow is in [`CI_ADOPTION.md`](./CI_ADOPTION.md#5-show-a-badge).
 
+## Decisions
+
+Real drift is a handful of decisions, not hundreds of mistakes: Mastodon's `10px` appears 165 times and is one missing step or one unnamed token, not 165 slips. The `decisions` section of `.rhythmguardrc.json` records those decisions once, and both the Stylelint rules and the audit honour them.
+
+```bash
+npx rhythmguard audit ./src --plan
+```
+
+prints a proposed section with one entry per off-scale value: how often it occurs, the properties it sits on, the two nearest steps, and `"decision": "undecided"`. Paste it into `.rhythmguardrc.json` and decide:
+
+```json
+{
+  "decisions": [
+    { "value": "10px", "decision": "adopt", "as": "--space-2xs" },
+    { "value": "15px", "decision": "snap" },
+    { "value": "2px", "decision": "allow", "reason": "borders and focus rings", "properties": ["outline-offset", "border-*"] },
+    { "value": "22px", "decision": "undecided" }
+  ]
+}
+```
+
+| Decision | Meaning | Effect |
+| --- | --- | --- |
+| `adopt` | The value is part of the scale; `as` names the token it should become | Stops being a finding in the rules and the audit |
+| `allow` | Intentional and not rhythm | Stops being a finding, on every property or only those in `properties` (`border-*` matches a prefix) |
+| `snap` | A slip to fix | Still a finding; `rhythmguard fix` executes it |
+| `undecided` | Nobody has looked yet | Still a finding; counted so the team sees it |
+
+Values match by px, so `10px` and `0.625rem` are one decision. The audit reports the counts in `contracts.decisions` (`adopt`, `allow`, `snap`, `undecided`, and `suppressed` findings) and in the summary table; `--plan` keeps decisions already made, with their current counts, and adds `undecided` entries for new values. A rule with `decisions: false` ignores the section; the audit sets that on its own Stylelint run so decisions are applied once, in the audit.
+
 ## Config file
 
 Shared settings go in `.rhythmguardrc.json`, loaded automatically when present. `--config <file>` points at another file, `--no-config` skips discovery.

--- a/docs/rules/use-scale.md
+++ b/docs/rules/use-scale.md
@@ -97,6 +97,7 @@ Token values in `rem` and `em` are converted through `baseFontSize`; values in u
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `preset` | `string` | `rhythmic-4` | Selects a built-in scale. See [scale presets](../SCALE_PRESETS.md). |
+| `decisions` | `boolean` | `true` | Read the `decisions` section of `.rhythmguardrc.json`: adopted values count as on scale, allowed values are not findings (optionally on some properties only). See [decisions](../AUDIT.md#decisions). |
 | `customScale` | `Array<number\|string>` | `undefined` | Highest-priority custom scale override |
 | `scale` | `Array<number\|string> \| "auto"` | `[0,4,8,12,16,24,32,40,48,64]` | Allowed values, or `"auto"` to infer them from tokens (see above) |
 | `scaleSources` | `Array<string \| { path, format? }>` | `[]` | Token files consulted first when `scale` is `"auto"` |

--- a/src/audit/args.js
+++ b/src/audit/args.js
@@ -29,6 +29,7 @@ const OPTIONS = [
   { flag: '--json', kind: 'flag', help: 'Alias for --format json', apply: (p) => { p.format = 'json'; } },
   { flag: '--markdown', kind: 'flag', help: 'Alias for --format markdown', apply: (p) => { p.format = 'markdown'; } },
   { flag: '--schema', kind: 'flag', help: 'Print the audit JSON schema and exit', apply: (p) => { p.schema = true; p.format = 'json'; } },
+  { flag: '--plan', kind: 'flag', help: 'Print a proposed decisions section for .rhythmguardrc.json: one entry per off-scale value', apply: (p) => { p.plan = true; } },
   { flag: '--output', kind: 'value', value: '<file>', help: 'Write json, markdown, html or badge output to a file',
     apply: (p, raw) => { p.outputPath = parsePathOption(raw, '--output'); setFrom(p, 'outputPath'); } },
   { flag: '--config', kind: 'value', value: '<file>', help: 'Load audit config (default: .rhythmguardrc.json when present)',

--- a/src/audit/config.js
+++ b/src/audit/config.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { normalizeDecisions } = require('../core/decisions');
 const {
   normalizeTokenKind,
   normalizeTokenSourceFormat,
@@ -58,6 +59,7 @@ function loadAuditConfig(parsed) {
 
   return {
     audit,
+    decisions: config.decisions,
     file: formatPath(resolvedPath),
     rootDir: path.dirname(resolvedPath),
   };
@@ -76,6 +78,7 @@ function applyAuditConfig(parsed, configResult) {
 
   if (!configResult) {
     next.tokenSources = normalizeCliTokenSources(parsed.tokenSources, parsed.tokenSourceFormat);
+    next.decisions = [];
     delete next.cliOptions;
     return next;
   }
@@ -112,6 +115,8 @@ function applyAuditConfig(parsed, configResult) {
     }
     return parseScale(String(value));
   });
+
+  next.decisions = normalizeDecisions(configResult.decisions, { baseFontSize: next.baseFontSize });
 
   delete next.cliOptions;
   return next;

--- a/src/audit/contract.js
+++ b/src/audit/contract.js
@@ -365,6 +365,7 @@ function toAuditContractReport(report) {
       scanScope: report.scanScope.mode,
     },
     contracts: {
+      decisions: report.decisions || null,
       motion: report.motion,
       scale: {
         cleanliness: report.scaleCleanliness,

--- a/src/audit/decisions.js
+++ b/src/audit/decisions.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const { decisionFor } = require('../core/decisions');
+const { formatLength, nearestScaleValues, parseLengthToken, toPx } = require('../core/length');
+
+/**
+ * Decisions applied to audit findings, and the plan that proposes them.
+ * Adopted and allowed values are removed from the findings; snap and undecided
+ * ones stay. The plan lists every off-scale value seen, keeping decisions
+ * already written and adding `undecided` entries for the rest.
+ */
+function findingPx(finding, baseFontSize) {
+  const raw = finding.value || finding.rawValue;
+  const parsed = typeof raw === 'string' ? parseLengthToken(raw.trim()) : null;
+  return parsed ? toPx(Math.abs(parsed.number), parsed.unit || 'px', baseFontSize) : null;
+}
+
+function findingProperty(finding) {
+  return finding.property || (finding.token ? 'class-string' : null);
+}
+
+function applyDecisions({ baseFontSize, cssFindings, decisions, tailwindFindings }) {
+  if (!decisions || decisions.length === 0) {
+    return { cssFindings, suppressed: 0, summary: null, tailwindFindings };
+  }
+  let suppressed = 0;
+  const keep = (finding) => {
+    if (finding.type !== 'off-scale' && !finding.token) {
+      return true;
+    }
+    const px = findingPx(finding, baseFontSize);
+    const decision = px === null ? null : decisionFor(px, findingProperty(finding), decisions);
+    if (decision && (decision.decision === 'adopt' || decision.decision === 'allow')) {
+      suppressed += 1;
+      return false;
+    }
+    return true;
+  };
+  const nextCss = cssFindings.filter(keep);
+  const nextTailwind = tailwindFindings.filter(keep);
+  const summary = { adopt: 0, allow: 0, snap: 0, undecided: 0 };
+  for (const decision of decisions) summary[decision.decision] += 1;
+  return { cssFindings: nextCss, suppressed, summary: { ...summary, suppressed }, tailwindFindings: nextTailwind };
+}
+
+/**
+ * One proposed entry per distinct off-scale px value: the most common spelling,
+ * how often it occurs, the properties it sits on, the two nearest scale steps,
+ * and the decision so far (`undecided` for anything nobody has looked at).
+ */
+function buildDecisionPlan({ baseFontSize, decisions, offScaleFindings, scale }) {
+  const groups = new Map();
+  for (const finding of offScaleFindings) {
+    const px = findingPx(finding, baseFontSize);
+    if (px === null) continue;
+    const key = String(px);
+    const group = groups.get(key) || { count: 0, properties: new Map(), px, spellings: new Map() };
+    group.count += 1;
+    const spelling = (finding.value || finding.rawValue).trim();
+    group.spellings.set(spelling, (group.spellings.get(spelling) || 0) + 1);
+    const property = findingProperty(finding);
+    if (property) group.properties.set(property, (group.properties.get(property) || 0) + 1);
+    groups.set(key, group);
+  }
+
+  const mostCommon = (map) => [...map.entries()].sort((a, b) => b[1] - a[1]).map(([name]) => name);
+  const scalePx = Array.isArray(scale) ? scale.map(Number).filter(Number.isFinite) : [];
+  const nearestFor = (px) => {
+    const nearest = nearestScaleValues(px, scalePx);
+    return nearest ? [formatLength(nearest.lower, 'px'), formatLength(nearest.upper, 'px')] : [];
+  };
+
+  const entries = [];
+  const decided = new Set();
+  for (const decision of decisions || []) {
+    const group = groups.get(String(decision.px));
+    decided.add(String(decision.px));
+    entries.push({
+      value: decision.value,
+      decision: decision.decision,
+      ...(decision.as ? { as: decision.as } : {}),
+      ...(decision.reason ? { reason: decision.reason } : {}),
+      ...(decision.properties ? { properties: decision.properties } : {}),
+      count: group ? group.count : 0,
+      nearest: nearestFor(decision.px),
+    });
+  }
+  for (const [key, group] of groups) {
+    if (decided.has(key)) continue;
+    entries.push({
+      value: mostCommon(group.spellings)[0],
+      decision: 'undecided',
+      count: group.count,
+      properties: mostCommon(group.properties).slice(0, 3),
+      nearest: nearestFor(group.px),
+    });
+  }
+  entries.sort((a, b) => b.count - a.count || String(a.value).localeCompare(String(b.value)));
+  return entries;
+}
+
+module.exports = {
+  applyDecisions,
+  buildDecisionPlan,
+};

--- a/src/audit/render-markdown.js
+++ b/src/audit/render-markdown.js
@@ -37,6 +37,10 @@ function renderMarkdown(report) {
     lines.push(`| Scale source | ${describeScaleSource(report.scale)} |`);
   }
 
+  if (report.decisions) {
+    lines.push(`| Decisions | ${report.decisions.adopt + report.decisions.allow + report.decisions.snap + report.decisions.undecided} (${report.decisions.adopt} adopt, ${report.decisions.allow} allow, ${report.decisions.snap} snap, ${report.decisions.undecided} undecided); ${report.decisions.suppressed} findings suppressed |`);
+  }
+
   if (report.baseline) {
     lines.push(`| New findings | ${report.baseline.newFindingsCount} |`);
     lines.push(`| Resolved findings | ${report.baseline.resolvedFindingsCount} |`);

--- a/src/audit/render-text.js
+++ b/src/audit/render-text.js
@@ -31,6 +31,9 @@ function renderText(report) {
     const rejected = report.scale.rejected ? ` (${report.scale.rejected.source} rejected: ${report.scale.rejected.reasons.join(', ')})` : '';
     lines.push(`  Scale source             ${report.scale.source}${files}${rejected}`);
   }
+  if (report.decisions) {
+    lines.push(`  Decisions                ${report.decisions.adopt + report.decisions.allow + report.decisions.snap + report.decisions.undecided} (${report.decisions.adopt} adopt, ${report.decisions.allow} allow, ${report.decisions.snap} snap, ${report.decisions.undecided} undecided); ${report.decisions.suppressed} findings suppressed`);
+  }
   if (report.baseline) {
     lines.push(`  Since baseline           ${report.baseline.resolvedFindingsCount} resolved, ${report.baseline.newFindingsCount} new`);
   }

--- a/src/audit/report.js
+++ b/src/audit/report.js
@@ -24,6 +24,7 @@ const {
   inferScaleFromDefinitions,
   scaleFromDefinitions,
 } = require('../core/scale-inference');
+const { applyDecisions, buildDecisionPlan } = require('./decisions');
 const { assertDirectory, getScanFiles } = require('./scan/files');
 const { collectCssFindings, runStylelintAudit } = require('./scan/stylesheets');
 const { collectTailwindFindings, collectTailwindMotionFindings } = require('./scan/templates');
@@ -62,7 +63,13 @@ async function createAuditReport(options) {
 
   const cssResults = await runStylelintAudit(cssFiles, lintOptions);
   const stylelintFindings = collectCssFindings(cssResults);
-  const cssFindings = stylelintFindings.filter((finding) => !finding.type.startsWith('motion-'));
+  const decided = applyDecisions({
+    baseFontSize: parsed.baseFontSize,
+    cssFindings: stylelintFindings.filter((finding) => !finding.type.startsWith('motion-')),
+    decisions: parsed.decisions || [],
+    tailwindFindings: collectTailwindFindings(templateFiles, lintOptions),
+  });
+  const cssFindings = decided.cssFindings;
   const motionFindings = [
     ...stylelintFindings.filter((finding) => finding.type.startsWith('motion-')),
     ...collectTailwindMotionFindings(templateFiles, lintOptions),
@@ -81,12 +88,23 @@ async function createAuditReport(options) {
     scanScope,
     scssFiles: cssResults.scssFiles || 0,
     scssSkipped: cssResults.scssSkipped || 0,
-    tailwindFindings: collectTailwindFindings(templateFiles, lintOptions),
+    tailwindFindings: decided.tailwindFindings,
     templateFiles,
     tokenCandidateMinCount: parsed.tokenCandidateMinCount,
     tokenKind: parsed.tokenKind,
     tokenSourceReports: tokenSourceResult.sources,
     tokenSourceWarnings: tokenSourceResult.warnings,
+  });
+
+  report.decisions = decided.summary;
+  report.decisionPlan = buildDecisionPlan({
+    baseFontSize: parsed.baseFontSize,
+    decisions: parsed.decisions || [],
+    offScaleFindings: [
+      ...stylelintFindings.filter((finding) => finding.type === 'off-scale'),
+      ...collectTailwindFindings(templateFiles, lintOptions),
+    ],
+    scale: scale.values,
   });
 
   if (parsed.sinceBaseline) {

--- a/src/audit/scan/stylesheets.js
+++ b/src/audit/scan/stylesheets.js
@@ -45,6 +45,7 @@ async function runStylelintAudit(cssFiles, options) {
     'rhythmguard/use-scale': [
       true,
       {
+        decisions: false,
         baseFontSize: options.baseFontSize,
         scale: options.scale,
         severity: 'warning',

--- a/src/audit/shared.js
+++ b/src/audit/shared.js
@@ -70,6 +70,8 @@ function createDefaultAuditOptions() {
     dir: null,
     failOnNewDrift: false,
     badgeMetric: 'drift',
+    decisions: [],
+    plan: false,
     format: 'text',
     ignorePath: DEFAULT_IGNORE_PATH,
     ignorePatterns: [],

--- a/src/cli/audit.js
+++ b/src/cli/audit.js
@@ -48,6 +48,11 @@ async function run() {
     process.exit(1);
   }
 
+  if (parsed.plan) {
+    writeOutput(`${JSON.stringify({ decisions: report.decisionPlan }, null, 2)}\n`, parsed.outputPath);
+    return;
+  }
+
   const auditFailures = getAuditFailures(report, parsed);
 
   if (parsed.format === 'json') {

--- a/src/core/decisions.js
+++ b/src/core/decisions.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { cachedByFiles } = require('./fs-cache');
+const { numbersEqual, parseLengthToken, toPx } = require('./length');
+
+/**
+ * The `decisions` section of .rhythmguardrc.json records what a team decided
+ * about each off-scale value the audit found:
+ *
+ *   adopt      the value is part of the scale (optionally naming the token it
+ *              should become); it stops being a finding everywhere
+ *   allow      the value is intentional and not rhythm (borders, focus rings);
+ *              not a finding, optionally only on some properties
+ *   snap       the value is a slip; still a finding, and `rhythmguard fix`
+ *              can execute it
+ *   undecided  recorded, still a finding, counted so the team sees it
+ *
+ * Decisions are matched by px value, so `10px` and `0.625rem` are one
+ * decision. The Stylelint rules and the audit read the same file, so a
+ * decision made once holds in the editor, in CI and in the report.
+ */
+const RC_FILE = '.rhythmguardrc.json';
+const DECISIONS = new Set(['adopt', 'allow', 'snap', 'undecided']);
+
+function normalizeDecisions(raw, { baseFontSize = 16 } = {}) {
+  if (raw === undefined || raw === null) {
+    return [];
+  }
+  if (!Array.isArray(raw)) {
+    throw new Error('Invalid Rhythmguard config: decisions must be an array.');
+  }
+  return raw.map((entry, index) => normalizeDecision(entry, index, baseFontSize));
+}
+
+function normalizeDecision(entry, index, baseFontSize) {
+  const where = `decisions[${index}]`;
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    throw new Error(`Invalid Rhythmguard config: ${where} must be an object.`);
+  }
+  const parsed = typeof entry.value === 'string' ? parseLengthToken(entry.value.trim()) : null;
+  const px = parsed ? toPx(Math.abs(parsed.number), parsed.unit || 'px', baseFontSize) : null;
+  if (px === null || !Number.isFinite(px)) {
+    throw new Error(`Invalid Rhythmguard config: ${where}.value must be a CSS length such as "10px" or "0.75rem".`);
+  }
+  if (!DECISIONS.has(entry.decision)) {
+    throw new Error(`Invalid Rhythmguard config: ${where}.decision must be one of ${Array.from(DECISIONS).join(', ')}.`);
+  }
+  if (entry.properties !== undefined && (!Array.isArray(entry.properties) || !entry.properties.every((p) => typeof p === 'string' && p.trim()))) {
+    throw new Error(`Invalid Rhythmguard config: ${where}.properties must be an array of property names or patterns such as "border-*".`);
+  }
+  if (entry.as !== undefined && (typeof entry.as !== 'string' || !/^(?:--|\$)[\w-]+$/.test(entry.as))) {
+    throw new Error(`Invalid Rhythmguard config: ${where}.as must be a custom property or Sass variable name such as "--space-2".`);
+  }
+  if (entry.reason !== undefined && typeof entry.reason !== 'string') {
+    throw new Error(`Invalid Rhythmguard config: ${where}.reason must be a string.`);
+  }
+  return {
+    as: entry.as || null,
+    decision: entry.decision,
+    properties: entry.properties ? entry.properties.map((p) => p.trim().toLowerCase()) : null,
+    px,
+    reason: entry.reason || null,
+    value: entry.value.trim(),
+  };
+}
+
+function propertyMatchesPattern(prop, pattern) {
+  if (pattern.endsWith('*')) {
+    return prop.startsWith(pattern.slice(0, -1));
+  }
+  return prop === pattern;
+}
+
+/** The decision that applies to a value (in px) on a property, or null. */
+function decisionFor(px, prop, decisions) {
+  if (!decisions || decisions.length === 0) {
+    return null;
+  }
+  const normalizedProp = String(prop || '').toLowerCase();
+  for (const decision of decisions) {
+    if (!numbersEqual(decision.px, Math.abs(px))) {
+      continue;
+    }
+    if (decision.properties && !decision.properties.some((pattern) => propertyMatchesPattern(normalizedProp, pattern))) {
+      continue;
+    }
+    return decision;
+  }
+  return null;
+}
+
+/** Decisions from the .rhythmguardrc.json in cwd, cached and revalidated by mtime. Invalid entries throw. */
+function loadRcDecisions(cwd = process.cwd(), { baseFontSize = 16 } = {}) {
+  const rcPath = path.join(cwd, RC_FILE);
+  return cachedByFiles(`decisions:${rcPath}:${baseFontSize}`, (consult) => {
+    consult(rcPath);
+    if (!fs.existsSync(rcPath)) {
+      return [];
+    }
+    let config;
+    try {
+      config = JSON.parse(fs.readFileSync(rcPath, 'utf8'));
+    } catch {
+      return [];
+    }
+    return normalizeDecisions(config && typeof config === 'object' ? config.decisions : undefined, { baseFontSize });
+  });
+}
+
+module.exports = {
+  DECISIONS,
+  decisionFor,
+  loadRcDecisions,
+  normalizeDecisions,
+};

--- a/src/core/fs-cache.js
+++ b/src/core/fs-cache.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const fs = require('node:fs');
+
+/**
+ * Editors and pre-commit hooks lint one file at a time, and each lint asks the
+ * filesystem the same questions: which package.json files sit between cwd and
+ * the repository, what .rhythmguardrc.json says, whether a token package is
+ * installed. The answers change only when one of those files changes, so a
+ * result is cached per key and revalidated by the mtime of every file the
+ * computation consulted: a stat per file instead of a read, a parse and a walk.
+ */
+const cache = new Map();
+
+function fileStamp(file) {
+  try {
+    return fs.statSync(file).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function cachedByFiles(cacheKey, compute) {
+  const cached = cache.get(cacheKey);
+  if (cached && cached.stamps.every(([file, stamp]) => fileStamp(file) === stamp)) {
+    return cached.value;
+  }
+  const consulted = [];
+  const value = compute((file) => consulted.push([file, fileStamp(file)]));
+  cache.set(cacheKey, { stamps: consulted, value });
+  return value;
+}
+
+module.exports = {
+  cachedByFiles,
+};

--- a/src/core/options.js
+++ b/src/core/options.js
@@ -359,6 +359,9 @@ function resolveUnits(options) {
 }
 
 const SCALE_VALIDATION_SCHEMA = Object.freeze({
+  decisions: Object.freeze({
+    entryValidator: isBoolean,
+  }),
   allowHairlines: Object.freeze({
     entryValidator: isBoolean,
   }),
@@ -545,6 +548,7 @@ function buildScaleOptions(rawOptions) {
 
   return {
     allowHairlines: options.allowHairlines !== false,
+    readDecisions: options.decisions !== false,
     allowNegative: options.allowNegative !== false,
     allowPercentages: options.allowPercentages !== false,
     baseFontSize:

--- a/src/core/scale-inference.js
+++ b/src/core/scale-inference.js
@@ -26,6 +26,8 @@ const FALLBACK_PRESET = 'rhythmic-4';
 const MIN_INFERRED_SCALE_LENGTH = 4;
 const RC_FILE = '.rhythmguardrc.json';
 
+const { cachedByFiles } = require('./fs-cache');
+
 const sourceCache = new Map();
 const TOKEN_PACKAGES = require('./token-packages.json').packages;
 
@@ -53,35 +55,6 @@ function readDirectDependencies(dir) {
  * installs are found by walking up; a stray global node_modules is never
  * consulted because the walk stops at the repository.
  */
-/**
- * Editors and pre-commit hooks lint one file at a time, and each lint asked
- * the filesystem the same questions: which package.json files sit between
- * cwd and the repository, what they declare, and whether a token package is
- * installed. The answers change only when one of those files changes, so
- * the result is cached per cwd and revalidated by mtime, which costs a stat
- * per file instead of a read, a JSON parse and a directory walk.
- */
-const discoveryCache = new Map();
-
-function fileStamp(file) {
-  try {
-    return fs.statSync(file).mtimeMs;
-  } catch {
-    return null;
-  }
-}
-
-function cachedByFiles(cacheKey, compute) {
-  const cached = discoveryCache.get(cacheKey);
-  if (cached && cached.stamps.every(([file, stamp]) => fileStamp(file) === stamp)) {
-    return cached.value;
-  }
-  const consulted = [];
-  const value = compute((file) => consulted.push([file, fileStamp(file)]));
-  discoveryCache.set(cacheKey, { stamps: consulted, value });
-  return value;
-}
-
 function projectRoots(cwd, consult = () => {}) {
   const roots = [];
   let current = path.resolve(cwd);

--- a/src/rules/no-offscale-transform/index.js
+++ b/src/rules/no-offscale-transform/index.js
@@ -28,7 +28,8 @@ const {
 
 const { validatePrimary, validateNoOffscaleTransformSecondaryOptions } = require('../validate');
 
-const { reportInvalidPreset, reportValueNode } = require('../report');
+const { reportInvalidPreset, reportProblem, reportValueNode } = require('../report');
+const { decisionFor, loadRcDecisions } = require('../../core/decisions');
 
 const ruleName = 'rhythmguard/no-offscale-transform';
 const messages = stylelint.utils.ruleMessages(ruleName, {
@@ -57,6 +58,12 @@ const ruleFunction = (primary, secondaryOptions) => {
 
     const options = buildScaleOptions(secondaryOptions);
     reportInvalidPreset(options, { message: messages.invalidPreset, result, root, ruleName });
+    try {
+      options.decisions = options.readDecisions ? loadRcDecisions(process.cwd(), { baseFontSize: options.baseFontSize }) : [];
+    } catch (error) {
+      reportProblem(error.message, { result, root, ruleName });
+      options.decisions = [];
+    }
 
     withResolvedScale(options, root);
 
@@ -114,6 +121,12 @@ const ruleFunction = (primary, secondaryOptions) => {
           parsedLength.unit !== '%' &&
           !options.units.includes(parsedLength.unit)
         ) {
+          return;
+        }
+
+        const decidedPx = toPx(Math.abs(parsedLength.number), parsedLength.unit, options.baseFontSize);
+        const decision = decidedPx === null ? null : decisionFor(decidedPx, prop, options.decisions);
+        if (decision && (decision.decision === 'adopt' || decision.decision === 'allow')) {
           return;
         }
 

--- a/src/rules/report.js
+++ b/src/rules/report.js
@@ -68,8 +68,14 @@ function reportInvalidPreset(options, { message, result, root, ruleName }) {
   });
 }
 
+/** A configuration problem that is not about one node: reported once, on the root. */
+function reportProblem(message, { result, root, ruleName }) {
+  stylelint.utils.report({ message, node: root, result, ruleName });
+}
+
 module.exports = {
   createTokenRegex,
   reportInvalidPreset,
+  reportProblem,
   reportValueNode,
 };

--- a/src/rules/use-scale/index.js
+++ b/src/rules/use-scale/index.js
@@ -30,7 +30,8 @@ const {
   withResolvedScale,
 } = require('../../core/scale-inference');
 
-const { createTokenRegex, reportInvalidPreset, reportValueNode } = require('../report');
+const { createTokenRegex, reportInvalidPreset, reportProblem, reportValueNode } = require('../report');
+const { decisionFor, loadRcDecisions } = require('../../core/decisions');
 const { validatePrimary, validateUseScaleSecondaryOptions } = require('../validate');
 
 const ruleName = 'rhythmguard/use-scale';
@@ -41,6 +42,19 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
   rejected: (value, lower, upper, note = '') =>
     `Unexpected off-scale value "${value}". Use scale values (nearest: ${lower} or ${upper}).${note ? ` ${note}` : ''}`,
 });
+
+/** Decisions from .rhythmguardrc.json; an invalid section is reported once and ignored. */
+function readDecisions(options, { result, root }) {
+  if (!options.readDecisions) {
+    return [];
+  }
+  try {
+    return loadRcDecisions(process.cwd(), { baseFontSize: options.baseFontSize });
+  } catch (error) {
+    reportProblem(error.message, { result, root, ruleName });
+    return [];
+  }
+}
 
 function checkLengthValue({
   decl,
@@ -87,6 +101,12 @@ function checkLengthValue({
     parsedLength.unit !== '%' &&
     !options.units.includes(parsedLength.unit)
   ) {
+    return false;
+  }
+
+  const decidedPx = toPx(Math.abs(parsedLength.number), parsedLength.unit, options.baseFontSize);
+  const decision = decidedPx === null ? null : decisionFor(decidedPx, decl.prop, options.decisions);
+  if (decision && (decision.decision === 'adopt' || decision.decision === 'allow')) {
     return false;
   }
 
@@ -160,6 +180,7 @@ const ruleFunction = (primary, secondaryOptions) => {
 
     const options = buildScaleOptions(secondaryOptions);
     reportInvalidPreset(options, { message: messages.invalidPreset, result, root, ruleName });
+    options.decisions = readDecisions(options, { result, root });
 
     withResolvedScale(options, root);
 

--- a/test/cli/audit-cli.test.js
+++ b/test/cli/audit-cli.test.js
@@ -964,3 +964,61 @@ test('outputs lead with what changed since the baseline', () => {
   const github = runAudit(fixtureDir, '--since-baseline', baselinePath, '--format', 'github').stdout;
   assert.match(github.split('\n')[0], /^::notice title=Rhythmguard audit::Since baseline: 2 resolved, 0 new/);
 });
+
+test('audit --plan proposes one decision per off-scale value, keeping decisions already made', () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-audit-plan-'));
+  fs.mkdirSync(path.join(fixtureDir, 'src'));
+  fs.writeFileSync(path.join(fixtureDir, 'src', 'a.css'), '.a { margin: 10px; padding: 10px 15px; } .b { margin-bottom: 0.625rem; outline-offset: 2px; }\n');
+  fs.writeFileSync(path.join(fixtureDir, '.rhythmguardrc.json'), JSON.stringify({ decisions: [{ value: '2px', decision: 'allow', reason: 'focus rings', properties: ['outline-offset'] }] }));
+
+  const result = runAuditCommand(fixtureDir, 'src', '--plan');
+  assert.equal(result.status, 0, result.stderr);
+  const plan = JSON.parse(result.stdout);
+  assert.deepEqual(Object.keys(plan), ['decisions']);
+  const byValue = Object.fromEntries(plan.decisions.map((entry) => [entry.value, entry]));
+  assert.equal(byValue['10px'].decision, 'undecided');
+  assert.equal(byValue['10px'].count, 3, '10px and 0.625rem are one decision');
+  assert.deepEqual(byValue['10px'].nearest, ['8px', '12px']);
+  assert.deepEqual(byValue['10px'].properties, ['margin', 'padding', 'margin-bottom']);
+  assert.equal(byValue['15px'].count, 1);
+  assert.equal(byValue['2px'].decision, 'allow', 'an existing decision is kept as written');
+  assert.equal(byValue['2px'].reason, 'focus rings');
+  assert.equal(plan.decisions.length, 3);
+});
+
+test('audit applies decisions: adopted and allowed values stop being findings, undecided ones are counted', () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-audit-decisions-'));
+  fs.mkdirSync(path.join(fixtureDir, 'src'));
+  fs.writeFileSync(path.join(fixtureDir, 'src', 'a.css'), '.a { margin: 10px; padding: 15px; gap: 2px; padding-top: 2px; inset: 22px; }\n');
+  fs.writeFileSync(path.join(fixtureDir, 'src', 'B.tsx'), 'export const B = <div className="p-[10px] m-[22px]" />;\n');
+  fs.writeFileSync(path.join(fixtureDir, '.rhythmguardrc.json'), JSON.stringify({
+    decisions: [
+      { value: '10px', decision: 'adopt' },
+      { value: '2px', decision: 'allow', properties: ['gap'] },
+      { value: '15px', decision: 'snap' },
+      { value: '22px', decision: 'undecided' },
+    ],
+  }));
+
+  const result = runAuditCommand(fixtureDir, 'src', '--format', 'json');
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  const offScale = report.findings.css.filter((finding) => finding.type === 'off-scale').map((finding) => `${finding.property}:${finding.value}`).sort();
+  assert.deepEqual(offScale, ['inset:22px', 'padding-top:2px', 'padding:15px'], 'adopted 10px and the gap-scoped 2px are gone; padding-top: 2px stays');
+  assert.deepEqual(report.findings.tailwind.map((finding) => finding.token), ['m-[22px]'], 'the adopted value is gone from class strings too');
+  assert.deepEqual(report.contracts.decisions, { adopt: 1, allow: 1, snap: 1, undecided: 1, suppressed: 3 });
+
+  const markdown = runAuditCommand(fixtureDir, 'src', '--format', 'markdown').stdout;
+  assert.match(markdown, /\| Decisions \| 4 \(1 adopt, 1 allow, 1 snap, 1 undecided\); 3 findings suppressed \|/);
+});
+
+test('audit refuses an invalid decisions section with a precise message', () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-audit-decisions-bad-'));
+  fs.mkdirSync(path.join(fixtureDir, 'src'));
+  fs.writeFileSync(path.join(fixtureDir, 'src', 'a.css'), '.a { margin: 10px; }\n');
+  fs.writeFileSync(path.join(fixtureDir, '.rhythmguardrc.json'), JSON.stringify({ decisions: [{ value: '10px', decision: 'maybe' }] }));
+
+  const result = runAuditCommand(fixtureDir, 'src', '--format', 'json');
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /decisions\[0\]\.decision must be one of adopt, allow, snap, undecided/);
+});

--- a/test/rules/scale-auto.test.js
+++ b/test/rules/scale-auto.test.js
@@ -426,3 +426,32 @@ test('scale "auto" uses component-level tokens when the root does not define a s
   assert.match(texts[0], /"13px".*nearest: 12px or 16px/);
   assert.doesNotMatch(texts[0], /using preset/);
 });
+
+test('rules honour decisions from .rhythmguardrc.json: adopt joins the scale, allow is scoped by property, snap still reports', async () => {
+  const dir = tempDir('decisions');
+  fs.writeFileSync(path.join(dir, '.rhythmguardrc.json'), JSON.stringify({
+    decisions: [
+      { value: '10px', decision: 'adopt', as: '--space-2xs' },
+      { value: '2px', decision: 'allow', reason: 'borders', properties: ['outline-offset', 'border-*'] },
+      { value: '15px', decision: 'snap' },
+    ],
+  }));
+
+  const previousCwd = process.cwd();
+  process.chdir(dir);
+  let result;
+  try {
+    result = await lintCss({
+      code: '.a { margin: 10px; padding: 0.625rem; outline-offset: 2px; gap: 2px; inset: 15px; }',
+      rules: { 'rhythmguard/use-scale': [true, { scale: [0, 4, 8, 12, 16, 24], properties: ['margin', 'padding', 'gap', 'inset', 'outline-offset'] }] },
+    });
+  } finally {
+    process.chdir(previousCwd);
+  }
+
+  assert.deepEqual(result.invalidOptionWarnings, []);
+  const texts = result.warnings.map((w) => w.text);
+  assert.equal(texts.length, 2, texts.join('\n'));
+  assert.match(texts[0], /"2px"/, 'gap: 2px is outside the allow scope');
+  assert.match(texts[1], /"15px"/, 'a snap decision is still reported');
+});

--- a/test/unit/decisions.test.js
+++ b/test/unit/decisions.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * The decisions section of .rhythmguardrc.json: one entry per off-scale value a
+ * team has looked at. `adopt` makes the value part of the scale, `allow` stops
+ * it being a finding (optionally on some properties only), `snap` records that
+ * it is a slip to fix, `undecided` records that nobody has decided yet.
+ */
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { decisionFor, normalizeDecisions } = require('../../src/core/decisions');
+
+test('normalizeDecisions parses values to px and keeps the fields the rules need', () => {
+  const decisions = normalizeDecisions([
+    { value: '10px', decision: 'adopt', as: '--space-2xs' },
+    { value: '0.9375rem', decision: 'snap' },
+    { value: '2px', decision: 'allow', reason: 'borders and focus rings', properties: ['outline-offset', 'border-*'] },
+    { value: '22px', decision: 'undecided', count: 3, nearest: ['20px', '24px'] },
+  ], { baseFontSize: 16 });
+
+  assert.deepEqual(decisions.map((entry) => [entry.px, entry.decision]), [[10, 'adopt'], [15, 'snap'], [2, 'allow'], [22, 'undecided']]);
+  assert.equal(decisions[0].as, '--space-2xs');
+  assert.deepEqual(decisions[2].properties, ['outline-offset', 'border-*']);
+  assert.equal(decisions[2].reason, 'borders and focus rings');
+});
+
+test('normalizeDecisions refuses what it cannot act on, naming the entry', () => {
+  assert.throws(() => normalizeDecisions([{ value: 'lots', decision: 'snap' }]), /decisions\[0\]\.value must be a CSS length/);
+  assert.throws(() => normalizeDecisions([{ value: '10px', decision: 'maybe' }]), /decisions\[0\]\.decision must be one of adopt, allow, snap, undecided/);
+  assert.throws(() => normalizeDecisions([{ value: '10px', decision: 'allow', properties: 'border' }]), /decisions\[0\]\.properties must be an array of property names or patterns/);
+  assert.throws(() => normalizeDecisions([{ value: '10px', decision: 'adopt', as: 'space-2xs' }]), /decisions\[0\]\.as must be a custom property or Sass variable name/);
+  assert.throws(() => normalizeDecisions({ value: '10px' }), /decisions must be an array/);
+});
+
+test('decisionFor matches by px value and by property scope', () => {
+  const decisions = normalizeDecisions([
+    { value: '10px', decision: 'adopt' },
+    { value: '2px', decision: 'allow', properties: ['outline-offset', 'border-*'] },
+    { value: '15px', decision: 'snap' },
+  ], { baseFontSize: 16 });
+
+  assert.equal(decisionFor(10, 'margin', decisions).decision, 'adopt');
+  assert.equal(decisionFor(0.625 * 16, 'padding', decisions).decision, 'adopt', 'rem values match through px');
+  assert.equal(decisionFor(2, 'outline-offset', decisions).decision, 'allow');
+  assert.equal(decisionFor(2, 'border-top-width', decisions).decision, 'allow', 'a trailing * matches a property prefix');
+  assert.equal(decisionFor(2, 'padding', decisions), null, 'an allow scoped to properties does not cover others');
+  assert.equal(decisionFor(15, 'padding', decisions).decision, 'snap');
+  assert.equal(decisionFor(13, 'padding', decisions), null);
+});

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -98,6 +98,33 @@ export interface AuditBaselineComparison {
 
 export type AuditScaleSource = "default" | "explicit" | "fallback" | "scanned-css" | "token-package" | "token-sources";
 
+export type AuditDecisionKind = "adopt" | "allow" | "snap" | "undecided";
+
+/** One entry of the `decisions` section of `.rhythmguardrc.json`. */
+export interface AuditDecision {
+  value: string;
+  decision: AuditDecisionKind;
+  /** For `adopt`: the token the value should become. */
+  as?: string;
+  /** For `allow`: property names or `prefix-*` patterns the allowance is limited to. */
+  properties?: string[];
+  reason?: string;
+}
+
+export interface AuditDecisionSummary {
+  adopt: number;
+  allow: number;
+  snap: number;
+  undecided: number;
+  suppressed: number;
+}
+
+/** One line of `rhythmguard audit --plan`: a decision entry with what the audit saw. */
+export interface AuditDecisionPlanEntry extends AuditDecision {
+  count: number;
+  nearest: string[];
+}
+
 export interface AuditScaleRejected {
   files?: string[];
   /** Why the inferred set was not accepted as a scale, for example "no common step". */
@@ -117,6 +144,8 @@ export interface AuditScale {
 }
 
 export interface AuditReport {
+  decisions?: AuditDecisionSummary | null;
+  decisionPlan?: AuditDecisionPlanEntry[];
   baseline?: AuditBaselineComparison | null;
   scale?: AuditScale | null;
   config?: string | null;
@@ -143,6 +172,8 @@ export interface AuditContractReport {
     scanScope: string;
   };
   contracts: {
+    /** Counts per decision kind and how many findings the decisions suppressed; null when the config has no decisions. */
+    decisions: AuditDecisionSummary | null;
     motion?: unknown;
     scale: {
       cleanliness?: unknown;

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -17,6 +17,8 @@ export interface ScaleSource {
 export interface RhythmguardRuleOptions {
   /** Exempt non-zero lengths of one CSS pixel or less (1px, -1px, 0.5px, 0.0625rem). Default true. */
   allowHairlines?: boolean;
+  /** Read the `decisions` section of `.rhythmguardrc.json` (default true). The audit sets false and applies decisions itself. */
+  decisions?: boolean;
   baseFontSize?: number;
   customScale?: ScaleValue[];
   includeMathFunctions?: boolean;


### PR DESCRIPTION
Remediation item 1, the product idea the others attach to.

Real drift is a handful of decisions, not hundreds of mistakes. The `decisions` section of `.rhythmguardrc.json` records them once:

```json
{ "decisions": [
  { "value": "10px", "decision": "adopt", "as": "--space-2xs" },
  { "value": "2px", "decision": "allow", "reason": "borders", "properties": ["border-*"] },
  { "value": "15px", "decision": "snap" }
] }
```

- **One core module** (`core/decisions.js`) normalises entries (px-matched, property scope with `prefix-*`, precise errors naming the entry) and answers "what is the decision for this value on this property". The rules and the audit both call it.
- **Rules:** adopted and allowed values stop being findings in `use-scale` and `no-offscale-transform`. A rule with `decisions: false` ignores the section; the audit sets that on its own Stylelint run so decisions are applied exactly once, in the audit, where they can be counted.
- **Audit:** `--plan` prints a proposed section from the current findings (spelling, count, properties, nearest steps, `undecided`), keeping decisions already made with their current counts. `contracts.decisions` reports adopt/allow/snap/undecided and the number of suppressed findings; the summary table and text output show it.
- **Cache:** the mtime-validated cache moved to `core/fs-cache.js` so the rc file is read once per process per cwd and revalidated by stat.
- Types, rule docs, a Decisions section in `docs/AUDIT.md`, architecture table rows, changelog.

Gate: lint, typecheck, 235 tests; benchmark check zero moved findings (no benchmark repo has a decisions section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)