### PR TITLE
feat(rules): fixWith: "token", and negative tokens that are valid CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ The format follows Keep a Changelog principles and semantic versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- `prefer-token` autofix writes a negative token as `calc(-1 * var(--token))`. It wrote `-var(--token)`, which is not valid CSS.
+
 ### Added
 
+- `use-scale` and `no-offscale-transform` accept `fixWith: "token"`: autofix writes `var(--name)` when exactly one custom property holds the snapped value in the literal's own unit, read from the stylesheet, `scaleSources`, the config file's token sources and installed token packages, and the literal otherwise. A rem literal never becomes a px token, and two tokens with the same value never become a guess. Default stays `"value"`; the default flips in 4.0.
 - **Decisions.** A `decisions` section in `.rhythmguardrc.json` records what a team decided about each off-scale value: `adopt` (part of the scale, optionally naming the token it should become), `allow` (intentional, optionally on some properties only), `snap` (a slip to fix) or `undecided`. Adopted and allowed values stop being findings in the Stylelint rules and the audit alike; values match by px so `10px` and `0.625rem` are one decision. `rhythmguard audit --plan` proposes the section from the current findings and keeps decisions already made. The audit reports counts in `contracts.decisions`. Rules accept `decisions: false` to ignore the section. Docs: `docs/AUDIT.md#decisions`.
 
 ### Changed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,6 +46,7 @@ The graph has no cycles. `src/index.js` is the only module that imports from eve
 | `core/options.js` | option schemas, defaults, normalisation, per-property scale resolution | a built options object; validation against Stylelint happens in `rules/validate.js` |
 | `core/token-sources.js` | reading tokens from CSS custom properties, Sass variables and maps, flat JSON, Style Dictionary and DTCG files; value normalisation keys | `{ token, value }` entries; definitions keyed by token name |
 | `core/token-map.js` | the effective value-to-token map a rule uses to suggest a token | value key to token name |
+| `core/token-index.js` | which token a fix may write for a length: same px, same unit, one candidate, custom properties only; negation that stays valid CSS | `var(--name)` or null |
 | `core/decisions.js` | the `decisions` section of `.rhythmguardrc.json`: normalisation, matching by px and property scope, cached loading | normalised decisions with a px value |
 | `core/fs-cache.js` | results cached per key and revalidated by the mtime of every file consulted | |
 | `core/scale-inference.js` | `scale: "auto"`: the source order, the plausibility check, package discovery, caches | an inference `{ scale, source, files, rejected? }` |

--- a/docs/rules/prefer-token.md
+++ b/docs/rules/prefer-token.md
@@ -79,6 +79,8 @@ W3C DTCG:
 
 Nested DTCG groups are walked recursively and the key path becomes the variable name, so `spacing.4` maps to `var(--spacing-4)`. Non-length values such as colors and fonts are ignored.
 
+Negative literals are replaced with `calc(-1 * var(--token))`, which is valid CSS; `-var()` is not.
+
 ## Options
 
 | Option | Type | Default | Description |

--- a/docs/rules/use-scale.md
+++ b/docs/rules/use-scale.md
@@ -97,6 +97,7 @@ Token values in `rem` and `em` are converted through `baseFontSize`; values in u
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `preset` | `string` | `rhythmic-4` | Selects a built-in scale. See [scale presets](../SCALE_PRESETS.md). |
+| `fixWith` | `"value" \| "token"` | `"value"` | What autofix writes. `"token"` writes `var(--name)` when exactly one custom property holds the snapped value in the literal's own unit, read from this stylesheet, `scaleSources`, `.rhythmguardrc.json` token sources and installed token packages; otherwise the literal. Negative values become `calc(-1 * var(--name))`. |
 | `decisions` | `boolean` | `true` | Read the `decisions` section of `.rhythmguardrc.json`: adopted values count as on scale, allowed values are not findings (optionally on some properties only). See [decisions](../AUDIT.md#decisions). |
 | `customScale` | `Array<number\|string>` | `undefined` | Highest-priority custom scale override |
 | `scale` | `Array<number\|string> \| "auto"` | `[0,4,8,12,16,24,32,40,48,64]` | Allowed values, or `"auto"` to infer them from tokens (see above) |

--- a/src/core/options.js
+++ b/src/core/options.js
@@ -62,6 +62,10 @@ function isSupportedUnit(value) {
   return SUPPORTED_SCALE_UNITS.has(value.trim().toLowerCase());
 }
 
+function isFixWith(value) {
+  return value === 'value' || value === 'token';
+}
+
 function isUnitStrategy(value) {
   return value === 'convert' || value === 'exact';
 }
@@ -381,6 +385,9 @@ const SCALE_VALIDATION_SCHEMA = Object.freeze({
   enforceInsideMathFunctions: Object.freeze({
     entryValidator: isBoolean,
   }),
+  fixWith: Object.freeze({
+    entryValidator: isFixWith,
+  }),
   fixToScale: Object.freeze({
     entryValidator: isBoolean,
   }),
@@ -559,6 +566,7 @@ function buildScaleOptions(rawOptions) {
         : 16,
     enforceInsideMathFunctions: options.enforceInsideMathFunctions === true,
     fixToScale: options.fixToScale !== false,
+    fixWith: options.fixWith === 'token' ? 'token' : 'value',
     ignoreMathFunctionArguments: normalizeMathFunctionArgumentMap(options.ignoreMathFunctionArguments),
     ignoreValues: Array.isArray(options.ignoreValues)
       ? options.ignoreValues.map((value) => String(value).toLowerCase())

--- a/src/core/scale-inference.js
+++ b/src/core/scale-inference.js
@@ -165,21 +165,27 @@ function cacheKey(sources) {
     .join('\n');
 }
 
-function scaleFromSources(sources, baseFontSize) {
+/** Parse token sources once per (sources, base font size, file mtimes). */
+function parseSourcesCached(sources, baseFontSize) {
   const normalized = sources.map((source) => normalizeSource(source, process.cwd())).filter(Boolean);
   if (normalized.length === 0) {
     return null;
   }
-
   const key = `${baseFontSize}\n${cacheKey(normalized)}`;
-  if (sourceCache.has(key)) {
-    return sourceCache.get(key);
+  if (!sourceCache.has(key)) {
+    sourceCache.set(key, parseTokenSources({ baseFontSize, sources: normalized, tokenKind: 'spacing' }));
   }
+  return sourceCache.get(key);
+}
 
-  const parsed = parseTokenSources({ baseFontSize, sources: normalized, tokenKind: 'spacing' });
+function scaleFromSources(sources, baseFontSize) {
+  const parsed = parseSourcesCached(sources, baseFontSize);
+  if (!parsed) {
+    return null;
+  }
   // scaleFromDefinitions also expands a bare Tailwind --spacing base into its multiples.
   const scale = scaleFromDefinitions(parsed.definitions, baseFontSize);
-  const outcome = scale
+  return scale
     ? {
       files: parsed.sources.map((source) => source.file),
       scale,
@@ -187,9 +193,26 @@ function scaleFromSources(sources, baseFontSize) {
       warnings: parsed.warnings,
     }
     : null;
+}
 
-  sourceCache.set(key, outcome);
-  return outcome;
+/**
+ * Every spacing token definition visible from a stylesheet, for fixes that
+ * write tokens: the stylesheet's own declarations, then `scaleSources`,
+ * `.rhythmguardrc.json` token sources and installed token packages. The same
+ * places scale inference reads, in the same order.
+ */
+function collectTokenDefinitions({ baseFontSize = 16, root, scaleSources = [], tokenRegex }) {
+  const definitions = root ? stylesheetDefinitions(root, tokenRegex, baseFontSize) : new Map();
+  const sources = [...scaleSources, ...rcTokenSources(process.cwd()), ...discoverTokenPackages(process.cwd())];
+  const parsed = parseSourcesCached(sources, baseFontSize);
+  if (parsed) {
+    for (const [token, definition] of parsed.definitions) {
+      if (!definitions.has(token)) {
+        definitions.set(token, definition);
+      }
+    }
+  }
+  return definitions;
 }
 
 /**
@@ -525,6 +548,7 @@ module.exports = {
   DEFAULT_AUTO_TOKEN_PATTERN,
   assessScale,
   autoScaleFallbackNote,
+  collectTokenDefinitions,
   discoverTokenPackages,
   inferScaleFromDefinitions,
   resolveAutoScale,

--- a/src/core/token-index.js
+++ b/src/core/token-index.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const { fixedLengthValue, numbersEqual, toPx } = require('./length');
+const { parseTokenValueLength } = require('./token-sources');
+
+/**
+ * Which token a fix may write for a length. Strict on purpose: the token must
+ * hold the same px value in the same unit as the literal being fixed, it must
+ * be a custom property (a Sass variable is not valid in CSS output), and it
+ * must be the only candidate. A fix that guesses a token is worse than a fix
+ * that writes a number, so anything ambiguous falls back to the literal.
+ */
+function tokenIndexFromDefinitions(definitions, baseFontSize = 16) {
+  const index = [];
+  for (const definition of definitions.values()) {
+    for (const raw of definition.values) {
+      const parsed = parseTokenValueLength(String(raw).trim());
+      if (!parsed) continue;
+      const unit = parsed.unit || 'px';
+      const px = toPx(Math.abs(parsed.number), unit, baseFontSize);
+      if (px === null || !Number.isFinite(px) || px === 0) continue;
+      index.push({ px, raw: String(raw).trim(), token: definition.token, unit });
+    }
+  }
+  return index;
+}
+
+function tokenForLength(index, px, unit) {
+  const wanted = unit || 'px';
+  const candidates = new Set();
+  for (const entry of index) {
+    if (entry.token.startsWith('--') && entry.unit === wanted && numbersEqual(entry.px, Math.abs(px))) {
+      candidates.add(entry.token);
+    }
+  }
+  if (candidates.size !== 1) {
+    return null;
+  }
+  return `var(${[...candidates][0]})`;
+}
+
+/** A negative token reference that is still valid where it is written. */
+function negateReplacement(replacement) {
+  if (!replacement || replacement.startsWith('-')) {
+    return replacement;
+  }
+  if (replacement.startsWith('$') || replacement.startsWith('@')) {
+    return `-${replacement}`;
+  }
+  return `calc(-1 * ${replacement})`;
+}
+
+/**
+ * The replacement text a length rule writes: the matching token when the
+ * options ask for one and exactly one qualifies, otherwise the literal.
+ */
+function replacementFor(parsedLength, nearestPx, options) {
+  if (options.fixWith === 'token' && options.tokenIndex) {
+    const token = tokenForLength(options.tokenIndex, nearestPx, parsedLength.unit || 'px');
+    if (token) {
+      return parsedLength.number < 0 ? negateReplacement(token) : token;
+    }
+  }
+  return fixedLengthValue(parsedLength, nearestPx, options);
+}
+
+module.exports = {
+  negateReplacement,
+  replacementFor,
+  tokenForLength,
+  tokenIndexFromDefinitions,
+};

--- a/src/rules/no-offscale-transform/index.js
+++ b/src/rules/no-offscale-transform/index.js
@@ -3,7 +3,6 @@
 const stylelint = require('stylelint');
 const valueParser = require('postcss-value-parser');
 const {
-  fixedLengthValue,
   formatLength,
   isHairlineLength,
   nearestScaleValues,
@@ -23,6 +22,7 @@ const {
 } = require('../../core/value-nodes');
 
 const {
+  collectTokenDefinitions,
   withResolvedScale,
 } = require('../../core/scale-inference');
 
@@ -30,6 +30,7 @@ const { validatePrimary, validateNoOffscaleTransformSecondaryOptions } = require
 
 const { reportInvalidPreset, reportProblem, reportValueNode } = require('../report');
 const { decisionFor, loadRcDecisions } = require('../../core/decisions');
+const { replacementFor, tokenIndexFromDefinitions } = require('../../core/token-index');
 
 const ruleName = 'rhythmguard/no-offscale-transform';
 const messages = stylelint.utils.ruleMessages(ruleName, {
@@ -66,6 +67,12 @@ const ruleFunction = (primary, secondaryOptions) => {
     }
 
     withResolvedScale(options, root);
+    if (options.fixWith === 'token') {
+      options.tokenIndex = tokenIndexFromDefinitions(
+        collectTokenDefinitions({ baseFontSize: options.baseFontSize, root, scaleSources: options.scaleSources, tokenRegex: new RegExp(options.tokenPattern) }),
+        options.baseFontSize,
+      );
+    }
 
     const getScaleStateForProperty = createPropertyScaleResolver(options);
 
@@ -149,7 +156,7 @@ const ruleFunction = (primary, secondaryOptions) => {
           }
 
           const fixedValue = options.fixToScale
-            ? fixedLengthValue(parsedLength, nearest.nearest, options)
+            ? replacementFor(parsedLength, nearest.nearest, options)
             : null;
 
           report(node, nearest, unit, fixedValue);
@@ -173,7 +180,7 @@ const ruleFunction = (primary, secondaryOptions) => {
         }
 
         const fixedValue = options.fixToScale
-          ? fixedLengthValue(parsedLength, nearest.nearest, options)
+          ? replacementFor(parsedLength, nearest.nearest, options)
           : null;
 
         report(node, nearest, 'px', fixedValue);

--- a/src/rules/prefer-token/index.js
+++ b/src/rules/prefer-token/index.js
@@ -31,6 +31,8 @@ const {
 const { createTokenRegex, reportInvalidPreset, reportValueNode } = require('../report');
 const { validatePrimary, validatePreferTokenSecondaryOptions } = require('../validate');
 
+const { negateReplacement } = require('../../core/token-index');
+
 const ruleName = 'rhythmguard/prefer-token';
 
 const messages = stylelint.utils.ruleMessages(ruleName, {
@@ -41,25 +43,7 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
 });
 
 function applyNegativeToken(replacement, parsedLength) {
-  if (!replacement || parsedLength.number >= 0) {
-    return replacement;
-  }
-
-  if (replacement.startsWith('-')) {
-    return replacement;
-  }
-
-  if (
-    replacement.startsWith('var(') ||
-    replacement.startsWith('theme(') ||
-    replacement.startsWith('token(') ||
-    replacement.startsWith('$') ||
-    replacement.startsWith('@')
-  ) {
-    return `-${replacement}`;
-  }
-
-  return `calc(${replacement} * -1)`;
+  return !replacement || parsedLength.number >= 0 ? replacement : negateReplacement(replacement);
 }
 
 function resolveTokenReplacement(tokenMap, raw, parsedLength, options) {

--- a/src/rules/use-scale/index.js
+++ b/src/rules/use-scale/index.js
@@ -3,7 +3,6 @@
 const stylelint = require('stylelint');
 const valueParser = require('postcss-value-parser');
 const {
-  fixedLengthValue,
   formatLength,
   isHairlineLength,
   nearestScaleValues,
@@ -27,11 +26,13 @@ const {
 
 const {
   autoScaleFallbackNote,
+  collectTokenDefinitions,
   withResolvedScale,
 } = require('../../core/scale-inference');
 
 const { createTokenRegex, reportInvalidPreset, reportProblem, reportValueNode } = require('../report');
 const { decisionFor, loadRcDecisions } = require('../../core/decisions');
+const { replacementFor, tokenIndexFromDefinitions } = require('../../core/token-index');
 const { validatePrimary, validateUseScaleSecondaryOptions } = require('../validate');
 
 const ruleName = 'rhythmguard/use-scale';
@@ -130,7 +131,7 @@ function checkLengthValue({
     }
 
     const fixedValue = options.fixToScale
-      ? fixedLengthValue(parsedLength, nearest.nearest, options)
+      ? replacementFor(parsedLength, nearest.nearest, options)
       : null;
 
     report(node.value, decl, node, nearest, fixedValue, unit);
@@ -154,7 +155,7 @@ function checkLengthValue({
   }
 
   const fixedValue = options.fixToScale
-    ? fixedLengthValue(parsedLength, nearest.nearest, options)
+    ? replacementFor(parsedLength, nearest.nearest, options)
     : null;
 
   report(node.value, decl, node, nearest, fixedValue, 'px');
@@ -181,10 +182,16 @@ const ruleFunction = (primary, secondaryOptions) => {
     const options = buildScaleOptions(secondaryOptions);
     reportInvalidPreset(options, { message: messages.invalidPreset, result, root, ruleName });
     options.decisions = readDecisions(options, { result, root });
-
     withResolvedScale(options, root);
 
     const tokenRegex = createTokenRegex(options.tokenPattern, result, ruleName);
+    if (options.fixWith === 'token') {
+      options.tokenIndex = tokenIndexFromDefinitions(
+        collectTokenDefinitions({ baseFontSize: options.baseFontSize, root, scaleSources: options.scaleSources, tokenRegex }),
+        options.baseFontSize,
+      );
+    }
+
     let fallbackNote = autoScaleFallbackNote(options.scaleInference);
     const getScaleStateForProperty = createPropertyScaleResolver(options);
 

--- a/test/rules/fix-with-token.test.js
+++ b/test/rules/fix-with-token.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { lintCss } = require('../helpers/lint');
+
+const rule = (extra = {}) => ({ 'rhythmguard/use-scale': [true, { scale: [0, 4, 8, 12, 16, 24], fixWith: 'token', ...extra }] });
+
+test('fixWith: "token" writes the project token when one token matches the snapped value in the same unit', async () => {
+  const result = await lintCss({
+    code: ':root { --space-3: 12px; --space-4: 16px; }\n.a { padding: 13px; margin: -13px; gap: 0.8rem; inset: 17px; }',
+    rules: rule(),
+    fix: true,
+  });
+  assert.deepEqual(result.invalidOptionWarnings, []);
+  assert.equal(result.code, ':root { --space-3: 12px; --space-4: 16px; }\n.a { padding: var(--space-3); margin: calc(-1 * var(--space-3)); gap: 0.75rem; inset: var(--space-4); }');
+});
+
+test('fixWith: "token" falls back to the literal when two tokens share the value', async () => {
+  const result = await lintCss({
+    code: ':root { --space-3: 12px; --space-md: 12px; }\n.a { padding: 13px; }',
+    rules: rule(),
+    fix: true,
+  });
+  assert.equal(result.code, ':root { --space-3: 12px; --space-md: 12px; }\n.a { padding: 12px; }');
+});
+
+test('fixWith: "token" reads tokens from scaleSources, so a file without token declarations still gets them', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rhythmguard-fixwith-'));
+  fs.writeFileSync(path.join(dir, 'tokens.css'), ':root { --space-3: 12px; }\n');
+  const result = await lintCss({
+    code: '.a { padding: 13px; }',
+    rules: rule({ scaleSources: [path.join(dir, 'tokens.css')] }),
+    fix: true,
+  });
+  assert.equal(result.code, '.a { padding: var(--space-3); }');
+});
+
+test('fixWith rejects anything but "value" and "token"', async () => {
+  const result = await lintCss({ code: '.a { padding: 13px; }', rules: rule({ fixWith: 'guess' }) });
+  assert.equal(result.invalidOptionWarnings.length, 1);
+});
+
+test('prefer-token writes a negative token as calc(-1 * var()), never as -var()', async () => {
+  const result = await lintCss({
+    code: '.a { margin: -12px; }',
+    rules: { 'rhythmguard/prefer-token': [true, { tokenMap: { '12px': 'var(--space-3)' } }] },
+    fix: true,
+  });
+  assert.equal(result.code, '.a { margin: calc(-1 * var(--space-3)); }');
+});

--- a/test/unit/token-index.test.js
+++ b/test/unit/token-index.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * The token index answers "which token should a fix write for this length".
+ * It is deliberately strict: same px value, same unit, exactly one candidate.
+ * Anything else falls back to a literal, because a fix that guesses a token is
+ * worse than a fix that writes a number.
+ */
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { addDefinition } = require('../../src/core/token-sources');
+const { negateReplacement, tokenForLength, tokenIndexFromDefinitions } = require('../../src/core/token-index');
+
+function definitions(entries) {
+  const map = new Map();
+  for (const [token, value] of entries) addDefinition(map, { baseFontSize: 16, file: 'tokens.css', source: 'tokens.css', token, value });
+  return map;
+}
+
+test('tokenIndexFromDefinitions records each token with its raw unit and px value', () => {
+  const index = tokenIndexFromDefinitions(definitions([['--space-3', '12px'], ['--space-4', '1rem'], ['$spacer', '16px'], ['--space-fluid', 'clamp(1rem, 2vw, 2rem)']]));
+  assert.deepEqual(index.map((entry) => [entry.token, entry.unit, entry.px]), [['--space-3', 'px', 12], ['--space-4', 'rem', 16], ['$spacer', 'px', 16]]);
+});
+
+test('tokenForLength requires the same px value, the same unit, a custom property, and exactly one candidate', () => {
+  const index = tokenIndexFromDefinitions(definitions([['--space-3', '12px'], ['--space-4', '1rem'], ['$spacer', '16px'], ['--gap-md', '0.75rem']]));
+  assert.equal(tokenForLength(index, 12, 'px'), 'var(--space-3)');
+  assert.equal(tokenForLength(index, 12, 'rem'), 'var(--gap-md)', 'a rem literal gets the rem token');
+  assert.equal(tokenForLength(index, 16, 'rem'), 'var(--space-4)');
+  assert.equal(tokenForLength(index, 16, 'px'), null, 'the only 16px token is a Sass variable, not valid in CSS');
+  assert.equal(tokenForLength(index, 8, 'px'), null);
+
+  const ambiguous = tokenIndexFromDefinitions(definitions([['--space-3', '12px'], ['--spacing-md', '12px']]));
+  assert.equal(tokenForLength(ambiguous, 12, 'px'), null, 'two tokens for one value is a guess, so no token');
+});
+
+test('negateReplacement writes valid CSS for a negative token', () => {
+  assert.equal(negateReplacement('var(--space-3)'), 'calc(-1 * var(--space-3))');
+  assert.equal(negateReplacement('theme(spacing.3)'), 'calc(-1 * theme(spacing.3))');
+  assert.equal(negateReplacement('$spacer'), '-$spacer', 'Sass variables negate with a sign');
+  assert.equal(negateReplacement('-var(--x)'), '-var(--x)', 'already negative stays as written');
+});

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -17,6 +17,8 @@ export interface ScaleSource {
 export interface RhythmguardRuleOptions {
   /** Exempt non-zero lengths of one CSS pixel or less (1px, -1px, 0.5px, 0.0625rem). Default true. */
   allowHairlines?: boolean;
+  /** What autofix writes: the nearest literal (default) or, with "token", `var(--name)` when exactly one custom property holds that value in the same unit. */
+  fixWith?: "value" | "token";
   /** Read the `decisions` section of `.rhythmguardrc.json` (default true). The audit sets false and applies decisions itself. */
   decisions?: boolean;
   baseFontSize?: number;


### PR DESCRIPTION
Remediation item 2, opt-in as agreed; the default flips in 4.0.

- `fixWith: "token"` on `use-scale` and `no-offscale-transform`: autofix writes `var(--name)` when exactly one custom property holds the snapped value **in the literal's own unit**, read from the stylesheet, `scaleSources`, the config file's token sources and installed token packages. Otherwise the literal. So a rem literal never turns into a px token (different behaviour under font scaling), a Sass variable is never written into CSS, and two tokens with the same value are treated as a guess and not written. `core/token-index.js` owns that decision.
- **Bug fixed on the way:** `prefer-token` wrote negative tokens as `-var(--x)`, which is not valid CSS. Both rules now share one negation: `calc(-1 * var(--x))` for functions, a sign for Sass variables.
- Tests: token index contract (unit, ambiguity, Sass exclusion, negation), rule fixes across units and negatives, scaleSources-fed tokens, option validation, and the prefer-token negative fix. Rule docs, architecture table, types, changelog.

Gate: lint, typecheck, 243 tests; benchmark check zero moved findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)