### PR TITLE
docs: three runtime dependencies; how fixes stay deterministic with fixWith token

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ CI for this repository runs on self-hosted runners for pushes and same-repo bran
 
 **The benchmark is the regression suite for real code.** If your change alters findings on any benchmark repository, `npm run bench:quiet -- --check` fails and prints the diff. Review it. If the new findings are right, run `npm run bench:quiet -- --update-snapshots`, commit `benchmarks/quiet/snapshots/`, and say in the PR why they are right.
 
-**Fixes are deterministic.** Autofix snaps to the nearest scale step or to an explicit token map. It never guesses a token. Keep that property.
+**Fixes are deterministic.** Autofix snaps to the nearest scale step, or with `fixWith: "token"` writes the one custom property that holds that value in the same unit. It never guesses a token: two candidates, a unit mismatch or a Sass variable all mean the literal is written instead. `rhythmguard fix` follows the same rule. Keep that property.
 
 **Prose without em dashes.** House style, applied to docs and messages alike.
 
@@ -98,7 +98,7 @@ CI for this repository runs on self-hosted runners for pushes and same-repo bran
 - Stylelint `^16.0.0 || ^17.0.0`. The 16.0.0 floor has known autofix differences; CI runs the floor suite against it.
 - Node `>=20.19.0`.
 - CommonJS and ESM entry points; every export has a declaration under `types/`.
-- Two runtime dependencies, `known-css-properties` and `postcss-value-parser`. `postcss-scss`, `stylelint-config-tailwindcss` and `stylelint-plugin-logical-css` are optional peers and dev dependencies here. `test/contracts/architecture.test.js` fails if a runtime import is not declared.
+- Three runtime dependencies: `known-css-properties`, `postcss` and `postcss-value-parser`. `postcss-scss`, `stylelint-config-tailwindcss` and `stylelint-plugin-logical-css` are optional peers and dev dependencies here. `test/contracts/architecture.test.js` fails if a runtime import is not declared.
 
 ## Review
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The audit scans CSS declarations, Tailwind class strings and your token contract
 
 ## Compatibility
 
-Stylelint 16 and 17. Node 20.19 or newer. Two runtime dependencies (`known-css-properties`, `postcss-value-parser`); `postcss-scss`, `stylelint-config-tailwindcss` and `stylelint-plugin-logical-css` are optional peers. CommonJS and ESM entry points, TypeScript declarations for every export. The CI matrix runs Node 20 and 22 against Stylelint 16.0.0, 16.x and 17.x. Upgrading from 2.x: [docs/MIGRATING_TO_3.md](docs/MIGRATING_TO_3.md).
+Stylelint 16 and 17. Node 20.19 or newer. Three runtime dependencies (`known-css-properties`, `postcss`, `postcss-value-parser`); `postcss-scss`, `stylelint-config-tailwindcss` and `stylelint-plugin-logical-css` are optional peers. CommonJS and ESM entry points, TypeScript declarations for every export. The CI matrix runs Node 20 and 22 against Stylelint 16.0.0, 16.x and 17.x. Upgrading from 2.x: [docs/MIGRATING_TO_3.md](docs/MIGRATING_TO_3.md).
 
 ## Contributing and support
 


### PR DESCRIPTION
The codemod declared `postcss` an hour ago, which made the dependency count in the README and CONTRIBUTING stale again. Both now say three. CONTRIBUTING's determinism rule for fixes is restated to cover `fixWith: "token"` and `rhythmguard fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)